### PR TITLE
Transaction logging on add/update of actively persisted items

### DIFF
--- a/btree/btree.go
+++ b/btree/btree.go
@@ -177,6 +177,7 @@ func (btree *Btree[TK, TV]) FindOne(ctx context.Context, key TK, firstItemWithKe
 			return true, nil
 		}
 	}
+	btree.unfetchCurrentValue()
 	node, err := btree.getRootNode(ctx)
 	if err != nil {
 		return false, err
@@ -220,13 +221,29 @@ func (btree *Btree[TK, TV]) GetCurrentValue(ctx context.Context) (TV, error) {
 		return zero, err
 	} else {
 		// Register to local cache the "item get" for submit/resolution on Commit.
+		vnf := item.ValueNeedsFetch 
 		if err := btree.storeInterface.ItemActionTracker.Get(ctx, item); err != nil {
 			return zero, err
 		}
 		btree.storeInterface.NodeRepository.Fetched(btree.currentItemRef.nodeID)
+		if vnf && !item.ValueNeedsFetch && item.Value != nil {
+			item.valueWasFetched = true
+		}
 		// TODO: in V2, we need to fetch Value if btree is set to save Value in another "data segment"
 		// and it is not yet fetched. That fetch action can error thus, need to be able to return an error.
 		return *item.Value, nil
+	}
+}
+
+// Unfetch Current Value will reset the current item's value as if it was not fetched from the backend.
+// Useful when trying to conserve memory as item's values are large data, calling this method will set it
+// to nil, "unfetch" status.
+func (btree *Btree[TK, TV]) unfetchCurrentValue() {
+	if btree.StoreInfo.IsValueDataActivelyPersisted && !btree.StoreInfo.IsValueDataGloballyCached &&
+	btree.currentItem != nil && btree.currentItem.Value != nil && btree.currentItem.valueWasFetched {
+		btree.currentItem.Value = nil
+		btree.currentItem.ValueNeedsFetch = true
+		btree.currentItem.valueWasFetched = false
 	}
 }
 
@@ -277,6 +294,7 @@ func (btree *Btree[TK, TV]) First(ctx context.Context) (bool, error) {
 	if btree.StoreInfo.Count == 0 {
 		return false, nil
 	}
+	btree.unfetchCurrentValue()
 	node, err := btree.getRootNode(ctx)
 	if err != nil {
 		return false, err
@@ -291,6 +309,7 @@ func (btree *Btree[TK, TV]) Last(ctx context.Context) (bool, error) {
 	if btree.StoreInfo.Count == 0 {
 		return false, nil
 	}
+	btree.unfetchCurrentValue()
 	node, err := btree.getRootNode(ctx)
 	if err != nil {
 		return false, err
@@ -305,6 +324,7 @@ func (btree *Btree[TK, TV]) Next(ctx context.Context) (bool, error) {
 	if btree.StoreInfo.Count == 0 || !btree.isCurrentItemSelected() {
 		return false, nil
 	}
+	btree.unfetchCurrentValue()
 	node, err := btree.getNode(ctx, btree.currentItemRef.getNodeID())
 	if err != nil {
 		return false, err
@@ -322,6 +342,7 @@ func (btree *Btree[TK, TV]) Previous(ctx context.Context) (bool, error) {
 	if btree.StoreInfo.Count == 0 || !btree.isCurrentItemSelected() {
 		return false, nil
 	}
+	btree.unfetchCurrentValue()
 	node, err := btree.getNode(ctx, btree.currentItemRef.getNodeID())
 	if err != nil {
 		return false, err

--- a/btree/btree.go
+++ b/btree/btree.go
@@ -229,8 +229,6 @@ func (btree *Btree[TK, TV]) GetCurrentValue(ctx context.Context) (TV, error) {
 		if vnf && !item.ValueNeedsFetch && item.Value != nil {
 			item.valueWasFetched = true
 		}
-		// TODO: in V2, we need to fetch Value if btree is set to save Value in another "data segment"
-		// and it is not yet fetched. That fetch action can error thus, need to be able to return an error.
 		return *item.Value, nil
 	}
 }

--- a/btree/btree.go
+++ b/btree/btree.go
@@ -221,7 +221,7 @@ func (btree *Btree[TK, TV]) GetCurrentValue(ctx context.Context) (TV, error) {
 		return zero, err
 	} else {
 		// Register to local cache the "item get" for submit/resolution on Commit.
-		vnf := item.ValueNeedsFetch 
+		vnf := item.ValueNeedsFetch
 		if err := btree.storeInterface.ItemActionTracker.Get(ctx, item); err != nil {
 			return zero, err
 		}
@@ -251,10 +251,14 @@ func (btree *Btree[TK, TV]) GetCurrentItem(ctx context.Context) (Item[TK, TV], e
 	if item, err := btree.getCurrentItem(ctx); err != nil || item == nil {
 		return zero, err
 	} else {
+		vnf := item.ValueNeedsFetch
 		if err := btree.storeInterface.ItemActionTracker.Get(ctx, item); err != nil {
 			return zero, err
 		}
 		btree.storeInterface.NodeRepository.Fetched(btree.currentItemRef.nodeID)
+		if vnf && !item.ValueNeedsFetch && item.Value != nil {
+			item.valueWasFetched = true
+		}
 		return *item, nil
 	}
 }

--- a/btree/btree_node.go
+++ b/btree/btree_node.go
@@ -35,6 +35,8 @@ type Item[TK Comparable, TV any] struct {
 	// flag that tells B-Tree whether value data needs fetching or not.
 	// Applicable only for B-Tree where 'IsValueDataInNodeSegment' is false use-case.
 	ValueNeedsFetch bool
+	// For internal use only, 'tells whether value was just read from the backend.
+	valueWasFetched bool
 }
 
 func newItem[TK Comparable, TV any](key TK, value TV) *Item[TK, TV] {

--- a/in_red_ck/basic_test.go
+++ b/in_red_ck/basic_test.go
@@ -9,7 +9,7 @@ import (
 func Test_OpenVsNewBTree(t *testing.T) {
 	trans, _ := NewMockTransaction(t, true, -1)
 	trans.Begin()
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "fooStore",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -29,7 +29,7 @@ func Test_OpenVsNewBTree(t *testing.T) {
 func Test_SingleBTree(t *testing.T) {
 	trans, _ := NewMockTransaction(t, true, -1)
 	trans.Begin()
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "fooStore",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -66,7 +66,7 @@ func Test_SingleBTree(t *testing.T) {
 func Test_UniqueKeyBTree(t *testing.T) {
 	trans, _ := NewMockTransaction(t, true, -1)
 	trans.Begin()
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "fooWorld",
 		SlotLength:               8,
 		IsUnique:                 true,
@@ -89,7 +89,7 @@ func Test_UniqueKeyBTree(t *testing.T) {
 func Test_UniqueKeyBTreeAcrossCommits(t *testing.T) {
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "fooWorld2",
 		SlotLength:               8,
 		IsUnique:                 true,
@@ -121,7 +121,7 @@ func Test_UniqueKeyBTreeAcrossCommits(t *testing.T) {
 func Test_UniqueKeyBTreeOnMultipleCommits(t *testing.T) {
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "fooWorld3",
 		SlotLength:               8,
 		IsUnique:                 true,

--- a/in_red_ck/btree_with_transaction_test.go
+++ b/in_red_ck/btree_with_transaction_test.go
@@ -24,7 +24,7 @@ func Test_TransactionInducedErrorOnNew(t *testing.T) {
 
 	// This call should fail and cause rollback because slotLength is being asked to 99 which will
 	// fail spec check vs the "existing" store created above (w/ slot length 5).
-	NewBtree[int, string](ctx, sop.StoreInfo{
+	NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "fooStore",
 		SlotLength:               99,
 		IsUnique:                 false,

--- a/in_red_ck/integration_tests/basic_test.go
+++ b/in_red_ck/integration_tests/basic_test.go
@@ -35,7 +35,7 @@ func Test_TransactionStory_OpenVsNewBTree(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	trans.Begin()
-	b3, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "barstore",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -66,7 +66,7 @@ func Test_TransactionStory_SingleBTree(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	trans.Begin()
-	b3, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "barstore",
 		SlotLength:               8,
 		IsUnique:                 false,

--- a/in_red_ck/integration_tests/transaction_edge_cases_test.go
+++ b/in_red_ck/integration_tests/transaction_edge_cases_test.go
@@ -23,7 +23,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -73,7 +73,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	}
 	t1, _ = in_red_ck.NewTransaction(false, -1, false)
 	t1.Begin()
-	b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -108,7 +108,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -131,7 +131,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb77",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -141,7 +141,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -178,7 +178,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -201,7 +201,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb77",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -211,7 +211,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -249,7 +249,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -274,7 +274,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 		t1.Commit(ctx)
 		t1, _ = in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb77",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -284,7 +284,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 		}, t1)
 	}
 
-	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -321,7 +321,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -350,7 +350,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb77",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -360,7 +360,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -421,7 +421,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "twophase3",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -438,7 +438,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	f1 := func() error {
 		t1, _ := in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ := in_red_ck.NewBtree[int, string](ctx2, sop.StoreInfo{
+		b3, _ := in_red_ck.NewBtree[int, string](ctx2, sop.StoreOptions{
 			Name:                     "twophase3",
 			SlotLength:               8,
 			IsUnique:                 false,
@@ -455,7 +455,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	f2 := func() error {
 		t2, _ := in_red_ck.NewTransaction(true, -1, false)
 		t2.Begin()
-		b32, _ := in_red_ck.NewBtree[int, string](ctx2, sop.StoreInfo{
+		b32, _ := in_red_ck.NewBtree[int, string](ctx2, sop.StoreOptions{
 			Name:                     "twophase3",
 			SlotLength:               8,
 			IsUnique:                 false,
@@ -508,7 +508,7 @@ func Test_ConcurrentCommitsComplexDupeAllowed(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "tablex",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -591,7 +591,7 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "tablex2",
 		SlotLength:               8,
 		IsUnique:                 true,
@@ -675,7 +675,7 @@ func Test_ConcurrentCommitsComplexUpdateConflicts(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "tabley",
 		SlotLength:               8,
 		IsUnique:                 false,

--- a/in_red_ck/integration_tests/transaction_logging_test.go
+++ b/in_red_ck/integration_tests/transaction_logging_test.go
@@ -22,7 +22,7 @@ func MultipleExpiredTransCleanup(t *testing.T) {
 	trans, _ := in_red_ck.NewTransaction(true, -1, true)
 	trans.Begin()
 
-	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "ztab1",
 		SlotLength:               8,
 		IsUnique:                 false,

--- a/in_red_ck/integration_tests/transaction_test.go
+++ b/in_red_ck/integration_tests/transaction_test.go
@@ -57,7 +57,7 @@ func Test_SimpleAddPerson(t *testing.T) {
 
 	pk, p := newPerson("joe", "krueger", "male", "email", "phone")
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -141,7 +141,7 @@ func Test_AddAndSearchManyPersons(t *testing.T) {
 	}
 
 	trans.Begin()
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -206,7 +206,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -229,7 +229,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(true, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     tableName1,
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -260,7 +260,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(false, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     tableName1,
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -279,7 +279,7 @@ func VolumeDeletes(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -304,7 +304,7 @@ func VolumeDeletes(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(true, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     tableName1,
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -324,7 +324,7 @@ func MixedOperations(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -364,7 +364,7 @@ func MixedOperations(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(true, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     tableName1,
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -407,7 +407,7 @@ func MixedOperations(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(true, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     tableName1,
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -423,7 +423,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
 
-	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     tableName2,
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -460,7 +460,7 @@ func Test_IllegalBtreeStoreName(t *testing.T) {
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
 
-	if _, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	if _, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "2phase",
 		SlotLength:               8,
 		IsUnique:                 false,

--- a/in_red_ck/integration_tests/value_data_segment/basic_test.go
+++ b/in_red_ck/integration_tests/value_data_segment/basic_test.go
@@ -33,7 +33,7 @@ func Test_TransactionStory_OpenVsNewBTree(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	trans.Begin()
-	b3, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "fooStore",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -64,7 +64,7 @@ func Test_TransactionStory_SingleBTree(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	trans.Begin()
-	b3, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "fooStore",
 		SlotLength:               8,
 		IsUnique:                 false,

--- a/in_red_ck/integration_tests/value_data_segment/transaction_edge_cases_test.go
+++ b/in_red_ck/integration_tests/value_data_segment/transaction_edge_cases_test.go
@@ -22,7 +22,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -45,7 +45,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb7",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -55,7 +55,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -86,7 +86,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	}
 	t1, _ = in_red_ck.NewTransaction(false, -1, false)
 	t1.Begin()
-	b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -121,7 +121,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -144,7 +144,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb7",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -154,7 +154,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -191,7 +191,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -214,7 +214,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb7",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -224,7 +224,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -262,7 +262,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -287,7 +287,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 		t1.Commit(ctx)
 		t1, _ = in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb7",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -297,7 +297,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 		}, t1)
 	}
 
-	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -334,7 +334,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -363,7 +363,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb7",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -373,7 +373,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb7",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -434,7 +434,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "twophase2",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -451,7 +451,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	f1 := func() error {
 		t1, _ := in_red_ck.NewTransaction(true, -1, false)
 		t1.Begin()
-		b3, _ := in_red_ck.NewBtree[int, string](ctx2, sop.StoreInfo{
+		b3, _ := in_red_ck.NewBtree[int, string](ctx2, sop.StoreOptions{
 			Name:                     "twophase2",
 			SlotLength:               8,
 			IsUnique:                 false,
@@ -468,7 +468,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	f2 := func() error {
 		t2, _ := in_red_ck.NewTransaction(true, -1, false)
 		t2.Begin()
-		b32, _ := in_red_ck.NewBtree[int, string](ctx2, sop.StoreInfo{
+		b32, _ := in_red_ck.NewBtree[int, string](ctx2, sop.StoreOptions{
 			Name:                     "twophase2",
 			SlotLength:               8,
 			IsUnique:                 false,

--- a/in_red_ck/integration_tests/value_data_segment/transaction_test.go
+++ b/in_red_ck/integration_tests/value_data_segment/transaction_test.go
@@ -54,7 +54,7 @@ func Test_SimpleAddPerson(t *testing.T) {
 
 	pk, p := newPerson("joe", "krueger", "male", "email", "phone")
 
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -138,7 +138,7 @@ func Test_AddAndSearchManyPersons(t *testing.T) {
 	}
 
 	trans.Begin()
-	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -203,7 +203,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -226,7 +226,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(true, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -257,7 +257,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(false, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -276,7 +276,7 @@ func VolumeDeletes(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -301,7 +301,7 @@ func VolumeDeletes(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(true, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -321,7 +321,7 @@ func MixedOperations(t *testing.T) {
 
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
-	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -361,7 +361,7 @@ func MixedOperations(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(true, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -404,7 +404,7 @@ func MixedOperations(t *testing.T) {
 			}
 			t1, _ = in_red_ck.NewTransaction(true, -1, false)
 			t1.Begin()
-			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = in_red_ck.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -420,7 +420,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
 
-	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "twophase",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -457,7 +457,7 @@ func Test_IllegalBtreeStoreName(t *testing.T) {
 	t1, _ := in_red_ck.NewTransaction(true, -1, false)
 	t1.Begin()
 
-	if _, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreInfo{
+	if _, err := in_red_ck.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "2phase",
 		SlotLength:               8,
 		IsUnique:                 false,

--- a/in_red_ck/item_action_tracker.go
+++ b/in_red_ck/item_action_tracker.go
@@ -137,9 +137,9 @@ func (t *itemActionTracker[TK, TV]) Add(ctx context.Context, item *btree.Item[TK
 		}
 		if len(itemsForAdd.Blobs) > 0 {
 			// Log so on crash it can get cleaned up.
-			// if err := t.tlogger.log(ctx, addActivelyPersistedItem, extractRequestPayloadIDs(&itemsForAdd)); err != nil {
-			// 	return err
-			// }
+			if err := t.tlogger.log(ctx, addActivelyPersistedItem, extractRequestPayloadIDs(&itemsForAdd)); err != nil {
+				return err
+			}
 			if err := t.blobStore.Add(ctx, itemsForAdd); err != nil {
 				return err
 			}
@@ -168,9 +168,9 @@ func (t *itemActionTracker[TK, TV]) Update(ctx context.Context, item *btree.Item
 			}
 			if len(itemsForAdd.Blobs) > 0 {
 				// Log so on crash it can get cleaned up.
-				// if err := t.tlogger.log(ctx, updateActivelyPersistedItem, extractRequestPayloadIDs(&itemsForAdd)); err != nil {
-				// 	return err
-				// }
+				if err := t.tlogger.log(ctx, updateActivelyPersistedItem, extractRequestPayloadIDs(&itemsForAdd)); err != nil {
+					return err
+				}
 				if err := t.blobStore.Add(ctx, itemsForAdd); err != nil {
 					return err
 				}

--- a/in_red_ck/item_action_tracker.go
+++ b/in_red_ck/item_action_tracker.go
@@ -137,9 +137,9 @@ func (t *itemActionTracker[TK, TV]) Add(ctx context.Context, item *btree.Item[TK
 		}
 		if len(itemsForAdd.Blobs) > 0 {
 			// Log so on crash it can get cleaned up.
-			if err := t.tlogger.log(ctx, addActivelyPersistedItem, extractRequestPayloadIDs(&itemsForAdd)); err != nil {
-				return err
-			}
+			// if err := t.tlogger.log(ctx, addActivelyPersistedItem, extractRequestPayloadIDs(&itemsForAdd)); err != nil {
+			// 	return err
+			// }
 			if err := t.blobStore.Add(ctx, itemsForAdd); err != nil {
 				return err
 			}
@@ -168,9 +168,9 @@ func (t *itemActionTracker[TK, TV]) Update(ctx context.Context, item *btree.Item
 			}
 			if len(itemsForAdd.Blobs) > 0 {
 				// Log so on crash it can get cleaned up.
-				if err := t.tlogger.log(ctx, updateActivelyPersistedItem, extractRequestPayloadIDs(&itemsForAdd)); err != nil {
-					return err
-				}
+				// if err := t.tlogger.log(ctx, updateActivelyPersistedItem, extractRequestPayloadIDs(&itemsForAdd)); err != nil {
+				// 	return err
+				// }
 				if err := t.blobStore.Add(ctx, itemsForAdd); err != nil {
 					return err
 				}

--- a/in_red_ck/manage_btree.go
+++ b/in_red_ck/manage_btree.go
@@ -45,7 +45,7 @@ func OpenBtree[TK btree.Comparable, TV any](ctx context.Context, name string, t 
 // If B-Tree(name) is not found in the backend, a new one will be created. Otherwise, the existing one will be opened
 // and the parameters checked if matching. If you know that it exists, then it is more convenient and more readable to call
 // the OpenBtree function.
-func NewBtree[TK btree.Comparable, TV any](ctx context.Context, si sop.StoreInfo, t Transaction) (btree.BtreeInterface[TK, TV], error) {
+func NewBtree[TK btree.Comparable, TV any](ctx context.Context, si sop.StoreOptions, t Transaction) (btree.BtreeInterface[TK, TV], error) {
 	if t == nil {
 		return nil, fmt.Errorf("Transaction 't' parameter can't be nil")
 	}
@@ -91,7 +91,7 @@ func newBtree[TK btree.Comparable, TV any](ctx context.Context, s *btree.StoreIn
 	si := StoreInterface[TK, TV]{}
 
 	// Assign the item action tracker frontend and backend bits.
-	iat := newItemActionTracker[TK, TV](s, trans.redisCache, trans.blobStore)
+	iat := newItemActionTracker[TK, TV](s, trans.redisCache, trans.blobStore, trans.logger)
 	si.ItemActionTracker = iat
 
 	// Assign the node repository frontend and backend bits.

--- a/in_red_ck/node_repository.go
+++ b/in_red_ck/node_repository.go
@@ -194,7 +194,7 @@ func (nr *nodeRepository) commitNewRootNodes(ctx context.Context, nodes []sop.Tu
 	if len(nodes) == 0 {
 		return true, nil
 	}
-	vids := nr.convertToRegistryRequestPayload(nodes)
+	vids := convertToRegistryRequestPayload(nodes)
 	handles, err := nr.transaction.registry.Get(ctx, vids...)
 	if err != nil {
 		return false, err
@@ -241,7 +241,7 @@ func (nr *nodeRepository) commitUpdatedNodes(ctx context.Context, nodes []sop.Tu
 		return true, nil, nil
 	}
 	// 1st pass, update the virtual ID registry ensuring the set of nodes are only being modified by us.
-	vids := nr.convertToRegistryRequestPayload(nodes)
+	vids := convertToRegistryRequestPayload(nodes)
 	handles, err := nr.transaction.registry.Get(ctx, vids...)
 	if err != nil {
 		return false, nil, err
@@ -300,7 +300,7 @@ func (nr *nodeRepository) commitRemovedNodes(ctx context.Context, nodes []sop.Tu
 	if len(nodes) == 0 {
 		return true, nil, nil
 	}
-	vids := nr.convertToRegistryRequestPayload(nodes)
+	vids := convertToRegistryRequestPayload(nodes)
 	handles, err := nr.transaction.registry.Get(ctx, vids...)
 	if err != nil {
 		return false, nil, err
@@ -374,7 +374,7 @@ func (nr *nodeRepository) areFetchedItemsIntact(ctx context.Context, nodes []sop
 		return true, nil
 	}
 	// Check if the Items read for each fetchedNode are intact.
-	vids := nr.convertToRegistryRequestPayload(nodes)
+	vids := convertToRegistryRequestPayload(nodes)
 	handles, err := nr.transaction.registry.Get(ctx, vids...)
 	if err != nil {
 		return false, err
@@ -584,7 +584,7 @@ func (nr *nodeRepository) touchNodes(ctx context.Context, handles []cas.Registry
 	return handles, nil
 }
 
-func (nr *nodeRepository) convertToBlobRequestPayload(nodes []sop.Tuple[*btree.StoreInfo, []interface{}]) []cas.BlobsPayload[sop.UUID] {
+func convertToBlobRequestPayload(nodes []sop.Tuple[*btree.StoreInfo, []interface{}]) []cas.BlobsPayload[sop.UUID] {
 	bibs := make([]cas.BlobsPayload[sop.UUID], len(nodes))
 	for i := range nodes {
 		bibs[i] = cas.BlobsPayload[sop.UUID]{
@@ -598,7 +598,7 @@ func (nr *nodeRepository) convertToBlobRequestPayload(nodes []sop.Tuple[*btree.S
 	return bibs
 }
 
-func (nr *nodeRepository) convertToRegistryRequestPayload(nodes []sop.Tuple[*btree.StoreInfo, []interface{}]) []cas.RegistryPayload[sop.UUID] {
+func convertToRegistryRequestPayload(nodes []sop.Tuple[*btree.StoreInfo, []interface{}]) []cas.RegistryPayload[sop.UUID] {
 	vids := make([]cas.RegistryPayload[sop.UUID], len(nodes))
 	for i := range nodes {
 		vids[i] = cas.RegistryPayload[sop.UUID]{

--- a/in_red_ck/sop_test.go
+++ b/in_red_ck/sop_test.go
@@ -13,7 +13,7 @@ func Test_HelloWorld(t *testing.T) {
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
 
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "inmymemory",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -43,7 +43,7 @@ func Test_FunctionalityTests(t *testing.T) {
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
 
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "inmymemory1",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -134,7 +134,7 @@ func Test_ComplexDataMgmtCases(t *testing.T) {
 	max := 100000
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "inmymemory2",
 		SlotLength:               8,
 		IsUnique:                 true,
@@ -347,7 +347,7 @@ func Test_SimpleDataMgmtCases(t *testing.T) {
 	max := 100000
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[string, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[string, string](ctx, sop.StoreOptions{
 		Name:                     "inmymemory3",
 		SlotLength:               8,
 		IsUnique:                 false,

--- a/in_red_ck/transaction_edge_cases_test.go
+++ b/in_red_ck/transaction_edge_cases_test.go
@@ -19,7 +19,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -43,7 +43,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = NewMockTransaction(t, true, -1)
 		t1.Begin()
-		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -53,7 +53,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -84,7 +84,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	}
 	t1, _ = NewMockTransaction(t, false, -1)
 	t1.Begin()
-	b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -120,7 +120,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -143,7 +143,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = NewMockTransaction(t, true, -1)
 		t1.Begin()
-		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -153,7 +153,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -180,7 +180,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 
 	t2, _ = NewMockTransaction(t, true, -1)
 	t2.Begin()
-	b32, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -207,7 +207,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -230,7 +230,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = NewMockTransaction(t, true, -1)
 		t1.Begin()
-		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -240,7 +240,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -278,7 +278,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -303,7 +303,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 		t1.Commit(ctx)
 		t1, _ = NewMockTransaction(t, true, -1)
 		t1.Begin()
-		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -313,7 +313,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 		}, t1)
 	}
 
-	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -350,7 +350,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 	t1.Begin()
 	t2.Begin()
 
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -379,7 +379,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = NewMockTransaction(t, true, -1)
 		t1.Begin()
-		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+		b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb",
 			SlotLength:               nodeSlotLength,
 			IsUnique:                 false,
@@ -389,7 +389,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		}, t1)
 	}
 
-	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -448,7 +448,7 @@ func Test_CommitThrowsException(t *testing.T) {
 	// Commit successfully 1st so we can create a good data set that we can check if restored on commit failed.
 	trans, _ := NewMockTransaction(t, true, -1)
 	trans.Begin()
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,

--- a/in_red_ck/transaction_logger.go
+++ b/in_red_ck/transaction_logger.go
@@ -197,13 +197,13 @@ func (tl *transactionLog) processExpiredTransactionLogs(ctx context.Context, t *
 			continue
 		}
 
-		// Process pre commit log functions.
-		if lastCommittedFunctionLog == addActivelyPersistedItem && committedFunctionLogs[i].Value != nil {
-			itemsForDelete := (committedFunctionLogs[i].Value).(cas.BlobsPayload[sop.UUID])
-			if err := t.blobStore.Remove(ctx, itemsForDelete); err != nil {
-				return err
-			}
-		}
+		// // Process pre commit log functions.
+		// if lastCommittedFunctionLog == addActivelyPersistedItem && committedFunctionLogs[i].Value != nil {
+		// 	itemsForDelete := (committedFunctionLogs[i].Value).(cas.BlobsPayload[sop.UUID])
+		// 	if err := t.blobStore.Remove(ctx, itemsForDelete); err != nil {
+		// 		return err
+		// 	}
+		// }
 	}
 
 	if err := tl.logger.Remove(ctx, tid); err != nil {

--- a/in_red_ck/transaction_logger.go
+++ b/in_red_ck/transaction_logger.go
@@ -15,6 +15,12 @@ type commitFunction int
 // Transaction commit functions.
 const (
 	unknown = iota
+
+	// Pre commit log functions.
+	addActivelyPersistedItem
+	updateActivelyPersistedItem
+
+	// commit log functions.
 	lockTrackedItems
 	commitTrackedItemsValues
 	commitNewRootNodes

--- a/in_red_ck/transaction_logging_test.go
+++ b/in_red_ck/transaction_logging_test.go
@@ -12,7 +12,7 @@ func Test_TLog_Rollback(t *testing.T) {
 	trans, _ := NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
 
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "tlogtable",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -58,7 +58,7 @@ func Test_TLog_FailOnFinalizeCommit(t *testing.T) {
 	trans, _ := NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
 
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "tlogtable",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,

--- a/in_red_ck/transaction_test.go
+++ b/in_red_ck/transaction_test.go
@@ -40,7 +40,7 @@ func Test_Rollback(t *testing.T) {
 	trans, _ := NewMockTransaction(t, true, -1)
 	trans.Begin()
 
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -64,7 +64,7 @@ func Test_Rollback(t *testing.T) {
 
 	trans, _ = NewMockTransaction(t, false, -1)
 	trans.Begin()
-	b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -93,7 +93,7 @@ func Test_SimpleAddPerson(t *testing.T) {
 
 	pk, p := newPerson("joe", "krueger", "male", "email", "phone")
 
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -143,7 +143,7 @@ func Test_TwoTransactionsWithNoConflict(t *testing.T) {
 	trans2.Begin()
 
 	pk, p := newPerson("tracy", "swift", "female", "email", "phone")
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -161,7 +161,7 @@ func Test_TwoTransactionsWithNoConflict(t *testing.T) {
 		return
 	}
 
-	b32, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -194,7 +194,7 @@ func Test_AddAndSearchManyPersons(t *testing.T) {
 	}
 
 	trans.Begin()
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -260,7 +260,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -283,7 +283,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = NewMockTransaction(t, true, -1)
 			t1.Begin()
-			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -314,7 +314,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = NewMockTransaction(t, false, -1)
 			t1.Begin()
-			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -332,7 +332,7 @@ func Test_VolumeDeletes(t *testing.T) {
 
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -357,7 +357,7 @@ func Test_VolumeDeletes(t *testing.T) {
 			}
 			t1, _ = NewMockTransaction(t, true, -1)
 			t1.Begin()
-			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -376,7 +376,7 @@ func Test_MixedOperations(t *testing.T) {
 
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
 		IsUnique:                 false,
@@ -416,7 +416,7 @@ func Test_MixedOperations(t *testing.T) {
 			}
 			t1, _ = NewMockTransaction(t, true, -1)
 			t1.Begin()
-			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,
@@ -459,7 +459,7 @@ func Test_MixedOperations(t *testing.T) {
 			}
 			t1, _ = NewMockTransaction(t, true, -1)
 			t1.Begin()
-			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+			b3, _ = NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 				Name:                     "persondb",
 				SlotLength:               nodeSlotLength,
 				IsUnique:                 false,

--- a/in_red_ck/two_phase_commit_test.go
+++ b/in_red_ck/two_phase_commit_test.go
@@ -11,7 +11,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
 
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "twophase",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -41,7 +41,7 @@ func Test_TwoPhaseCommitCommitted(t *testing.T) {
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
 
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "twophase1",
 		SlotLength:               8,
 		IsUnique:                 false,
@@ -93,7 +93,7 @@ func Test_TwoPhaseCommitRolledbackThenCommitted(t *testing.T) {
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
 
-	b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "twophase2",
 		SlotLength:               8,
 		IsUnique:                 true,
@@ -116,7 +116,7 @@ func Test_TwoPhaseCommitRolledbackThenCommitted(t *testing.T) {
 			t1.Begin()
 			twoPhase := t1.GetPhasedTransaction()
 
-			b3, _ := NewBtree[int, string](ctx, sop.StoreInfo{
+			b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
 				Name:                     "twophase2",
 				SlotLength:               8,
 				IsUnique:                 true,

--- a/in_red_ck/two_phase_commit_transaction.go
+++ b/in_red_ck/two_phase_commit_transaction.go
@@ -260,9 +260,9 @@ func (t *transaction) phase1Commit(ctx context.Context) error {
 
 	var preCommitTID gocql.UUID
 	if t.logger.committedState == addActivelyPersistedItem {
-		preCommitTID = t.logger.transactionID
-		// Assign new TID to the transaction as pre-commit logs need to be cleaned up seperately.
-		t.logger.setNewTID()
+		// preCommitTID = t.logger.transactionID
+		// // Assign new TID to the transaction as pre-commit logs need to be cleaned up seperately.
+		// t.logger.setNewTID()
 	}
 
 	if err := t.logger.log(ctx, lockTrackedItems, nil); err != nil {
@@ -294,8 +294,8 @@ func (t *transaction) phase1Commit(ctx context.Context) error {
 		// Remove the pre commit logs as not needed anymore from this point.
 		// TODO: finalize the logic here and the commit call above.
 		if preCommitTID != cas.NilUUID {
-			t.logger.logger.Remove(ctx, preCommitTID)
-			preCommitTID = cas.NilUUID
+			// t.logger.logger.Remove(ctx, preCommitTID)
+			// preCommitTID = cas.NilUUID
 		}
 
 		successful = true

--- a/in_red_ck/two_phase_commit_transaction.go
+++ b/in_red_ck/two_phase_commit_transaction.go
@@ -260,9 +260,9 @@ func (t *transaction) phase1Commit(ctx context.Context) error {
 
 	var preCommitTID gocql.UUID
 	if t.logger.committedState == addActivelyPersistedItem {
-		// preCommitTID = t.logger.transactionID
-		// // Assign new TID to the transaction as pre-commit logs need to be cleaned up seperately.
-		// t.logger.setNewTID()
+		preCommitTID = t.logger.transactionID
+		// Assign new TID to the transaction as pre-commit logs need to be cleaned up seperately.
+		t.logger.setNewTID()
 	}
 
 	if err := t.logger.log(ctx, lockTrackedItems, nil); err != nil {
@@ -294,8 +294,8 @@ func (t *transaction) phase1Commit(ctx context.Context) error {
 		// Remove the pre commit logs as not needed anymore from this point.
 		// TODO: finalize the logic here and the commit call above.
 		if preCommitTID != cas.NilUUID {
-			// t.logger.logger.Remove(ctx, preCommitTID)
-			// preCommitTID = cas.NilUUID
+			t.logger.logger.Remove(ctx, preCommitTID)
+			preCommitTID = cas.NilUUID
 		}
 
 		successful = true

--- a/in_red_ck/two_phase_commit_transaction.go
+++ b/in_red_ck/two_phase_commit_transaction.go
@@ -290,8 +290,8 @@ func (t *transaction) phase1Commit(ctx context.Context) error {
 		updatedNodes, removedNodes, addedNodes, fetchedNodes, rootNodes = t.classifyModifiedNodes()
 
 		// Commit new root nodes.
-		bibs := t.btreesBackend[0].nodeRepository.convertToBlobRequestPayload(rootNodes)
-		vids := t.btreesBackend[0].nodeRepository.convertToRegistryRequestPayload(rootNodes)
+		bibs := convertToBlobRequestPayload(rootNodes)
+		vids := convertToRegistryRequestPayload(rootNodes)
 		if err := t.logger.log(ctx, commitNewRootNodes, sop.Tuple[[]cas.RegistryPayload[sop.UUID], []cas.BlobsPayload[sop.UUID]]{
 			First: vids, Second: bibs,
 		}); err != nil {
@@ -312,7 +312,7 @@ func (t *transaction) phase1Commit(ctx context.Context) error {
 		}
 		if successful {
 			// Commit updated nodes.
-			if err := t.logger.log(ctx, commitUpdatedNodes, t.btreesBackend[0].nodeRepository.convertToRegistryRequestPayload(updatedNodes)); err != nil {
+			if err := t.logger.log(ctx, commitUpdatedNodes, convertToRegistryRequestPayload(updatedNodes)); err != nil {
 				return err
 			}
 			if successful, updatedNodesHandles, err = t.btreesBackend[0].nodeRepository.commitUpdatedNodes(ctx, updatedNodes); err != nil {
@@ -322,7 +322,7 @@ func (t *transaction) phase1Commit(ctx context.Context) error {
 		// Only do commit removed nodes if successful so far.
 		if successful {
 			// Commit removed nodes.
-			if err := t.logger.log(ctx, commitRemovedNodes, t.btreesBackend[0].nodeRepository.convertToRegistryRequestPayload(removedNodes)); err != nil {
+			if err := t.logger.log(ctx, commitRemovedNodes, convertToRegistryRequestPayload(removedNodes)); err != nil {
 				return err
 			}
 			if successful, removedNodesHandles, err = t.btreesBackend[0].nodeRepository.commitRemovedNodes(ctx, removedNodes); err != nil {
@@ -351,8 +351,8 @@ func (t *transaction) phase1Commit(ctx context.Context) error {
 
 	// Commit added nodes.
 	if err := t.logger.log(ctx, commitAddedNodes, sop.Tuple[[]cas.RegistryPayload[sop.UUID], []cas.BlobsPayload[sop.UUID]]{
-		First:  t.btreesBackend[0].nodeRepository.convertToRegistryRequestPayload(addedNodes),
-		Second: t.btreesBackend[0].nodeRepository.convertToBlobRequestPayload(addedNodes),
+		First:  convertToRegistryRequestPayload(addedNodes),
+		Second: convertToBlobRequestPayload(addedNodes),
 	}); err != nil {
 		return err
 	}
@@ -501,28 +501,28 @@ func (t *transaction) rollback(ctx context.Context, rollbackTrackedItemsValues b
 		}
 	}
 	if t.logger.committedState > commitAddedNodes {
-		bibs := t.btreesBackend[0].nodeRepository.convertToBlobRequestPayload(addedNodes)
-		vids := t.btreesBackend[0].nodeRepository.convertToRegistryRequestPayload(addedNodes)
+		bibs := convertToBlobRequestPayload(addedNodes)
+		vids := convertToRegistryRequestPayload(addedNodes)
 		bv := sop.Tuple[[]cas.RegistryPayload[sop.UUID], []cas.BlobsPayload[sop.UUID]]{First: vids, Second: bibs}
 		if err := t.btreesBackend[0].nodeRepository.rollbackAddedNodes(ctx, bv); err != nil {
 			lastErr = err
 		}
 	}
 	if t.logger.committedState > commitRemovedNodes {
-		vids := t.btreesBackend[0].nodeRepository.convertToRegistryRequestPayload(removedNodes)
+		vids := convertToRegistryRequestPayload(removedNodes)
 		if err := t.btreesBackend[0].nodeRepository.rollbackRemovedNodes(ctx, vids); err != nil {
 			lastErr = err
 		}
 	}
 	if t.logger.committedState > commitUpdatedNodes {
-		vids := t.btreesBackend[0].nodeRepository.convertToRegistryRequestPayload(updatedNodes)
+		vids := convertToRegistryRequestPayload(updatedNodes)
 		if err := t.btreesBackend[0].nodeRepository.rollbackUpdatedNodes(ctx, vids); err != nil {
 			lastErr = err
 		}
 	}
 	if t.logger.committedState > commitNewRootNodes {
-		bibs := t.btreesBackend[0].nodeRepository.convertToBlobRequestPayload(rootNodes)
-		vids := t.btreesBackend[0].nodeRepository.convertToRegistryRequestPayload(rootNodes)
+		bibs := convertToBlobRequestPayload(rootNodes)
+		vids := convertToRegistryRequestPayload(rootNodes)
 		bv := sop.Tuple[[]cas.RegistryPayload[sop.UUID], []cas.BlobsPayload[sop.UUID]]{First: vids, Second: bibs}
 		if err := t.btreesBackend[0].nodeRepository.rollbackNewRootNodes(ctx, bv); err != nil {
 			lastErr = err

--- a/in_red_ck/value_data_separate_segment_test.go
+++ b/in_red_ck/value_data_separate_segment_test.go
@@ -11,7 +11,7 @@ func Test_ValueDataInSeparateSegment_Rollback(t *testing.T) {
 	trans, _ := NewMockTransaction(t, true, -1)
 	trans.Begin()
 
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                         "persondb7",
 		SlotLength:                   nodeSlotLength,
 		IsUnique:                     false,
@@ -58,7 +58,7 @@ func Test_ValueDataInSeparateSegment_SimpleAddPerson(t *testing.T) {
 
 	pk, p := newPerson("joe", "krueger", "male", "email", "phone")
 
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                         "persondb7",
 		SlotLength:                   nodeSlotLength,
 		IsUnique:                     false,
@@ -109,7 +109,7 @@ func Test_ValueDataInSeparateSegment_TwoTransactionsWithNoConflict(t *testing.T)
 	trans2.Begin()
 
 	pk, p := newPerson("tracy", "swift", "female", "email", "phone")
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                         "persondb7",
 		SlotLength:                   nodeSlotLength,
 		IsUnique:                     false,
@@ -128,7 +128,7 @@ func Test_ValueDataInSeparateSegment_TwoTransactionsWithNoConflict(t *testing.T)
 		return
 	}
 
-	b32, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b32, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                         "persondb7",
 		SlotLength:                   nodeSlotLength,
 		IsUnique:                     false,
@@ -162,7 +162,7 @@ func Test_ValueDataInSeparateSegment_AddAndSearchManyPersons(t *testing.T) {
 	}
 
 	trans.Begin()
-	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, err := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                         "persondb7",
 		SlotLength:                   nodeSlotLength,
 		IsUnique:                     false,
@@ -228,7 +228,7 @@ func Test_ValueDataInSeparateSegment_VolumeAddThenSearch(t *testing.T) {
 
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions {
 		Name:                         "persondb7",
 		SlotLength:                   nodeSlotLength,
 		IsUnique:                     false,
@@ -285,7 +285,7 @@ func Test_ValueDataInSeparateSegment_VolumeDeletes(t *testing.T) {
 
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                         "persondb7",
 		SlotLength:                   nodeSlotLength,
 		IsUnique:                     false,
@@ -323,7 +323,7 @@ func Test_ValueDataInSeparateSegment_MixedOperations(t *testing.T) {
 
 	t1, _ := NewMockTransaction(t, true, -1)
 	t1.Begin()
-	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreInfo{
+	b3, _ := NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                         "persondb7",
 		SlotLength:                   nodeSlotLength,
 		IsUnique:                     false,

--- a/store_options.go
+++ b/store_options.go
@@ -1,7 +1,7 @@
 package sop
 
-// StoreInfo contains a given (B-Tree) store details.
-type StoreInfo struct {
+// StoreOptions contains field options settable when constructing a given (B-Tree).
+type StoreOptions struct {
 	// Short name of this (B-Tree store).
 	Name string
 	// Count of items that can be stored on a given node.

--- a/streaming_data/streaming_data_store.go
+++ b/streaming_data/streaming_data_store.go
@@ -42,7 +42,7 @@ func (x StreamingDataKey[TK]) Compare(other interface{}) int {
 //
 // This behaviour makes this store ideal for data management of huge blobs, like movies or huge data graphs.
 func NewStreamingDataStore[TK btree.Comparable](ctx context.Context, name string, trans in_red_ck.Transaction) *StreamingDataStore[TK] {
-	btree, _ := in_red_ck.NewBtree[StreamingDataKey[TK], []byte](ctx, sop.StoreInfo{
+	btree, _ := in_red_ck.NewBtree[StreamingDataKey[TK], []byte](ctx, sop.StoreOptions{
 		Name:                         name,
 		SlotLength:                   500,
 		IsUnique:                     true,


### PR DESCRIPTION
* Fix for bug https://github.com/SharedCode/sop/discussions/50 mainly. Will add more auto tests in a bit, but seen to work in some degree.
* Renamed sop.StoreInfo to sop.StoreOptions as it is a struct used for allowing enduser to specify "configurable options". This name is more idiomatic way in Golang.