### PR TITLE
Added a feature to allow custom "store" caching duration config.

### DIFF
--- a/aws_s3/cached_bucket.go
+++ b/aws_s3/cached_bucket.go
@@ -94,7 +94,7 @@ func (b *cachedBucket) fetch(ctx context.Context, bucketName string, isLargeObje
 					// Tolerate Redis cache failure.
 					k := b.formatKey(bucketName, names[i])
 					if err := b.redisCache.Delete(ctx, k); err != nil {
-						log.Error(fmt.Sprintf("redis delete for key %s failed, details: %v", k, err))
+						log.Warn(fmt.Sprintf("redis delete for key %s failed, details: %v", k, err))
 					}
 				}
 				lastError = r[i].Error
@@ -134,7 +134,7 @@ func (b *cachedBucket) fetch(ctx context.Context, bucketName string, isLargeObje
 			}
 			k := b.formatKey(bucketName, names[i])
 			if err := b.redisCache.SetStruct(ctx, k, cd, b.cacheExpiry); err != nil {
-				log.Error(fmt.Sprintf("redis setstruct for key %s failed, details: %v", k, err))
+				log.Warn(fmt.Sprintf("redis setstruct for key %s failed, details: %v", k, err))
 			}
 			r[i] = sop.KeyValueStoreItemActionResponse[sop.KeyValuePair[string, []byte]]{
 				Payload: sop.KeyValuePair[string, []byte]{
@@ -150,7 +150,7 @@ func (b *cachedBucket) fetch(ctx context.Context, bucketName string, isLargeObje
 		if r[i].Error != nil {
 			k := b.formatKey(bucketName, names[i])
 			if err := b.redisCache.Delete(ctx, k); err != nil {
-				log.Error(fmt.Sprintf("redis setstruct for key %s failed, details: %v", k, err))
+				log.Warn(fmt.Sprintf("redis setstruct for key %s failed, details: %v", k, err))
 			}
 			lastError = r[i].Error
 		}
@@ -202,7 +202,7 @@ func (b *cachedBucket) fetchAndCache(ctx context.Context, bucketName string, nam
 		}
 		k := b.formatKey(bucketName, name)
 		if err := b.redisCache.SetStruct(ctx, k, cd, b.cacheExpiry); err != nil {
-			log.Error(fmt.Sprintf("redis setstruct for key %s failed, details: %v", k, err))
+			log.Warn(fmt.Sprintf("redis setstruct for key %s failed, details: %v", k, err))
 		}
 	}
 	// Package to return the newly fetched object.
@@ -244,7 +244,7 @@ func (b *cachedBucket) Add(ctx context.Context, bucketName string, entries ...so
 				}
 				k := b.formatKey(bucketName, entries[i].Key)
 				if err := b.redisCache.SetStruct(ctx, k, cd, b.cacheExpiry); err != nil {
-					log.Error(fmt.Sprintf("redis setstruct for key %s failed, details: %v", k, err))
+					log.Warn(fmt.Sprintf("redis setstruct for key %s failed, details: %v", k, err))
 				}
 			}
 			continue
@@ -274,7 +274,7 @@ func (b *cachedBucket) Remove(ctx context.Context, bucketName string, names ...s
 	// Remove from cache.
 	err := b.redisCache.Delete(ctx, keys...)
 	if err != nil {
-		log.Error(fmt.Sprintf("redis deletes for bucket %s failed, details: %v", bucketName, err))
+		log.Warn(fmt.Sprintf("redis deletes for bucket %s failed, details: %v", bucketName, err))
 	}
 	// Remove from AWS S3 bucket.
 	return b.bucketStore.Remove(ctx, bucketName, names...)

--- a/cassandra/btree.cql
+++ b/cassandra/btree.cql
@@ -29,7 +29,14 @@ create table store (
     -- is value data globally cached.
     vdgc boolean,
     -- leaf load balancing feature, defaults to false in Cassandra.
-    llb boolean);
+    llb boolean
+    -- store cache config fields.
+    -- registry cache duration.
+    rcd duration,
+    -- node cache duration.
+    ncd duration,
+    -- value data cache duration.
+    vdcd duration);
 
 -- Node Blob demo table 1.
 create table foo_b(

--- a/cassandra/btree.cql
+++ b/cassandra/btree.cql
@@ -36,7 +36,9 @@ create table store (
     -- node cache duration.
     ncd duration,
     -- value data cache duration.
-    vdcd duration);
+    vdcd duration,
+    -- store cache duration.
+    scd duration);
 
 -- Node Blob demo table 1.
 create table foo_b(

--- a/cassandra/connection.go
+++ b/cassandra/connection.go
@@ -110,7 +110,7 @@ func OpenConnection(config Config) (*Connection, error) {
 		return nil, err
 	}
 	// Auto create the "store" table if not yet.
-	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.store (name text PRIMARY KEY, root_id UUID, slot_count int, count bigint, unique boolean, des text, reg_tbl text, blob_tbl text, ts bigint, vdins boolean, vdap boolean, vdgc boolean, llb boolean, rcd duration, ncd duration, vdcd duration);", config.Keyspace)).Exec(); err != nil {
+	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.store (name text PRIMARY KEY, root_id UUID, slot_count int, count bigint, unique boolean, des text, reg_tbl text, blob_tbl text, ts bigint, vdins boolean, vdap boolean, vdgc boolean, llb boolean, rcd duration, ncd duration, vdcd duration, scd duration);", config.Keyspace)).Exec(); err != nil {
 		return nil, err
 	}
 	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.t_log (id UUID, c_f int, c_f_p blob, PRIMARY KEY(id, c_f));", config.Keyspace)).Exec(); err != nil {

--- a/cassandra/connection.go
+++ b/cassandra/connection.go
@@ -110,7 +110,7 @@ func OpenConnection(config Config) (*Connection, error) {
 		return nil, err
 	}
 	// Auto create the "store" table if not yet.
-	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.store (name text PRIMARY KEY, root_id UUID, slot_count int, count bigint, unique boolean, des text, reg_tbl text, blob_tbl text, ts bigint, vdins boolean, vdap boolean, vdgc boolean, llb boolean);", config.Keyspace)).Exec(); err != nil {
+	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.store (name text PRIMARY KEY, root_id UUID, slot_count int, count bigint, unique boolean, des text, reg_tbl text, blob_tbl text, ts bigint, vdins boolean, vdap boolean, vdgc boolean, llb boolean, rcd duration, ncd duration, vdcd duration);", config.Keyspace)).Exec(); err != nil {
 		return nil, err
 	}
 	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.t_log (id UUID, c_f int, c_f_p blob, PRIMARY KEY(id, c_f));", config.Keyspace)).Exec(); err != nil {

--- a/cassandra/registry.go
+++ b/cassandra/registry.go
@@ -172,6 +172,7 @@ func (v *registry) Get(ctx context.Context, storesLids ...sop.RegistryPayload[so
 			storesHandles = append(storesHandles, sop.RegistryPayload[sop.Handle]{
 				RegistryTable: storeLids.RegistryTable,
 				BlobTable:     storeLids.BlobTable,
+				CacheDuration: storeLids.CacheDuration,
 				IDs:           handles,
 			})
 			continue

--- a/cassandra/store_repository.go
+++ b/cassandra/store_repository.go
@@ -15,8 +15,6 @@ import (
 	"github.com/SharedCode/sop/redis"
 )
 
-// Keep these common interfaces where they are implemented, if there will be a need, it is easy to move them to common folder.
-
 type storeRepository struct {
 	redisCache      redis.Cache
 	manageBlobStore sop.ManageBlobStore
@@ -41,27 +39,18 @@ func NewStoreRepositoryExt(manageBlobStore sop.ManageBlobStore) sop.StoreReposit
 	return r
 }
 
-var storeCacheDuration = time.Duration(2 * time.Hour)
-// SetStoreCacheDuration allows store repository cache duration to get set globally.
-func SetStoreCacheDuration(duration time.Duration) {
-	if duration < time.Minute {
-		duration = time.Duration(30 * time.Minute)
-	}
-	storeCacheDuration = duration
-}
-
 // Add a new store record, create a new Virtual ID registry and node blob tables.
 func (sr *storeRepository) Add(ctx context.Context, stores ...sop.StoreInfo) error {
 	if connection == nil {
 		return fmt.Errorf("Cassandra connection is closed, 'call OpenConnection(config) to open it")
 	}
-	insertStatement := fmt.Sprintf("INSERT INTO %s.store (name, root_id, slot_count, count, unique, des, reg_tbl, blob_tbl, ts, vdins, vdap, vdgc, llb, rcd, ncd, vdcd) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);", connection.Config.Keyspace)
+	insertStatement := fmt.Sprintf("INSERT INTO %s.store (name, root_id, slot_count, count, unique, des, reg_tbl, blob_tbl, ts, vdins, vdap, vdgc, llb, rcd, ncd, vdcd, scd) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);", connection.Config.Keyspace)
 	for _, s := range stores {
 
 		// Add a new store record.
 		qry := connection.Session.Query(insertStatement, s.Name, gocql.UUID(s.RootNodeID), s.SlotLength, s.Count, s.IsUnique, s.Description,
 			s.RegistryTable, s.BlobTable, s.Timestamp, s.IsValueDataInNodeSegment, s.IsValueDataActivelyPersisted, s.IsValueDataGloballyCached,
-			s.LeafLoadBalancing, s.CacheConfig.RegistryCacheDuration, s.CacheConfig.NodeCacheDuration, s.CacheConfig.ValueDataCacheDuration).WithContext(ctx)
+			s.LeafLoadBalancing, s.CacheConfig.RegistryCacheDuration, s.CacheConfig.NodeCacheDuration, s.CacheConfig.ValueDataCacheDuration, s.CacheConfig.StoreCacheDuration).WithContext(ctx)
 		if connection.Config.ConsistencyBook.StoreAdd > gocql.Any {
 			qry.Consistency(connection.Config.ConsistencyBook.StoreAdd)
 		}
@@ -85,7 +74,7 @@ func (sr *storeRepository) Add(ctx context.Context, stores ...sop.StoreInfo) err
 			return err
 		}
 		// Tolerate error in Redis caching.
-		if err := sr.redisCache.SetStruct(ctx, s.Name, &s, storeCacheDuration); err != nil {
+		if err := sr.redisCache.SetStruct(ctx, s.Name, &s, s.CacheConfig.StoreCacheDuration); err != nil {
 			log.Warn(fmt.Sprintf("StoreRepository Add failed (redis setstruct), details: %v", err))
 		}
 	}
@@ -181,7 +170,7 @@ func (sr *storeRepository) Update(ctx context.Context, stores ...sop.StoreInfo) 
 	// Update redis since we've successfully updated Cassandra Store table.
 	for i := range stores {
 		// Tolerate redis error since we've successfully updated the master table.
-		if err := sr.redisCache.SetStruct(ctx, stores[i].Name, &stores[i], storeCacheDuration); err != nil {
+		if err := sr.redisCache.SetStruct(ctx, stores[i].Name, &stores[i], stores[i].CacheConfig.StoreCacheDuration); err != nil {
 			log.Warn(fmt.Sprintf("StoreRepository Update (redis setstruct) failed, details: %v", err))
 		}
 	}
@@ -212,7 +201,7 @@ func (sr *storeRepository) Get(ctx context.Context, names ...string) ([]sop.Stor
 	if len(paramQ) == 0 {
 		return stores, nil
 	}
-	selectStatement := fmt.Sprintf("SELECT name, root_id, slot_count, count, unique, des, reg_tbl, blob_tbl, ts, vdins, vdap, vdgc, llb, rcd, ncd, vdcd FROM %s.store  WHERE name in (%v);",
+	selectStatement := fmt.Sprintf("SELECT name, root_id, slot_count, count, unique, des, reg_tbl, blob_tbl, ts, vdins, vdap, vdgc, llb, rcd, ncd, vdcd, scd FROM %s.store  WHERE name in (%v);",
 		connection.Config.Keyspace, strings.Join(paramQ, ", "))
 
 	qry := connection.Session.Query(selectStatement, namesAsIntf...).WithContext(ctx)
@@ -225,10 +214,10 @@ func (sr *storeRepository) Get(ctx context.Context, names ...string) ([]sop.Stor
 	var rid gocql.UUID
 	for iter.Scan(&store.Name, &rid, &store.SlotLength, &store.Count, &store.IsUnique,
 		&store.Description, &store.RegistryTable, &store.BlobTable, &store.Timestamp, &store.IsValueDataInNodeSegment, &store.IsValueDataActivelyPersisted, &store.IsValueDataGloballyCached,
-		&store.LeafLoadBalancing, &store.CacheConfig.RegistryCacheDuration, &store.CacheConfig.NodeCacheDuration, &store.CacheConfig.ValueDataCacheDuration) {
+		&store.LeafLoadBalancing, &store.CacheConfig.RegistryCacheDuration, &store.CacheConfig.NodeCacheDuration, &store.CacheConfig.ValueDataCacheDuration, &store.CacheConfig.StoreCacheDuration) {
 		store.RootNodeID = sop.UUID(rid)
 
-		if err := sr.redisCache.SetStruct(ctx, store.Name, &store, storeCacheDuration); err != nil {
+		if err := sr.redisCache.SetStruct(ctx, store.Name, &store, store.CacheConfig.StoreCacheDuration); err != nil {
 			log.Warn(fmt.Sprintf("StoreRepository Get (redis setstruct) failed, details: %v", err))
 		}
 

--- a/in_red_cfs/fs/blob_store.go
+++ b/in_red_cfs/fs/blob_store.go
@@ -40,7 +40,7 @@ func NewBlobStoreExt(
 
 func (b *blobStore) GetOne(ctx context.Context, blobFilePath string, blobID sop.UUID, target interface{}) error {
 	fp := b.toFilePath(blobFilePath, blobID)
-	fn := fmt.Sprintf("%s%c%s", fp, os.PathSeparator, blobID.ToString())
+	fn := fmt.Sprintf("%s%c%s", fp, os.PathSeparator, blobID.String())
 	ba, err := b.fileIO.ReadFile(fn)
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func (b *blobStore) Add(ctx context.Context, storesblobs ...sop.BlobsPayload[sop
 				}
 			}
 			// WriteFile will add or replace existing file. 666 - gives R/W permission to everybody.
-			fn := fmt.Sprintf("%s%c%s", fp, os.PathSeparator, blob.Key.ToString())
+			fn := fmt.Sprintf("%s%c%s", fp, os.PathSeparator, blob.Key.String())
 			if err = b.fileIO.WriteFile(fn, ba, permission); err != nil {
 				return err
 			}
@@ -79,7 +79,7 @@ func (b *blobStore) Remove(ctx context.Context, storesBlobsIDs ...sop.BlobsPaylo
 	for _, storeBlobIDs := range storesBlobsIDs {
 		for _, blobID := range storeBlobIDs.Blobs {
 			fp := b.toFilePath(storeBlobIDs.BlobTable, blobID)
-			fn := fmt.Sprintf("%s%c%s", fp, os.PathSeparator, blobID.ToString())
+			fn := fmt.Sprintf("%s%c%s", fp, os.PathSeparator, blobID.String())
 			// Ok if file does not exist to return nil as it it was successfully removed.
 			if !b.fileIO.Exists(fn) {
 				return nil

--- a/in_red_ck/item_action_tracker.go
+++ b/in_red_ck/item_action_tracker.go
@@ -84,7 +84,7 @@ func (t *itemActionTracker[TK, TV]) Get(ctx context.Context, item *btree.Item[TK
 						return err
 					}
 					// Just log Redis error since it is just secondary.
-					if err := t.redisCache.SetStruct(ctx, formatItemKey(item.ID.String()), &v, nodeCacheDuration); err != nil {
+					if err := t.redisCache.SetStruct(ctx, formatItemKey(item.ID.String()), &v, t.storeInfo.CacheConfig.ValueDataCacheDuration); err != nil {
 						log.Warn(err.Error())
 					}
 				}
@@ -143,7 +143,7 @@ func (t *itemActionTracker[TK, TV]) Add(ctx context.Context, item *btree.Item[TK
 				return err
 			}
 			if t.storeInfo.IsValueDataGloballyCached {
-				t.redisCache.SetStruct(ctx, formatItemKey(itemForAdd.Key.String()), itemForAdd.Value, nodeCacheDuration)
+				t.redisCache.SetStruct(ctx, formatItemKey(itemForAdd.Key.String()), itemForAdd.Value, t.storeInfo.CacheConfig.ValueDataCacheDuration)
 			}
 		}
 	}
@@ -174,7 +174,7 @@ func (t *itemActionTracker[TK, TV]) Update(ctx context.Context, item *btree.Item
 					return err
 				}
 				if t.storeInfo.IsValueDataGloballyCached {
-					t.redisCache.SetStruct(ctx, formatItemKey(itemForAdd.Key.String()), itemForAdd.Value, nodeCacheDuration)
+					t.redisCache.SetStruct(ctx, formatItemKey(itemForAdd.Key.String()), itemForAdd.Value, t.storeInfo.CacheConfig.ValueDataCacheDuration)
 				}
 			}
 		}
@@ -263,7 +263,7 @@ func (t *itemActionTracker[TK, TV]) checkTrackedItems(ctx context.Context) error
 		if readItem.Action == getAction && cachedItem.Action == getAction {
 			continue
 		}
-		return fmt.Errorf("lock(item: %v) call detected conflict", uuid.ToString())
+		return fmt.Errorf("lock(item: %v) call detected conflict", uuid.String())
 	}
 	return nil
 }
@@ -292,9 +292,9 @@ func (t *itemActionTracker[TK, TV]) lock(ctx context.Context, duration time.Dura
 					continue
 				}
 				if readItem.LockID.IsNil() {
-					return fmt.Errorf("lock(item: %v) call can't attain a lock in Redis", uuid.ToString())
+					return fmt.Errorf("lock(item: %v) call can't attain a lock in Redis", uuid.String())
 				}
-				return fmt.Errorf("lock(item: %v) call detected conflict", uuid.ToString())
+				return fmt.Errorf("lock(item: %v) call detected conflict", uuid.String())
 			}
 			// We got the item locked, ensure we can unlock it.
 			cachedItem.isLockOwner = true
@@ -309,7 +309,7 @@ func (t *itemActionTracker[TK, TV]) lock(ctx context.Context, duration time.Dura
 		if readItem.Action == getAction && cachedItem.Action == getAction {
 			continue
 		}
-		return fmt.Errorf("lock(item: %v) call detected conflict", uuid.ToString())
+		return fmt.Errorf("lock(item: %v) call detected conflict", uuid.String())
 	}
 	return nil
 }

--- a/in_red_ck/item_action_tracker.go
+++ b/in_red_ck/item_action_tracker.go
@@ -77,7 +77,7 @@ func (t *itemActionTracker[TK, TV]) Get(ctx context.Context, item *btree.Item[TK
 			if t.storeInfo.IsValueDataGloballyCached {
 				if err := t.redisCache.GetStruct(ctx, formatItemKey(item.ID.String()), &v); err != nil {
 					if !redis.KeyNotFound(err) {
-						log.Error(err.Error())
+						log.Warn(err.Error())
 					}
 					// If item not found in Redis or an error fetching it, fetch from Blob store.
 					if err := t.blobStore.GetOne(ctx, t.storeInfo.BlobTable, item.ID, &v); err != nil {
@@ -85,7 +85,7 @@ func (t *itemActionTracker[TK, TV]) Get(ctx context.Context, item *btree.Item[TK
 					}
 					// Just log Redis error since it is just secondary.
 					if err := t.redisCache.SetStruct(ctx, formatItemKey(item.ID.String()), &v, nodeCacheDuration); err != nil {
-						log.Error(err.Error())
+						log.Warn(err.Error())
 					}
 				}
 			} else {

--- a/in_red_ck/item_action_tracker.value_data.go
+++ b/in_red_ck/item_action_tracker.value_data.go
@@ -30,7 +30,7 @@ func (t *itemActionTracker[TK, TV]) commitTrackedItemsValues(ctx context.Context
 	// Add to cache since succeeded to add to the blob store.
 	if t.storeInfo.IsValueDataGloballyCached {
 		for _, kvp := range itemsForAdd.Blobs {
-			t.redisCache.SetStruct(ctx, formatItemKey(kvp.Key.String()), kvp.Value, nodeCacheDuration)
+			t.redisCache.SetStruct(ctx, formatItemKey(kvp.Key.String()), kvp.Value, t.storeInfo.CacheConfig.ValueDataCacheDuration)
 		}
 	}
 	return nil

--- a/in_red_ck/manage_btree.go
+++ b/in_red_ck/manage_btree.go
@@ -62,7 +62,7 @@ func NewBtree[TK btree.Comparable, TV any](ctx context.Context, si sop.StoreOpti
 		trans.Rollback(ctx)
 		return nil, err
 	}
-	ns := sop.NewStoreInfoExt(si.Name, si.SlotLength, si.IsUnique, si.IsValueDataInNodeSegment, si.IsValueDataActivelyPersisted, si.IsValueDataGloballyCached, si.LeafLoadBalancing, si.Description, si.BlobStoreBaseFolderPath)
+	ns := sop.NewStoreInfoExt(si.Name, si.SlotLength, si.IsUnique, si.IsValueDataInNodeSegment, si.IsValueDataActivelyPersisted, si.IsValueDataGloballyCached, si.LeafLoadBalancing, si.Description, si.BlobStoreBaseFolderPath, si.CacheConfig)
 	// Allow caller to use the same name for blob store and the store name.
 	if si.DisableBlobStoreFormatting {
 		ns.BlobTable = ns.Name

--- a/in_red_ck/node_repository.go
+++ b/in_red_ck/node_repository.go
@@ -126,7 +126,7 @@ func (nr *nodeRepository) get(ctx context.Context, logicalID sop.UUID, target in
 		}
 		target.(btree.MetaDataType).SetVersion(h[0].IDs[0].Version)
 		if err := nr.transaction.redisCache.SetStruct(ctx, nr.formatKey(nodeID.String()), target, nr.storeInfo.CacheConfig.NodeCacheDuration); err != nil {
-			log.Warn(fmt.Sprintf("failed to cache in Redis the newly fetched node with ID: %v, details: %v", nodeID.ToString(), err))
+			log.Warn(fmt.Sprintf("failed to cache in Redis the newly fetched node with ID: %v, details: %v", nodeID.String(), err))
 		}
 		nr.nodeLocalCache[logicalID] = cacheNode{
 			action: defaultAction,
@@ -592,6 +592,7 @@ func convertToRegistryRequestPayload(nodes []sop.Tuple[*sop.StoreInfo, []interfa
 		vids[i] = sop.RegistryPayload[sop.UUID]{
 			RegistryTable: nodes[i].First.RegistryTable,
 			BlobTable:     nodes[i].First.BlobTable,
+			CacheDuration: nodes[i].First.CacheConfig.RegistryCacheDuration,
 			IDs:           make([]sop.UUID, len(nodes[i].Second)),
 		}
 		for ii := range nodes[i].Second {

--- a/in_red_ck/node_repository.go
+++ b/in_red_ck/node_repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	log "log/slog"
-	"time"
 
 	"github.com/SharedCode/sop"
 	"github.com/SharedCode/sop/btree"
@@ -21,16 +20,6 @@ type cacheNode struct {
 
 type nodeRepositoryTyped[TK btree.Comparable, TV any] struct {
 	realNodeRepository *nodeRepository
-}
-
-var nodeCacheDuration time.Duration = time.Duration(1 * time.Hour)
-
-// SetNodeCacheDuration allows node cache duration to get set globally.
-func SetNodeCacheDuration(duration time.Duration) {
-	if duration < time.Minute {
-		duration = time.Duration(20 * time.Minute)
-	}
-	nodeCacheDuration = duration
 }
 
 // Add will upsert node to the map.
@@ -136,8 +125,8 @@ func (nr *nodeRepository) get(ctx context.Context, logicalID sop.UUID, target in
 			return nil, err
 		}
 		target.(btree.MetaDataType).SetVersion(h[0].IDs[0].Version)
-		if err := nr.transaction.redisCache.SetStruct(ctx, nr.formatKey(nodeID.String()), target, nodeCacheDuration); err != nil {
-			log.Warn(fmt.Sprintf("failed to cache in Redis the newly fetched node with ID: %v, details: %v", nodeID, err))
+		if err := nr.transaction.redisCache.SetStruct(ctx, nr.formatKey(nodeID.String()), target, nr.storeInfo.CacheConfig.NodeCacheDuration); err != nil {
+			log.Warn(fmt.Sprintf("failed to cache in Redis the newly fetched node with ID: %v, details: %v", nodeID.ToString(), err))
 		}
 		nr.nodeLocalCache[logicalID] = cacheNode{
 			action: defaultAction,
@@ -222,7 +211,7 @@ func (nr *nodeRepository) commitNewRootNodes(ctx context.Context, nodes []sop.Tu
 	for i := range nodes {
 		for ii := range nodes[i].Second {
 			if err := nr.transaction.redisCache.SetStruct(ctx, nr.formatKey(handles[i].IDs[ii].GetActiveID().String()),
-				nodes[i].Second[ii], nodeCacheDuration); err != nil {
+				nodes[i].Second[ii], nodes[i].First.CacheConfig.NodeCacheDuration); err != nil {
 				return false, err
 			}
 		}
@@ -285,7 +274,7 @@ func (nr *nodeRepository) commitUpdatedNodes(ctx context.Context, nodes []sop.Tu
 	}
 	for i := range nodes {
 		for ii := range nodes[i].Second {
-			if err := nr.transaction.redisCache.SetStruct(ctx, nr.formatKey(handles[i].IDs[ii].GetInActiveID().String()), nodes[i].Second[ii], nodeCacheDuration); err != nil {
+			if err := nr.transaction.redisCache.SetStruct(ctx, nr.formatKey(handles[i].IDs[ii].GetInActiveID().String()), nodes[i].Second[ii], nodes[i].First.CacheConfig.NodeCacheDuration); err != nil {
 				return false, nil, err
 			}
 		}
@@ -352,7 +341,7 @@ func (nr *nodeRepository) commitAddedNodes(ctx context.Context, nodes []sop.Tupl
 			blobs[i].Blobs[ii].Value = nodes[i].Second[ii]
 			handles[i].IDs[ii] = h
 			// Add node to Redis cache.
-			if err := nr.transaction.redisCache.SetStruct(ctx, nr.formatKey(metaData.GetID().String()), nodes[i].Second[ii], nodeCacheDuration); err != nil {
+			if err := nr.transaction.redisCache.SetStruct(ctx, nr.formatKey(metaData.GetID().String()), nodes[i].Second[ii], nodes[i].First.CacheConfig.NodeCacheDuration); err != nil {
 				return err
 			}
 		}

--- a/in_red_ck/two_phase_commit_transaction.go
+++ b/in_red_ck/two_phase_commit_transaction.go
@@ -816,7 +816,7 @@ func (t *transaction) deleteObsoleteEntries(ctx context.Context,
 		}
 		if err := t.redisCache.Delete(ctx, deletedKeys...); err != nil && !redis.KeyNotFound(err) {
 			lastErr = err
-			log.Error(fmt.Sprintf("Redis delete failed, details: %v", err))
+			log.Warn(fmt.Sprintf("Redis delete failed, details: %v", err))
 		}
 		if err := t.blobStore.Remove(ctx, unusedNodeIDs...); err != nil {
 			lastErr = err

--- a/in_red_cs3/blob_store.go
+++ b/in_red_cs3/blob_store.go
@@ -29,13 +29,13 @@ func NewBlobStore(s3Client *s3.Client, marshaler sop.Marshaler) (*blobStore, err
 
 func (b *blobStore) GetOne(ctx context.Context, blobFilePath string, blobID sop.UUID, target interface{}) error {
 	if b.isLargeObjects {
-		s3o, err := b.BucketAsStore.FetchLargeObject(ctx, blobFilePath, blobID.ToString())
+		s3o, err := b.BucketAsStore.FetchLargeObject(ctx, blobFilePath, blobID.String())
 		if err != nil {
 			return err
 		}
 		return b.marshaler.Unmarshal(s3o.Data, target)
 	}
-	s3o := b.BucketAsStore.Fetch(ctx, blobFilePath, blobID.ToString())
+	s3o := b.BucketAsStore.Fetch(ctx, blobFilePath, blobID.String())
 	if s3o.Error != nil {
 		return s3o.Error
 	}
@@ -50,7 +50,7 @@ func (b *blobStore) Add(ctx context.Context, storesblobs ...sop.BlobsPayload[sop
 				return err
 			}
 			res := b.BucketAsStore.Add(ctx, storeBlobs.BlobTable, sop.KeyValuePair[string, *aws_s3.S3Object]{
-				Key:   blob.Key.ToString(),
+				Key:   blob.Key.String(),
 				Value: &aws_s3.S3Object{Data: ba},
 			})
 			if res.Error != nil {
@@ -69,7 +69,7 @@ func (b *blobStore) Remove(ctx context.Context, storesBlobsIDs ...sop.BlobsPaylo
 	for _, storeBlobIDs := range storesBlobsIDs {
 		s3okeys := make([]string, len(storeBlobIDs.Blobs))
 		for i, blobID := range storeBlobIDs.Blobs {
-			s3okeys[i] = blobID.ToString()
+			s3okeys[i] = blobID.String()
 		}
 		res := b.BucketAsStore.Remove(ctx, storeBlobIDs.BlobTable, s3okeys...)
 		if res.Error != nil {

--- a/repository.go
+++ b/repository.go
@@ -2,6 +2,7 @@ package sop
 
 import (
 	"context"
+	"time"
 )
 
 // Manage or fetch Virtual ID request/response payload.
@@ -10,6 +11,8 @@ type RegistryPayload[T Handle | UUID] struct {
 	RegistryTable string
 	// During Rollback and Commit, we need to get hold of the paired BlobTable(or blob base folder path if in FS).
 	BlobTable string
+	// CacheDuration to be used for Redis caching.
+	CacheDuration time.Duration
 	// IDs is an array containing the Virtual IDs details to be stored or to be fetched.
 	IDs []T
 }

--- a/store_info.go
+++ b/store_info.go
@@ -4,7 +4,19 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
+
+// Store Cache config specificaiton.
+type StoreCacheConfig struct {
+	// Specifies this store's Registry Objects' Redis cache duration.
+	RegistryCacheDuration time.Duration
+	// Specifies this store's Node's Redis cache duration.
+	NodeCacheDuration time.Duration
+	// Only used if IsValueDataInNodeSegment(false) & IsValueDataGloballyCached(true).
+	// Specifies this store's Item Value part Redis cache duration.
+	ValueDataCacheDuration time.Duration
+}
 
 // StoreInfo contains a given (B-Tree) store details.
 type StoreInfo struct {
@@ -42,6 +54,9 @@ type StoreInfo struct {
 	// If true, node load will be balanced by pushing items to sibling nodes if there are vacant slots,
 	// otherwise will not. This feature can be turned off if backend is impacted by the "balancing" act.
 	LeafLoadBalancing bool
+	// Redis cache specification for this store's objects(registry, nodes, item value part).
+	// Defaults to the global specification and can be overriden for each store.
+	CacheConfig StoreCacheConfig
 }
 
 // NewStoreInfo instantiates a new Store, defaults extended parameters to typical use-case values. Please use NewStoreInfoExtended(..) function
@@ -52,13 +67,13 @@ func NewStoreInfo(name string, slotLength int, isUnique bool, isValueDataInNodeS
 	if !isValueDataInNodeSegment {
 		isValueDataGloballyCached = true
 	}
-	return NewStoreInfoExt(name, slotLength, isUnique, isValueDataInNodeSegment, isValueDataActivelyPersisted, isValueDataGloballyCached, leafLoadBalancing, desciption, "")
+	return NewStoreInfoExt(name, slotLength, isUnique, isValueDataInNodeSegment, isValueDataActivelyPersisted, isValueDataGloballyCached, leafLoadBalancing, desciption, "", GetDefaulCacheConfig())
 }
 
 // NewStoreInfoExt instantiates a new Store and offers more parameters configurable to your desire.
 // blobStoreBasePath can be left blank("") and SOP will generate a name for it. This parameter is geared so one can specify
 // a base path folder for the blob store using the File System. If using Cassandra table, please specify blank("").
-func NewStoreInfoExt(name string, slotLength int, isUnique bool, isValueDataInNodeSegment bool, isValueDataActivelyPersisted bool, isValueDataGloballyCached bool, leafLoadBalancing bool, desciption string, blobStoreBasePath string) *StoreInfo {
+func NewStoreInfoExt(name string, slotLength int, isUnique bool, isValueDataInNodeSegment bool, isValueDataActivelyPersisted bool, isValueDataGloballyCached bool, leafLoadBalancing bool, desciption string, blobStoreBasePath string, cacheConfig StoreCacheConfig) *StoreInfo {
 	// Only even numbered slot lengths are allowed as we reduced scenarios to simplify logic.
 	if slotLength%2 != 0 {
 		slotLength--
@@ -104,6 +119,7 @@ func NewStoreInfoExt(name string, slotLength int, isUnique bool, isValueDataInNo
 		IsValueDataActivelyPersisted: isValueDataActivelyPersisted,
 		IsValueDataGloballyCached:    isValueDataGloballyCached,
 		LeafLoadBalancing:            leafLoadBalancing,
+		CacheConfig: cacheConfig,
 	}
 }
 

--- a/store_info.go
+++ b/store_info.go
@@ -16,6 +16,8 @@ type StoreCacheConfig struct {
 	// Only used if IsValueDataInNodeSegment(false) & IsValueDataGloballyCached(true).
 	// Specifies this store's Item Value part Redis cache duration.
 	ValueDataCacheDuration time.Duration
+	// Specifies this store's Redis cache duration.
+	StoreCacheDuration time.Duration
 }
 
 // StoreInfo contains a given (B-Tree) store details.

--- a/store_info.go
+++ b/store_info.go
@@ -69,13 +69,13 @@ func NewStoreInfo(name string, slotLength int, isUnique bool, isValueDataInNodeS
 	if !isValueDataInNodeSegment {
 		isValueDataGloballyCached = true
 	}
-	return NewStoreInfoExt(name, slotLength, isUnique, isValueDataInNodeSegment, isValueDataActivelyPersisted, isValueDataGloballyCached, leafLoadBalancing, desciption, "", GetDefaulCacheConfig())
+	return NewStoreInfoExt(name, slotLength, isUnique, isValueDataInNodeSegment, isValueDataActivelyPersisted, isValueDataGloballyCached, leafLoadBalancing, desciption, "", nil)
 }
 
 // NewStoreInfoExt instantiates a new Store and offers more parameters configurable to your desire.
 // blobStoreBasePath can be left blank("") and SOP will generate a name for it. This parameter is geared so one can specify
 // a base path folder for the blob store using the File System. If using Cassandra table, please specify blank("").
-func NewStoreInfoExt(name string, slotLength int, isUnique bool, isValueDataInNodeSegment bool, isValueDataActivelyPersisted bool, isValueDataGloballyCached bool, leafLoadBalancing bool, desciption string, blobStoreBasePath string, cacheConfig StoreCacheConfig) *StoreInfo {
+func NewStoreInfoExt(name string, slotLength int, isUnique bool, isValueDataInNodeSegment bool, isValueDataActivelyPersisted bool, isValueDataGloballyCached bool, leafLoadBalancing bool, desciption string, blobStoreBasePath string, cacheConfig *StoreCacheConfig) *StoreInfo {
 	// Only even numbered slot lengths are allowed as we reduced scenarios to simplify logic.
 	if slotLength%2 != 0 {
 		slotLength--
@@ -110,6 +110,12 @@ func NewStoreInfoExt(name string, slotLength int, isUnique bool, isValueDataInNo
 		isValueDataActivelyPersisted = false
 	}
 
+	// Use the SOP default cache config if the parameter received is not set.
+	if cacheConfig == nil {
+		cc := GetDefaulCacheConfig()
+		cacheConfig = &cc
+	}
+
 	return &StoreInfo{
 		Name:                         name,
 		SlotLength:                   slotLength,
@@ -121,7 +127,7 @@ func NewStoreInfoExt(name string, slotLength int, isUnique bool, isValueDataInNo
 		IsValueDataActivelyPersisted: isValueDataActivelyPersisted,
 		IsValueDataGloballyCached:    isValueDataGloballyCached,
 		LeafLoadBalancing:            leafLoadBalancing,
-		CacheConfig: cacheConfig,
+		CacheConfig: *cacheConfig,
 	}
 }
 

--- a/store_options.go
+++ b/store_options.go
@@ -36,6 +36,9 @@ type StoreOptions struct {
 	// Set to true to allow use of the store name as the blob store name. Useful for integrating with systems like AWS S3 where
 	// strict bucket naming convention is applied.
 	DisableBlobStoreFormatting bool
+	// Redis cache specification for this store's objects(registry, nodes, item value part).
+	// Defaults to the global specification and can be overriden for each store.
+	CacheConfig StoreCacheConfig
 }
 
 // ValueDataSize enumeration.
@@ -54,6 +57,17 @@ const (
 	BigData
 )
 
+var defaultCacheConfig StoreCacheConfig
+
+// Assigns to the global default cache duration config.
+func SetDefaultCacheConfig(cacheDuration StoreCacheConfig) {
+	defaultCacheConfig = cacheDuration
+}
+// Returns the global default cache duration config.
+func GetDefaulCacheConfig() StoreCacheConfig {
+	return defaultCacheConfig
+}
+
 // Helper function to easily configure a store. Select the right valueDataSize matching your usage scenario.
 // blobStoreBaseFolderPath is only used if storing blobs in File System. This specified the base folder path of the directory to contain the blobs.
 //
@@ -70,6 +84,11 @@ func ConfigureStore(storeName string, uniqueKey bool, slotLength int, descriptio
 		IsValueDataInNodeSegment: true,
 		Description:              description,
 		BlobStoreBaseFolderPath:  blobStoreBaseFolderPath,
+		CacheConfig: StoreCacheConfig{
+			RegistryCacheDuration: defaultCacheConfig.RegistryCacheDuration,
+			NodeCacheDuration: defaultCacheConfig.NodeCacheDuration,
+			ValueDataCacheDuration: defaultCacheConfig.ValueDataCacheDuration,
+		},
 	}
 	if valueDataSize == MediumData {
 		so.IsValueDataInNodeSegment = false

--- a/store_options.go
+++ b/store_options.go
@@ -40,7 +40,7 @@ type StoreOptions struct {
 	DisableBlobStoreFormatting bool
 	// Redis cache specification for this store's objects(registry, nodes, item value part).
 	// Defaults to the global specification and can be overriden for each store.
-	CacheConfig StoreCacheConfig
+	CacheConfig *StoreCacheConfig
 }
 
 // ValueDataSize enumeration.
@@ -91,7 +91,7 @@ func ConfigureStore(storeName string, uniqueKey bool, slotLength int, descriptio
 		IsValueDataInNodeSegment: true,
 		Description:              description,
 		BlobStoreBaseFolderPath:  blobStoreBaseFolderPath,
-		CacheConfig: StoreCacheConfig{
+		CacheConfig: &StoreCacheConfig{
 			RegistryCacheDuration: defaultCacheConfig.RegistryCacheDuration,
 			NodeCacheDuration: defaultCacheConfig.NodeCacheDuration,
 			ValueDataCacheDuration: defaultCacheConfig.ValueDataCacheDuration,

--- a/store_options.go
+++ b/store_options.go
@@ -1,5 +1,7 @@
 package sop
 
+import "time"
+
 // StoreOptions contains field options settable when constructing a given (B-Tree).
 type StoreOptions struct {
 	// Short name of this (B-Tree store).
@@ -57,7 +59,12 @@ const (
 	BigData
 )
 
-var defaultCacheConfig StoreCacheConfig
+var defaultCacheConfig StoreCacheConfig = StoreCacheConfig{
+	StoreCacheDuration: time.Duration(12 * time.Hour),
+	RegistryCacheDuration: time.Duration(12 * time.Hour),
+	ValueDataCacheDuration: time.Duration(12 * time.Hour),
+	NodeCacheDuration: time.Duration(12 * time.Hour),
+}
 
 // Assigns to the global default cache duration config.
 func SetDefaultCacheConfig(cacheDuration StoreCacheConfig) {
@@ -88,6 +95,7 @@ func ConfigureStore(storeName string, uniqueKey bool, slotLength int, descriptio
 			RegistryCacheDuration: defaultCacheConfig.RegistryCacheDuration,
 			NodeCacheDuration: defaultCacheConfig.NodeCacheDuration,
 			ValueDataCacheDuration: defaultCacheConfig.ValueDataCacheDuration,
+			StoreCacheDuration: defaultCacheConfig.StoreCacheDuration,
 		},
 	}
 	if valueDataSize == MediumData {

--- a/uuid.go
+++ b/uuid.go
@@ -2,7 +2,6 @@ package sop
 
 import (
 	"bytes"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,15 +33,10 @@ func NewUUID() UUID {
 var NilUUID UUID
 
 func (id UUID) IsNil() bool {
-	return bytes.Compare(id[:], NilUUID[:]) == 0
+	return bytes.Equal(id[:], NilUUID[:])
 }
 
 // String converts UUID to its string representation.
 func (id UUID) String() string {
-	return string(id[:])
-}
-
-// ToString Returns format xxxx-yyyy-zzzz-rrrr-tttt
-func (id UUID) ToString() string {
-	return fmt.Sprintf("%x-%x-%x-%x-%x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
+	return 	uuid.UUID(id).String()
 }


### PR DESCRIPTION
Everything defaults to 12 hrs, see sop.GetDefaultCacheConfig(& sop.SetDefaultCacheConfig) but during creation of Btree(NewBtree function call), code can specify a custom caching duration for the store.

Example use-case, put non-expiration caching on all data of a store for the one most commonly used by end-client.
Registry, Node, StoreInfo, Value Data caching can be set on each "store" level, or defaults to 12 hrs for all.