### PR TITLE
Value Data in separate Segment & Value Data actively persisted features

### DIFF
--- a/btree/btree.go
+++ b/btree/btree.go
@@ -105,13 +105,37 @@ func (btree *Btree[TK, TV]) Count() int64 {
 // Add a key/value pair item to the tree.
 func (btree *Btree[TK, TV]) Add(ctx context.Context, key TK, value TV) (bool, error) {
 	var item = newItem[TK, TV](key, value)
+
+	node, err := btree.getRootNode(ctx)
+	if err != nil {
+		return false, err
+	}
+	result, err := node.add(ctx, btree, item)
+	if err != nil {
+		return false, err
+	}
+	// Add failed with no reason, 'just return false.
+	if !result {
+		return false, nil
+	}
+
 	// Add to local cache for submit/resolution on Commit.
 	if err := btree.storeInterface.ItemActionTracker.Add(ctx, item); err != nil {
 		return false, err
 	}
-	return btree.AddItem(ctx, item)
+
+	// Service the node's requested action(s).
+	btree.distribute(ctx)
+	btree.promote(ctx)
+
+	// Increment store's item count.
+	// TODO: Register StoreInfo change to transaction manager (on V2) so it can get persisted.
+	btree.StoreInfo.Count++
+
+	return true, nil
 }
 
+// For internal use only, when SOP is doing refetch and merge in commt.
 func (btree *Btree[TK, TV]) AddItem(ctx context.Context, item *Item[TK, TV]) (bool, error) {
 	node, err := btree.getRootNode(ctx)
 	if err != nil {
@@ -350,6 +374,7 @@ func (btree *Btree[TK, TV]) UpdateCurrentItem(ctx context.Context, newValue TV) 
 	return true, nil
 }
 
+// For internal use only, when SOP is doing refetch and merge in commt.
 func (btree *Btree[TK, TV]) UpdateCurrentNodeItem(ctx context.Context, item *Item[TK, TV]) (bool, error) {
 	if btree.currentItemRef.getNodeID() == sop.NilUUID {
 		return false, nil

--- a/btree/store_info.go
+++ b/btree/store_info.go
@@ -78,6 +78,11 @@ func NewStoreInfoExt(name string, slotLength int, isUnique bool, isValueDataInNo
 		slotLength = maxSlotLength
 	}
 
+	// Enforce isValueDataInNodeSegment true as required if isValueDataActivelyPersisted.
+	if isValueDataActivelyPersisted {
+		isValueDataInNodeSegment = true
+	}
+
 	return &StoreInfo{
 		Name:                         name,
 		SlotLength:                   slotLength,

--- a/in_red_ck/item_action_tracker.go
+++ b/in_red_ck/item_action_tracker.go
@@ -32,8 +32,6 @@ type cacheItem[TK btree.Comparable, TV any] struct {
 	// Version of the item as read from DB.
 	versionInDB       int
 	isLockOwner       bool
-	// inflightItemValue *TV
-	partlyCommitted bool
 }
 
 type itemActionTracker[TK btree.Comparable, TV any] struct {

--- a/in_red_ck/item_action_tracker.go
+++ b/in_red_ck/item_action_tracker.go
@@ -32,7 +32,7 @@ type cacheItem[TK btree.Comparable, TV any] struct {
 	// Version of the item as read from DB.
 	versionInDB       int
 	isLockOwner       bool
-	inflightItemValue *TV
+	// inflightItemValue *TV
 	partlyCommitted bool
 }
 
@@ -128,7 +128,7 @@ func (t *itemActionTracker[TK, TV]) Add(ctx context.Context, item *btree.Item[TK
 		// Actively persist the item.
 		itemsForAdd := cas.BlobsPayload[sop.KeyValuePair[sop.UUID, interface{}]]{
 			BlobTable: t.storeInfo.BlobTable,
-			Blobs:     make([]sop.KeyValuePair[sop.UUID, interface{}], 0, 5),
+			Blobs:     make([]sop.KeyValuePair[sop.UUID, interface{}], 0, 1),
 		}
 		itemForAdd := t.manage(item.ID, cachedItem)
 		if itemForAdd != nil {
@@ -152,7 +152,7 @@ func (t *itemActionTracker[TK, TV]) Update(ctx context.Context, item *btree.Item
 			// Actively persist the item.
 			itemsForAdd := cas.BlobsPayload[sop.KeyValuePair[sop.UUID, interface{}]]{
 				BlobTable: t.storeInfo.BlobTable,
-				Blobs:     make([]sop.KeyValuePair[sop.UUID, interface{}], 0, 5),
+				Blobs:     make([]sop.KeyValuePair[sop.UUID, interface{}], 0, 1),
 			}
 			itemForAdd := t.manage(item.ID, v)
 			if itemForAdd != nil {

--- a/in_red_ck/item_action_tracker.value_data.go
+++ b/in_red_ck/item_action_tracker.value_data.go
@@ -61,7 +61,7 @@ func (t *itemActionTracker[TK, TV]) manage(uuid sop.UUID, cachedItem cacheItem[T
 				Value: cachedItem.item.Value,
 			}
 			// nullify Value since we are saving it to a separate partition.
-			cachedItem.inflightItemValue = cachedItem.item.Value
+			// cachedItem.inflightItemValue = cachedItem.item.Value
 			cachedItem.item.Value = nil
 			cachedItem.item.ValueNeedsFetch = true
 		}
@@ -69,14 +69,6 @@ func (t *itemActionTracker[TK, TV]) manage(uuid sop.UUID, cachedItem cacheItem[T
 	}
 	return r
 }
-
-// TODO: for IsValueDataActivelyPersisted, we need to support both partial & full rollback.
-// For refetch & merge: partial rollback will not undo saved "values" in data segments and
-// will, thus, merge with the "item" keeping these values' data in other segments and not in memory.
-// So, it is a light weight merge.
-//
-// When timeout or conflict occurs, then full rollback will allow undo of entire changes including
-// these "values" data segments deletion.
 
 func (t *itemActionTracker[TK, TV]) rollbackTrackedValuesInSeparateSegments(ctx context.Context) error {
 	if t.storeInfo.IsValueDataInNodeSegment {
@@ -88,11 +80,11 @@ func (t *itemActionTracker[TK, TV]) rollbackTrackedValuesInSeparateSegments(ctx 
 	}
 	for itemID, cachedItem := range t.items {
 		if cachedItem.Action == addAction || cachedItem.Action == updateAction {
-			if cachedItem.inflightItemValue != nil {
-				cachedItem.item.Value = cachedItem.inflightItemValue
-				cachedItem.inflightItemValue = nil
-				cachedItem.item.ValueNeedsFetch = false
-			}
+			// if cachedItem.inflightItemValue != nil {
+			// 	cachedItem.item.Value = cachedItem.inflightItemValue
+			// 	cachedItem.inflightItemValue = nil
+			// 	cachedItem.item.ValueNeedsFetch = false
+			// }
 			if t.storeInfo.IsValueDataGloballyCached {
 				t.redisCache.Delete(ctx, t.formatKey(cachedItem.item.ID.String()))
 			}

--- a/in_red_ck/item_action_tracker.value_data.go
+++ b/in_red_ck/item_action_tracker.value_data.go
@@ -70,7 +70,7 @@ func (t *itemActionTracker[TK, TV]) manage(uuid sop.UUID, cachedItem cacheItem[T
 	return r
 }
 
-// TODO: for IsValueDataActivelyPersisted, we need to support both partial & fulle rollback.
+// TODO: for IsValueDataActivelyPersisted, we need to support both partial & full rollback.
 // For refetch & merge: partial rollback will not undo saved "values" in data segments and
 // will, thus, merge with the "item" keeping these values' data in other segments and not in memory.
 // So, it is a light weight merge.

--- a/in_red_ck/manage_btree.go
+++ b/in_red_ck/manage_btree.go
@@ -166,9 +166,9 @@ func refetchAndMergeClosure[TK btree.Comparable, TV any](si *StoreInterface[TK, 
 		b3.StoreInfo.Count = storeInfo[0].Count
 		b3.StoreInfo.RootNodeID = storeInfo[0].RootNodeID
 
-		for _, ci := range b3ModifiedItems {
+		for uuid, ci := range b3ModifiedItems {
 			if ci.Action == addAction {
-				if b3.StoreInfo.IsValueDataActivelyPersisted {
+				if !b3.StoreInfo.IsValueDataInNodeSegment {
 					if ok, err := b3.AddItem(ctx, ci.item); !ok || err != nil {
 						if err != nil {
 							return err
@@ -186,7 +186,7 @@ func refetchAndMergeClosure[TK btree.Comparable, TV any](si *StoreInterface[TK, 
 				}
 				continue
 			}
-			if ok, err := b3.FindOneWithID(ctx, ci.item.Key, ci.item.ID); !ok || err != nil {
+			if ok, err := b3.FindOneWithID(ctx, ci.item.Key, uuid); !ok || err != nil {
 				if err != nil {
 					return err
 				}
@@ -216,7 +216,7 @@ func refetchAndMergeClosure[TK btree.Comparable, TV any](si *StoreInterface[TK, 
 				continue
 			}
 			if ci.Action == updateAction {
-				if b3.StoreInfo.IsValueDataActivelyPersisted {
+				if !b3.StoreInfo.IsValueDataInNodeSegment {
 					// Merge the inflight Item ID with target.
 					si.ItemActionTracker.(*itemActionTracker[TK, TV]).forDeletionItems = append(
 						si.ItemActionTracker.(*itemActionTracker[TK, TV]).forDeletionItems, item.ID)

--- a/streaming_data/streaming_data_store.go
+++ b/streaming_data/streaming_data_store.go
@@ -9,8 +9,8 @@ import (
 	"github.com/SharedCode/sop/in_red_ck"
 )
 
-// StreamingDataStore interface contains methods useful for managing entries that allow encoding or decoding
-// of data streams.
+// StreamingDataStore contains methods useful for storage & management of entries that allow
+// encoding and decoding to/from data streams.
 type StreamingDataStore[TK btree.Comparable] struct {
 	btree btree.BtreeInterface[streamingDataKey[TK], []byte]
 }

--- a/streaming_data/streaming_data_store.go
+++ b/streaming_data/streaming_data_store.go
@@ -41,7 +41,7 @@ func NewStreamingDataStore[TK btree.Comparable](ctx context.Context, name string
 }
 
 // Add insert an item to the b-tree and returns an encoder you can use to write the streaming data on.
-func (s *StreamingDataStore[TK]) Add(ctx context.Context, key TK) (Encoder, error) {
+func (s *StreamingDataStore[TK]) Add(ctx context.Context, key TK) (*Encoder[TK], error) {
 	w := newWriter[TK](ctx, true, key, s.btree)
 	return newEncoder(ctx, w), nil
 }
@@ -49,7 +49,7 @@ func (s *StreamingDataStore[TK]) Add(ctx context.Context, key TK) (Encoder, erro
 // AddIfNotExist adds an item if there is no item matching the key yet.
 // Otherwise, it will do nothing and return false, for not adding the item.
 // This is useful for cases one wants to add an item without creating a duplicate entry.
-func (s *StreamingDataStore[TK]) AddIfNotExist(ctx context.Context, key TK) (Encoder, error) {
+func (s *StreamingDataStore[TK]) AddIfNotExist(ctx context.Context, key TK) (*Encoder[TK], error) {
 	if found, err := s.FindOne(ctx, key, false); err != nil || found {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (s *StreamingDataStore[TK]) RemoveCurrentItem(ctx context.Context) (bool, e
 }
 
 // Update finds the item with key and update its value to the value argument.
-func (s *StreamingDataStore[TK]) Update(ctx context.Context, key TK) (Encoder, error) {
+func (s *StreamingDataStore[TK]) Update(ctx context.Context, key TK) (*Encoder[TK], error) {
 	if found, err := s.FindOne(ctx, key, false); err != nil || !found {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (s *StreamingDataStore[TK]) Update(ctx context.Context, key TK) (Encoder, e
 }
 // UpdateCurrentItem will update the Value of the current item.
 // Key is read-only, thus, no argument for the key.
-func (s *StreamingDataStore[TK]) UpdateCurrentItem(ctx context.Context) (Encoder, error) {
+func (s *StreamingDataStore[TK]) UpdateCurrentItem(ctx context.Context) (*Encoder[TK], error) {
 	w := newWriter[TK](ctx, false, s.btree.GetCurrentKey().key, s.btree)
 	return newEncoder(ctx, w), nil
 }


### PR DESCRIPTION
Both features mentioned above were seen operational in unit & integration tests. And a lot faster/optimal now.
* When conflict is detected and can be retried/remerged, saved data in separate segment is kept as is and not rolled back, but instead merged as is.

It only gets rolled back when real rollback occurs(not the partial rollback for refetch and merge).