### PR TITLE
Refined StreamingDataStore constructor functions

### DIFF
--- a/streaming_data/streaming_data_store_test.go
+++ b/streaming_data/streaming_data_store_test.go
@@ -16,7 +16,7 @@ func Test_StreamingDataStoreInvalidCases(t *testing.T) {
 	trans.Begin()
 
 	// Empty Store get/update methods test cases.
-	sds := NewStreamingDataStore[string](ctx, "fooStore", trans)
+	sds, _ := NewStreamingDataStore[string](ctx, "fooStore", trans)
 	if _, err := sds.GetCurrentValue(ctx); err == nil {
 		t.Errorf("GetCurrentValue on empty btree failed, got nil want err")
 	}
@@ -31,7 +31,7 @@ func Test_StreamingDataStoreInvalidCases(t *testing.T) {
 func Test_StreamingDataStoreBasicUse(t *testing.T) {
 	trans, _ := in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds := NewStreamingDataStore[string](ctx, "fooStore", trans)
+	sds, _ := NewStreamingDataStore[string](ctx, "fooStore", trans)
 	encoder, _ := sds.Add(ctx, "fooVideo")
 	for i := 0; i < 10; i++ {
 		encoder.Encode(fmt.Sprintf("%d. a huge chunk, about 10MB.", i))
@@ -41,7 +41,7 @@ func Test_StreamingDataStoreBasicUse(t *testing.T) {
 	// Read back the data. Pass false on 2nd argument will toggle to a "reader" transaction.
 	trans, _ = in_red_ck.NewMockTransactionWithLogging(t, false, -1)
 	trans.Begin()
-	sds = NewStreamingDataStore[string](ctx, "fooStore", trans)
+	sds, _ = NewStreamingDataStore[string](ctx, "fooStore", trans)
 
 	ok, _ := sds.FindOne(ctx, "fooVideo")
 	if !ok {
@@ -74,7 +74,7 @@ func Test_StreamingDataStoreBasicUse(t *testing.T) {
 func Test_StreamingDataStoreMultipleItems(t *testing.T) {
 	trans, _ := in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds := NewStreamingDataStore[string](ctx, "fooStoreM", trans)
+	sds, _ := NewStreamingDataStore[string](ctx, "fooStoreM", trans)
 	encoder, _ := sds.Add(ctx, "fooVideo")
 	for i := 0; i < 10; i++ {
 		encoder.Encode(fmt.Sprintf("%d. a huge chunk, about 12MB.", i))
@@ -88,7 +88,7 @@ func Test_StreamingDataStoreMultipleItems(t *testing.T) {
 	// Read back the data. Pass false on 2nd argument will toggle to a "reader" transaction.
 	trans, _ = in_red_ck.NewMockTransactionWithLogging(t, false, -1)
 	trans.Begin()
-	sds = NewStreamingDataStore[string](ctx, "fooStoreM", trans)
+	sds, _ = NewStreamingDataStore[string](ctx, "fooStoreM", trans)
 
 	ok, _ := sds.FindOne(ctx, "fooVideo")
 	if !ok {
@@ -122,7 +122,7 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 	// Upload the video.
 	trans, _ := in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds := NewStreamingDataStore[string](ctx, "fooStore", trans)
+	sds, _ := NewStreamingDataStore[string](ctx, "fooStore", trans)
 	encoder, _ := sds.Add(ctx, "fooVideo2")
 	for i := 0; i < 10; i++ {
 		encoder.Encode(fmt.Sprintf("%d. a huge chunk, about 10MB.", i))
@@ -132,7 +132,7 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 	// Update the video.
 	trans, _ = in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds = NewStreamingDataStore[string](ctx, "fooStore", trans)
+	sds, _ = NewStreamingDataStore[string](ctx, "fooStore", trans)
 	encoder, _ = sds.Update(ctx, "fooVideo2")
 	chunkCount := 9
 	for i := 0; i < chunkCount; i++ {
@@ -145,7 +145,7 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 	// Read back the video.
 	trans, _ = in_red_ck.NewMockTransactionWithLogging(t, false, -1)
 	trans.Begin()
-	sds = NewStreamingDataStore[string](ctx, "fooStore", trans)
+	sds, _ = NewStreamingDataStore[string](ctx, "fooStore", trans)
 
 	ok, _ := sds.FindOne(ctx, "fooVideo2")
 	if !ok {
@@ -179,7 +179,7 @@ func Test_StreamingDataStoreUpdateWithCountCheck(t *testing.T) {
 	// Upload the video.
 	trans, _ := in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds := NewStreamingDataStore[string](ctx, "fooStore2", trans)
+	sds, _ := NewStreamingDataStore[string](ctx, "fooStore2", trans)
 	encoder, _ := sds.Add(ctx, "fooVideo1")
 	encodeVideo(encoder, 50)
 	trans.Commit(ctx)
@@ -187,7 +187,7 @@ func Test_StreamingDataStoreUpdateWithCountCheck(t *testing.T) {
 	// Update the video.
 	trans, _ = in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds = NewStreamingDataStore[string](ctx, "fooStore2", trans)
+	sds, _ = NewStreamingDataStore[string](ctx, "fooStore2", trans)
 	encoder, _ = sds.Update(ctx, "fooVideo1")
 	encodeVideo(encoder, 5)
 	// Important to close the encoder, otherwise, cleanup will not happen.
@@ -203,7 +203,7 @@ func Test_StreamingDataStoreUpdateExtend(t *testing.T) {
 	// Upload the video.
 	trans, _ := in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds := NewStreamingDataStore[string](ctx, "fooStore4", trans)
+	sds, _ := NewStreamingDataStore[string](ctx, "fooStore4", trans)
 	encoder, _ := sds.Add(ctx, "fooVideo3")
 	encodeVideo(encoder, 5)
 	trans.Commit(ctx)
@@ -211,7 +211,7 @@ func Test_StreamingDataStoreUpdateExtend(t *testing.T) {
 	// Update the video.
 	trans, _ = in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds = NewStreamingDataStore[string](ctx, "fooStore4", trans)
+	sds, _ = NewStreamingDataStore[string](ctx, "fooStore4", trans)
 	encoder, _ = sds.Update(ctx, "fooVideo3")
 	encodeVideo(encoder, 7)
 	// Since we updated with 7 chunks, 2 longer than existing, Close will not do anything.
@@ -228,7 +228,7 @@ func Test_StreamingDataStoreUpdate(t *testing.T) {
 	// Upload the video.
 	trans, _ := in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds := NewStreamingDataStore[string](ctx, "fooStore5", trans)
+	sds, _ := NewStreamingDataStore[string](ctx, "fooStore5", trans)
 	encoder, _ := sds.Add(ctx, "fooVideo")
 	encodeVideo(encoder, 5)
 	trans.Commit(ctx)
@@ -236,7 +236,7 @@ func Test_StreamingDataStoreUpdate(t *testing.T) {
 	// Update the video.
 	trans, _ = in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds = NewStreamingDataStore[string](ctx, "fooStore5", trans)
+	sds, _ = NewStreamingDataStore[string](ctx, "fooStore5", trans)
 	encoder, _ = sds.Update(ctx, "fooVideo")
 	encodeVideo(encoder, 5)
 	encoder.Close()
@@ -251,7 +251,7 @@ func Test_StreamingDataStoreDelete(t *testing.T) {
 	// Upload the video.
 	trans, _ := in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds := NewStreamingDataStore[string](ctx, "fooStore3", trans)
+	sds, _ := NewStreamingDataStore[string](ctx, "fooStore3", trans)
 
 	encoder, _ := sds.Add(ctx, "fooVideo1")
 	encodeVideo(encoder, 50)

--- a/streaming_data/streaming_data_store_test.go
+++ b/streaming_data/streaming_data_store_test.go
@@ -14,8 +14,9 @@ var ctx = context.Background()
 func Test_StreamingDataStoreInvalidCases(t *testing.T) {
 	trans, _ := in_red_ck.NewMockTransactionWithLogging(t, true, -1)
 	trans.Begin()
-	sds := NewStreamingDataStore[string](ctx, "fooStore", trans)
 
+	// Empty Store get/update methods test cases.
+	sds := NewStreamingDataStore[string](ctx, "fooStore", trans)
 	if _, err := sds.GetCurrentValue(ctx); err == nil {
 		t.Errorf("GetCurrentValue on empty btree failed, got nil want err")
 	}


### PR DESCRIPTION
* Added error return in StreamingDataStore constructor functions
* Added OpenStreamingDataStore function to "open" an existing store. Previously "implicitly" supported in NewStreamingDataStore, but having explicit function for it is better, more intuitive
