### PR TITLE
Added support for "sliding time", a.k.a. TTL

### DIFF
--- a/cassandra/btree.cql
+++ b/cassandra/btree.cql
@@ -33,12 +33,20 @@ create table store (
     -- store cache config fields.
     -- registry cache duration.
     rcd duration,
+    -- registry cache is sliding time or not.
+    rc_ttl boolean,
     -- node cache duration.
     ncd duration,
+    -- node cache is sliding time or not.
+    nc_ttl boolean,
     -- value data cache duration.
     vdcd duration,
+    -- valud data cache is sliding time or not.
+     vdc_ttl boolean,
     -- store cache duration.
-    scd duration);
+    scd duration,
+    -- store cache is sliding time or not.
+     sc_ttl boolean);
 
 -- Node Blob demo table 1.
 create table foo_b(

--- a/cassandra/btree.cql
+++ b/cassandra/btree.cql
@@ -32,19 +32,19 @@ create table store (
     llb boolean
     -- store cache config fields.
     -- registry cache duration.
-    rcd duration,
+    rcd bigint,
     -- registry cache is sliding time or not.
     rc_ttl boolean,
     -- node cache duration.
-    ncd duration,
+    ncd bigint,
     -- node cache is sliding time or not.
     nc_ttl boolean,
     -- value data cache duration.
-    vdcd duration,
+    vdcd bigint,
     -- valud data cache is sliding time or not.
      vdc_ttl boolean,
     -- store cache duration.
-    scd duration,
+    scd bigint,
     -- store cache is sliding time or not.
      sc_ttl boolean);
 

--- a/cassandra/connection.go
+++ b/cassandra/connection.go
@@ -110,7 +110,7 @@ func OpenConnection(config Config) (*Connection, error) {
 		return nil, err
 	}
 	// Auto create the "store" table if not yet.
-	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.store (name text PRIMARY KEY, root_id UUID, slot_count int, count bigint, unique boolean, des text, reg_tbl text, blob_tbl text, ts bigint, vdins boolean, vdap boolean, vdgc boolean, llb boolean, rcd duration, rc_ttl boolean, ncd duration, nc_ttl boolean, vdcd duration, vdc_ttl boolean, scd duration, sc_ttl boolean);", config.Keyspace)).Exec(); err != nil {
+	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.store (name text PRIMARY KEY, root_id UUID, slot_count int, count bigint, unique boolean, des text, reg_tbl text, blob_tbl text, ts bigint, vdins boolean, vdap boolean, vdgc boolean, llb boolean, rcd bigint, rc_ttl boolean, ncd bigint, nc_ttl boolean, vdcd bigint, vdc_ttl boolean, scd bigint, sc_ttl boolean);", config.Keyspace)).Exec(); err != nil {
 		return nil, err
 	}
 	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.t_log (id UUID, c_f int, c_f_p blob, PRIMARY KEY(id, c_f));", config.Keyspace)).Exec(); err != nil {

--- a/cassandra/connection.go
+++ b/cassandra/connection.go
@@ -110,7 +110,7 @@ func OpenConnection(config Config) (*Connection, error) {
 		return nil, err
 	}
 	// Auto create the "store" table if not yet.
-	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.store (name text PRIMARY KEY, root_id UUID, slot_count int, count bigint, unique boolean, des text, reg_tbl text, blob_tbl text, ts bigint, vdins boolean, vdap boolean, vdgc boolean, llb boolean, rcd duration, ncd duration, vdcd duration, scd duration);", config.Keyspace)).Exec(); err != nil {
+	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.store (name text PRIMARY KEY, root_id UUID, slot_count int, count bigint, unique boolean, des text, reg_tbl text, blob_tbl text, ts bigint, vdins boolean, vdap boolean, vdgc boolean, llb boolean, rcd duration, rc_ttl boolean, ncd duration, nc_ttl boolean, vdcd duration, vdc_ttl boolean, scd duration, sc_ttl boolean);", config.Keyspace)).Exec(); err != nil {
 		return nil, err
 	}
 	if err := s.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.t_log (id UUID, c_f int, c_f_p blob, PRIMARY KEY(id, c_f));", config.Keyspace)).Exec(); err != nil {

--- a/cassandra/registry.go
+++ b/cassandra/registry.go
@@ -157,7 +157,13 @@ func (v *registry) Get(ctx context.Context, storesLids ...sop.RegistryPayload[so
 		lidsAsIntfs := make([]interface{}, 0, len(storeLids.IDs))
 		for i := range storeLids.IDs {
 			h := sop.Handle{}
-			if err := v.redisCache.GetStruct(ctx, storeLids.IDs[i].String(), &h); err != nil {
+			var err error
+			if storeLids.IsCacheTTL {
+				err = v.redisCache.GetStructEx(ctx, storeLids.IDs[i].String(), &h, storeLids.CacheDuration)
+			} else {
+				err = v.redisCache.GetStruct(ctx, storeLids.IDs[i].String(), &h)
+			}
+			if err != nil {
 				if !redis.KeyNotFound(err) {
 					log.Warn(fmt.Sprintf("Registry Get (redis getstruct) failed, details: %v", err))
 				}
@@ -173,6 +179,7 @@ func (v *registry) Get(ctx context.Context, storesLids ...sop.RegistryPayload[so
 				RegistryTable: storeLids.RegistryTable,
 				BlobTable:     storeLids.BlobTable,
 				CacheDuration: storeLids.CacheDuration,
+				IsCacheTTL: storeLids.IsCacheTTL,
 				IDs:           handles,
 			})
 			continue
@@ -206,6 +213,7 @@ func (v *registry) Get(ctx context.Context, storesLids ...sop.RegistryPayload[so
 			RegistryTable: storeLids.RegistryTable,
 			BlobTable:     storeLids.BlobTable,
 			CacheDuration: storeLids.CacheDuration,
+			IsCacheTTL: storeLids.IsCacheTTL,
 			IDs:           handles,
 		})
 	}

--- a/in_red_cfs/integration_tests/delete_btree_test.go
+++ b/in_red_cfs/integration_tests/delete_btree_test.go
@@ -10,7 +10,7 @@ import (
 // It drops the blob & registry tables of the B-Tree, thus, the test was removed from the set.
 func DeleteBTree(t *testing.T) {
 	tableList := []string{
-		"fooStore", "persondb", "twophase", "twophase2", "twophase3",
+		"fooStore", "fooStore1", "fooStore2", "persondb", "twophase", "twophase2", "twophase3",
 		"twophase22", "persondb7", "persondb77", "person2db", "barStore1",
 		"barStore2", "tabley", "tablex2", "tablex", "ztab1", "videoStore",
 		"videoStoreM", "videoStoreD", "videoStoreU", "xyz", "emptystore",

--- a/in_red_cfs/integration_tests/transaction_test.go
+++ b/in_red_cfs/integration_tests/transaction_test.go
@@ -232,15 +232,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     tableName1,
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: true,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, tableName1, t1)
 		}
 	}
 
@@ -264,15 +256,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForReading, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     tableName1,
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: true,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, tableName1, t1)
 		}
 	}
 }
@@ -310,15 +294,7 @@ func Test_VolumeDeletes(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     tableName1,
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: true,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, tableName1, t1)
 		}
 	}
 }
@@ -372,15 +348,7 @@ func Test_MixedOperations(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     tableName1,
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: true,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, tableName1, t1)
 		}
 	}
 
@@ -416,15 +384,7 @@ func Test_MixedOperations(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     tableName1,
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: true,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, tableName1, t1)
 		}
 	}
 }

--- a/in_red_cfs/integration_tests/value_data_segment/transaction_edge_cases_test.go
+++ b/in_red_cfs/integration_tests/value_data_segment/transaction_edge_cases_test.go
@@ -88,15 +88,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	}
 	t1, _ = in_red_cfs.NewTransaction(sop.ForReading, -1, false)
 	t1.Begin()
-	b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-		Name:                     "persondb7",
-		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
-		IsValueDataInNodeSegment: false,
-		LeafLoadBalancing:        false,
-		Description:              "",
-		BlobStoreBaseFolderPath:  dataPath,
-	}, t1)
+	b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb7", t1)
 	var person Person
 	b3.FindOne(ctx, pk2, false)
 	person, _ = b3.GetCurrentValue(ctx)
@@ -148,26 +140,10 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 		t1.Begin()
-		b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-			Name:                     "persondb7",
-			SlotLength:               nodeSlotLength,
-			IsUnique:                 false,
-			IsValueDataInNodeSegment: false,
-			LeafLoadBalancing:        false,
-			Description:              "",
-			BlobStoreBaseFolderPath:  dataPath,
-		}, t1)
+		b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb7", t1)
 	}
 
-	b32, _ := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-		Name:                     "persondb7",
-		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
-		IsValueDataInNodeSegment: false,
-		LeafLoadBalancing:        false,
-		Description:              "",
-		BlobStoreBaseFolderPath:  dataPath,
-	}, t2)
+	b32, _ := in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb7", t2)
 
 	// edit both "pirellis" in both btrees, one each.
 	b3.FindOne(ctx, pk, false)
@@ -221,26 +197,10 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 		t1.Begin()
-		b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-			Name:                     "persondb7",
-			SlotLength:               nodeSlotLength,
-			IsUnique:                 false,
-			IsValueDataInNodeSegment: false,
-			LeafLoadBalancing:        false,
-			Description:              "",
-			BlobStoreBaseFolderPath:  dataPath,
-		}, t1)
+		b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb7", t1)
 	}
 
-	b32, _ := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-		Name:                     "persondb7",
-		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
-		IsValueDataInNodeSegment: false,
-		LeafLoadBalancing:        false,
-		Description:              "",
-		BlobStoreBaseFolderPath:  dataPath,
-	}, t2)
+	b32, _ := in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb7", t2)
 
 	// Read both records.
 	b32.FindOne(ctx, pk2, false)
@@ -297,26 +257,10 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 		t1.Commit(ctx)
 		t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 		t1.Begin()
-		b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-			Name:                     "persondb7",
-			SlotLength:               nodeSlotLength,
-			IsUnique:                 false,
-			IsValueDataInNodeSegment: false,
-			LeafLoadBalancing:        false,
-			Description:              "",
-			BlobStoreBaseFolderPath:  dataPath,
-		}, t1)
+		b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb7", t1)
 	}
 
-	b32, _ := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-		Name:                     "persondb7",
-		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
-		IsValueDataInNodeSegment: false,
-		LeafLoadBalancing:        false,
-		Description:              "",
-		BlobStoreBaseFolderPath:  dataPath,
-	}, t2)
+	b32, _ := in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb7", t2)
 
 	// Read both records.
 	b32.FindOne(ctx, pk2, false)
@@ -376,26 +320,10 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		t1.Commit(ctx)
 		t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 		t1.Begin()
-		b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-			Name:                     "persondb7",
-			SlotLength:               nodeSlotLength,
-			IsUnique:                 false,
-			IsValueDataInNodeSegment: false,
-			LeafLoadBalancing:        false,
-			Description:              "",
-			BlobStoreBaseFolderPath:  dataPath,
-		}, t1)
+		b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb7", t1)
 	}
 
-	b32, _ := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-		Name:                     "persondb7",
-		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
-		IsValueDataInNodeSegment: false,
-		LeafLoadBalancing:        false,
-		Description:              "",
-		BlobStoreBaseFolderPath:  dataPath,
-	}, t2)
+	b32, _ := in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb7", t2)
 
 	b3.FindOne(ctx, pk, false)
 	ci, _ := b3.GetCurrentItem(ctx)
@@ -467,15 +395,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	f1 := func() error {
 		t1, _ := in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 		t1.Begin()
-		b3, _ := in_red_cfs.NewBtree[int, string](ctx2, sop.StoreOptions{
-			Name:                     "twophase2",
-			SlotLength:               8,
-			IsUnique:                 false,
-			IsValueDataInNodeSegment: false,
-			LeafLoadBalancing:        true,
-			Description:              "",
-			BlobStoreBaseFolderPath:  dataPath,
-		}, t1)
+		b3, _ := in_red_cfs.OpenBtree[int, string](ctx2, "twophase2", t1)
 		b3.Add(ctx2, 5000, "I am the value with 5000 key.")
 		b3.Add(ctx2, 5001, "I am the value with 5001 key.")
 		b3.Add(ctx2, 5002, "I am also a value with 5000 key.")
@@ -485,15 +405,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	f2 := func() error {
 		t2, _ := in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 		t2.Begin()
-		b32, _ := in_red_cfs.NewBtree[int, string](ctx2, sop.StoreOptions{
-			Name:                     "twophase2",
-			SlotLength:               8,
-			IsUnique:                 false,
-			IsValueDataInNodeSegment: false,
-			LeafLoadBalancing:        true,
-			Description:              "",
-			BlobStoreBaseFolderPath:  dataPath,
-		}, t2)
+		b32, _ := in_red_cfs.OpenBtree[int, string](ctx2, "twophase2", t2)
 		b32.Add(ctx2, 5500, "I am the value with 5000 key.")
 		b32.Add(ctx2, 5501, "I am the value with 5001 key.")
 		b32.Add(ctx2, 5502, "I am also a value with 5000 key.")

--- a/in_red_cfs/integration_tests/value_data_segment/transaction_test.go
+++ b/in_red_cfs/integration_tests/value_data_segment/transaction_test.go
@@ -229,15 +229,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     "persondb",
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: false,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb", t1)
 		}
 	}
 
@@ -261,15 +253,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForReading, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     "persondb",
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: false,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb", t1)
 		}
 	}
 }
@@ -307,15 +291,7 @@ func VolumeDeletes(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     "persondb",
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: false,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb", t1)
 		}
 	}
 }
@@ -369,15 +345,7 @@ func MixedOperations(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     "persondb",
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: false,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb", t1)
 		}
 	}
 
@@ -413,15 +381,7 @@ func MixedOperations(t *testing.T) {
 			}
 			t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 			t1.Begin()
-			b3, _ = in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
-				Name:                     "persondb",
-				SlotLength:               nodeSlotLength,
-				IsUnique:                 false,
-				IsValueDataInNodeSegment: false,
-				LeafLoadBalancing:        false,
-				Description:              "",
-				BlobStoreBaseFolderPath:  dataPath,
-			}, t1)
+			b3, _ = in_red_cfs.OpenBtree[PersonKey, Person](ctx, "persondb", t1)
 		}
 	}
 }

--- a/in_red_ck/item_action_tracker.go
+++ b/in_red_ck/item_action_tracker.go
@@ -75,7 +75,13 @@ func (t *itemActionTracker[TK, TV]) Get(ctx context.Context, item *btree.Item[TK
 		if item.Value == nil && item.ValueNeedsFetch {
 			var v TV
 			if t.storeInfo.IsValueDataGloballyCached {
-				if err := t.redisCache.GetStruct(ctx, formatItemKey(item.ID.String()), &v); err != nil {
+				var err error
+				if t.storeInfo.CacheConfig.IsValueDataCacheTTL {
+					err = t.redisCache.GetStructEx(ctx, formatItemKey(item.ID.String()), &v, t.storeInfo.CacheConfig.ValueDataCacheDuration)
+				} else {
+					err = t.redisCache.GetStruct(ctx, formatItemKey(item.ID.String()), &v)
+				}
+				if err != nil {
 					if !redis.KeyNotFound(err) {
 						log.Warn(err.Error())
 					}

--- a/in_red_ck/manage_btree.go
+++ b/in_red_ck/manage_btree.go
@@ -30,7 +30,7 @@ func OpenBtree[TK btree.Comparable, TV any](ctx context.Context, name string, t 
 
 	var t2 interface{} = t.GetPhasedTransaction()
 	trans := t2.(*transaction)
-	stores, err := trans.storeRepository.Get(ctx, name)
+	stores, err := trans.storeRepository.Get(ctx, false, 0, name)
 	if len(stores) == 0 || stores[0].IsEmpty() || err != nil {
 		if err == nil {
 			trans.Rollback(ctx)
@@ -57,7 +57,13 @@ func NewBtree[TK btree.Comparable, TV any](ctx context.Context, si sop.StoreOpti
 	var t2 interface{} = t.GetPhasedTransaction()
 	trans := t2.(*transaction)
 
-	stores, err := trans.storeRepository.Get(ctx, si.Name)
+	var stores []sop.StoreInfo
+	var err error
+	if si.CacheConfig != nil {
+		stores, err = trans.storeRepository.Get(ctx, si.CacheConfig.IsStoreInfoCacheTTL, si.CacheConfig.StoreInfoCacheDuration, si.Name)
+	} else {
+		stores, err = trans.storeRepository.Get(ctx, false, 0, si.Name)
+	}
 	if err != nil {
 		trans.Rollback(ctx)
 		return nil, err
@@ -143,7 +149,7 @@ func refetchAndMergeClosure[TK btree.Comparable, TV any](si *StoreInterface[TK, 
 		si.ItemActionTracker.(*itemActionTracker[TK, TV]).items = make(map[sop.UUID]cacheItem[TK, TV])
 		si.backendNodeRepository.nodeLocalCache = make(map[sop.UUID]cacheNode)
 		// Reset StoreInfo of B-Tree in prep to replay the "actions".
-		storeInfo, err := sr.Get(ctx, b3.StoreInfo.Name)
+		storeInfo, err := sr.Get(ctx, b3.StoreInfo.CacheConfig.IsStoreInfoCacheTTL, b3.StoreInfo.CacheConfig.StoreInfoCacheDuration, b3.StoreInfo.Name)
 		if err != nil {
 			return err
 		}

--- a/in_red_ck/mocks/mock_store_repository.go
+++ b/in_red_ck/mocks/mock_store_repository.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"time"
 
 	"github.com/SharedCode/sop"
 )
@@ -37,7 +38,7 @@ func (sr *mockStoreRepository) Update(ctx context.Context, stores ...sop.StoreIn
 	return nil
 }
 
-func (sr *mockStoreRepository) Get(ctx context.Context, names ...string) ([]sop.StoreInfo, error) {
+func (sr *mockStoreRepository) Get(ctx context.Context, isCacheTTL bool, cacheDuration time.Duration, names ...string) ([]sop.StoreInfo, error) {
 	stores := make([]sop.StoreInfo, len(names))
 	for i, name := range names {
 		v := sr.lookup[name]

--- a/in_red_ck/try_in_docker/main.go
+++ b/in_red_ck/try_in_docker/main.go
@@ -30,7 +30,7 @@ func main() {
 	storeInfo := *sop.NewStoreInfo("foobar", 4, true, true, true, "")
 	storeInfo.RootNodeID = sop.NewUUID()
 	repo := cas.NewStoreRepository()
-	sis, err := repo.Get(ctx, "foobar")
+	sis, err := repo.Get(ctx, false, 0, "foobar")
 	if err != nil {
 		writeAndExit("Cassandra repo Get failed, err: %v.", err)
 	}

--- a/redis/mock_redis.go
+++ b/redis/mock_redis.go
@@ -25,6 +25,9 @@ func (m mockRedis) Set(ctx context.Context, key string, value string, expiration
 func (m mockRedis) Get(ctx context.Context, key string) (string, error) {
 	return "", nil
 }
+func (m mockRedis) GetEx(ctx context.Context, key string, expiration time.Duration) (string, error) {
+	return "", nil
+}
 func (m mockRedis) Ping(ctx context.Context) error {
 	return nil
 }
@@ -47,6 +50,11 @@ func (m *mockRedis) GetStruct(ctx context.Context, key string, target interface{
 	}
 	Marshaler.Unmarshal(ba, target)
 	return nil
+}
+
+// Mock only support GetStruct, GetStructEx just calls GetStruct ignoring expiration.
+func (m *mockRedis) GetStructEx(ctx context.Context, key string, target interface{}, expiration time.Duration) error {
+	return m.GetStruct(ctx, key, target)
 }
 func (m *mockRedis) Delete(ctx context.Context, keys ...string) error {
 	var lastErr error

--- a/repository.go
+++ b/repository.go
@@ -9,10 +9,14 @@ import (
 type RegistryPayload[T Handle | UUID] struct {
 	// Registry table (name) where the Virtual IDs will be stored or fetched from.
 	RegistryTable string
+
 	// During Rollback and Commit, we need to get hold of the paired BlobTable(or blob base folder path if in FS).
 	BlobTable string
 	// CacheDuration to be used for Redis caching.
 	CacheDuration time.Duration
+	// true will use Redis' sliding time, a.k.a. TTL support.
+	IsCacheTTL bool
+
 	// IDs is an array containing the Virtual IDs details to be stored or to be fetched.
 	IDs []T
 }
@@ -105,8 +109,9 @@ type TransactionLog interface {
 // Store is a general purpose Store interface specifying methods or CRUD operations on Key & Value
 // where Value is implied to be superset of Key.
 type Store[TK any, TV any] interface {
-	// Fetch store info with name.
-	Get(context.Context, ...TK) ([]TV, error)
+	// Fetch store info with name(s). If StoreInfo is known to be cached in sliding time(TTL) then specify true on the 2nd bool param & the sliding time duration on the 3rd param.
+	// Otherwise it can be set to false and 0.
+	Get(context.Context, bool, time.Duration, ...TK) ([]TV, error)
 	// Add store info & create related tables like for registry & for node blob.
 	Add(context.Context, ...TV) error
 	// Update store info. Update should also merge the Count of items between the incoming store info

--- a/store_info.go
+++ b/store_info.go
@@ -11,13 +11,21 @@ import (
 type StoreCacheConfig struct {
 	// Specifies this store's Registry Objects' Redis cache duration.
 	RegistryCacheDuration time.Duration
+	// Is RegistryCache sliding time(TTL) or not. If true, needs Redis 6.2.0+.
+	IsRegistryCacheTTL bool
 	// Specifies this store's Node's Redis cache duration.
 	NodeCacheDuration time.Duration
+	// Is NodeCache sliding time(TTL) or not. If true, needs Redis 6.2.0+.
+	IsNodeCacheTTL bool
 	// Only used if IsValueDataInNodeSegment(false) & IsValueDataGloballyCached(true).
 	// Specifies this store's Item Value part Redis cache duration.
 	ValueDataCacheDuration time.Duration
-	// Specifies this store's Redis cache duration.
-	StoreCacheDuration time.Duration
+	// Is ValueCache sliding time(TTL) or not. If true, needs Redis 6.2.0+.
+	IsValueDataCacheTTL bool
+	// Specifies this store's details(StoreInfo) Redis cache duration.
+	StoreInfoCacheDuration time.Duration
+	// Is StoreInfoCache sliding time(TTL) or not. If true, needs Redis 6.2.0+.
+	IsStoreInfoCacheTTL bool
 }
 
 // StoreInfo contains a given (B-Tree) store details.

--- a/store_options.go
+++ b/store_options.go
@@ -60,7 +60,7 @@ const (
 )
 
 var defaultCacheConfig StoreCacheConfig = StoreCacheConfig{
-	StoreCacheDuration:     time.Duration(12 * time.Hour),
+	StoreInfoCacheDuration: time.Duration(12 * time.Hour),
 	RegistryCacheDuration:  time.Duration(12 * time.Hour),
 	ValueDataCacheDuration: time.Duration(12 * time.Hour),
 	NodeCacheDuration:      time.Duration(12 * time.Hour),
@@ -94,9 +94,13 @@ func ConfigureStore(storeName string, uniqueKey bool, slotLength int, descriptio
 		BlobStoreBaseFolderPath:  blobStoreBaseFolderPath,
 		CacheConfig: &StoreCacheConfig{
 			RegistryCacheDuration:  defaultCacheConfig.RegistryCacheDuration,
+			IsRegistryCacheTTL: defaultCacheConfig.IsRegistryCacheTTL,
 			NodeCacheDuration:      defaultCacheConfig.NodeCacheDuration,
+			IsNodeCacheTTL: defaultCacheConfig.IsNodeCacheTTL,
 			ValueDataCacheDuration: defaultCacheConfig.ValueDataCacheDuration,
-			StoreCacheDuration:     defaultCacheConfig.StoreCacheDuration,
+			IsValueDataCacheTTL: defaultCacheConfig.IsValueDataCacheTTL,
+			StoreInfoCacheDuration: defaultCacheConfig.StoreInfoCacheDuration,
+			IsStoreInfoCacheTTL: defaultCacheConfig.IsStoreInfoCacheTTL,
 		},
 	}
 	if valueDataSize == MediumData {


### PR DESCRIPTION
Each data store can be configured with different caching rules. You can define a store w/ caching that don't expire, another one with "sliding time" for each date I/O, and another, absolute expire time.

SOP enforces minimum caching rule per store so it can operate w/ full integrity per store. (caching is a critical feature needed and each store has to meet minimum caching rule to work).