### PR TITLE
in_red_fs.Registry using new hash map on disk checkpoint

### DIFF
--- a/cassandra/registry.go
+++ b/cassandra/registry.go
@@ -119,6 +119,14 @@ func (v *registry) Update(ctx context.Context, allOrNothing bool, storesHandles 
 					h.Version, h.WorkInProgressTimestamp, h.IsDeleted, gocql.UUID(h.LogicalID))
 			}
 		}
+
+		if err := v.cache.IsLocked(ctx, handleKeys...); err != nil {
+			// Unlock the object Keys before return.
+			v.cache.Unlock(ctx, handleKeys...)
+			// Failed locking the batch.
+			return err
+		}
+
 		// Execute the batch query, all or nothing.
 		if err := connection.Session.ExecuteBatch(batch); err != nil {
 			// Unlock the object Keys before return.

--- a/cassandra/transaction_log.go
+++ b/cassandra/transaction_log.go
@@ -73,6 +73,7 @@ func (tl *transactionLog) GetOne(ctx context.Context) (sop.UUID, string, []sop.K
 	}
 	// Check one more time to remove race condition issue.
 	if err := tl.cache.IsLocked(ctx, tl.hourLockKey); err != nil {
+		tl.cache.Unlock(ctx, tl.hourLockKey)
 		// Just return nils as we can't attain a lock.
 		return sop.NilUUID, "", nil, nil
 	}

--- a/common/mocks/mock_redis.go
+++ b/common/mocks/mock_redis.go
@@ -93,6 +93,10 @@ func (m *mockRedis) IsLocked(ctx context.Context, lockKeys ...*sop.LockKey) erro
 	return nil
 }
 
+func (m *mockRedis) IsLockedByOthers(ctx context.Context, lockKeys ...string) (bool, error) {
+	return false, nil
+}
+
 func (m *mockRedis) Unlock(ctx context.Context, lockKeys ...*sop.LockKey) error {
 	return nil
 }

--- a/encoding/handle.go
+++ b/encoding/handle.go
@@ -9,15 +9,15 @@ import (
 	"github.com/SharedCode/sop"
 )
 
-type handleEncoder struct{}
+type HandleEncoder struct{}
 
 // Instantiates a Handler Marshaler.
-func NewHandleMarshaler() Marshaler {
-	return &handleEncoder{}
+func NewHandleMarshaler() *HandleEncoder {
+	return &HandleEncoder{}
 }
 
 // Encodes handler to byte array.
-func (he handleEncoder) Marshal(v any) ([]byte, error) {
+func (he HandleEncoder) Marshal(v any) ([]byte, error) {
 	w := bytes.NewBuffer(make([]byte, 0, sop.HandleSizeInBytes))
 	pv := v.(sop.Handle)
 	encode(w, &pv)
@@ -25,12 +25,21 @@ func (he handleEncoder) Marshal(v any) ([]byte, error) {
 }
 
 // Decodes byte array back to a handler type.
-func (he handleEncoder) Unmarshal(data []byte, v any) error {
+func (he HandleEncoder) Unmarshal(data []byte, v any) error {
 	r := bytes.NewBuffer(data)
 	h, err := decode(r)
 	target := v.(*sop.Handle)
 	*target = *h
 	return err
+}
+
+func (he HandleEncoder) UnmarshalLogicalID(data []byte) (sop.UUID, error) {
+	r := bytes.NewBuffer(data)
+	h, err := uuid.FromBytes(r.Next(16))
+	if err != nil {
+		return sop.NilUUID, err
+	}
+	return sop.UUID(h), nil
 }
 
 func encode(w *bytes.Buffer, h *sop.Handle) (int, error) {

--- a/encoding/handle.go
+++ b/encoding/handle.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SharedCode/sop"
 )
 
-type handleEncoder struct {}
+type handleEncoder struct{}
 
 // Instantiates a Handler Marshaler.
 func NewHandleMarshaler() Marshaler {
@@ -43,11 +43,11 @@ func encode(w *bytes.Buffer, h *sop.Handle) (int, error) {
 	}
 	w.Write([]byte{b})
 
-    var dummy4 [4]byte
+	var dummy4 [4]byte
 	binary.LittleEndian.PutUint32(dummy4[:], uint32(h.Version))
 	w.Write(dummy4[:])
 
-    var dummy8 [8]byte
+	var dummy8 [8]byte
 	binary.LittleEndian.PutUint64(dummy8[:], uint64(h.WorkInProgressTimestamp))
 	w.Write(dummy8[:])
 
@@ -57,7 +57,7 @@ func encode(w *bytes.Buffer, h *sop.Handle) (int, error) {
 	}
 	w.Write([]byte{b})
 
-    return w.Len(), nil
+	return w.Len(), nil
 }
 
 func decode(r *bytes.Buffer) (*sop.Handle, error) {
@@ -93,5 +93,5 @@ func decode(r *bytes.Buffer) (*sop.Handle, error) {
 		result.IsDeleted = true
 	}
 
-    return &result, nil
+	return &result, nil
 }

--- a/fs/direct_io.go
+++ b/fs/direct_io.go
@@ -14,6 +14,7 @@ import (
 type directIO struct {
 	file *os.File
 }
+
 const (
 	blockSize = directio.BlockSize
 )
@@ -70,7 +71,7 @@ func (dio directIO) readAt(block []byte, offset int64) (int, error) {
 	return dio.file.ReadAt(block, offset)
 }
 
-func (dio directIO)lockFileRegion(readWrite bool, offset int64, length int64, timeout time.Duration,) error {
+func (dio directIO) lockFileRegion(readWrite bool, offset int64, length int64, timeout time.Duration) error {
 	if dio.file == nil {
 		return fmt.Errorf("can't lock file region, there is no opened file")
 	}
@@ -79,10 +80,10 @@ func (dio directIO)lockFileRegion(readWrite bool, offset int64, length int64, ti
 		t = syscall.F_RDLCK
 	}
 	flock := syscall.Flock_t{
-		Type:   t,
-		Start:  offset,
-		Len:    length,
-		Pid:    int32(syscall.Getpid()),
+		Type:  t,
+		Start: offset,
+		Len:   length,
+		Pid:   int32(syscall.Getpid()),
 	}
 
 	if timeout <= 0 {
@@ -106,7 +107,7 @@ func (dio directIO)lockFileRegion(readWrite bool, offset int64, length int64, ti
 	}
 }
 
-func (dio directIO)isRegionLocked(readWrite bool, offset int64, length int64) (bool, error) {
+func (dio directIO) isRegionLocked(readWrite bool, offset int64, length int64) (bool, error) {
 	if dio.file == nil {
 		return false, fmt.Errorf("can't check if region is locked, there is no opened file")
 	}
@@ -131,15 +132,15 @@ func (dio directIO)isRegionLocked(readWrite bool, offset int64, length int64) (b
 	return flock.Type != syscall.F_UNLCK, nil
 }
 
-func (dio directIO)unlockFileRegion(offset int64, length int64) error {
+func (dio directIO) unlockFileRegion(offset int64, length int64) error {
 	if dio.file == nil {
 		return fmt.Errorf("can't unlock file region, there is no opened file")
 	}
 	flock := syscall.Flock_t{
-		Type:   syscall.F_UNLCK, // Unlock
-		Start:  offset,
-		Len:    length,
-		Pid:    int32(syscall.Getpid()),
+		Type:  syscall.F_UNLCK, // Unlock
+		Start: offset,
+		Len:   length,
+		Pid:   int32(syscall.Getpid()),
 	}
 
 	return syscall.FcntlFlock(dio.file.Fd(), syscall.F_SETLK, &flock)

--- a/fs/direct_io.go
+++ b/fs/direct_io.go
@@ -8,22 +8,31 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/SharedCode/sop"
 	"github.com/ncw/directio"
 )
 
 type directIO struct {
-	file *os.File
+	file                       *os.File
+	filename                   string
+	cache                      sop.Cache
+	useCacheForFileRegionLocks bool
 }
 
 const (
-	blockSize = directio.BlockSize
+	blockSize              = directio.BlockSize
+	lockKeyPrefix          = "infs"
+	lockFileRegionDuration = time.Duration(15 * time.Minute)
 )
 
 var errBlocked = errors.New("acquiring lock is blocked by another process")
 
 // Instantiate a direct File IO object.
-func newDirectIO() *directIO {
-	return &directIO{}
+func newDirectIO(cache sop.Cache, useCacheForFileRegionLocks bool) *directIO {
+	return &directIO{
+		cache:                      cache,
+		useCacheForFileRegionLocks: useCacheForFileRegionLocks,
+	}
 }
 
 // Open the file with a given filename.
@@ -36,45 +45,52 @@ func (dio *directIO) open(filename string, flag int, permission os.FileMode) err
 		return err
 	}
 	dio.file = f
+	dio.filename = filename
 	return nil
 }
 
-func (dio directIO) isFileEmpty(filePath string) (bool, error) {
-	fileInfo, err := os.Stat(filePath)
-	if err != nil {
-		return false, err
-	}
-	return fileInfo.Size() == 0, nil
+func (dio *directIO) fileExists(filePath string) bool {
+	_, err := os.Stat(filePath)
+	return !os.IsNotExist(err)
 }
 
 // Create a buffer that is aligned to the file sector size, usable as buffer for reading file data, directly.
-func (dio directIO) createAlignedBlock() []byte {
+func (dio *directIO) createAlignedBlock() []byte {
 	return dio.createAlignedBlockOfSize(directio.BlockSize)
 }
 
 // Create a buffer that is aligned to the file sector size, usable as buffer for reading file data, directly.
-func (dio directIO) createAlignedBlockOfSize(blockSize int) []byte {
+func (dio *directIO) createAlignedBlockOfSize(blockSize int) []byte {
 	return directio.AlignedBlock(blockSize)
 }
 
-func (dio directIO) writeAt(block []byte, offset int64) (int, error) {
+func (dio *directIO) writeAt(block []byte, offset int64) (int, error) {
 	if dio.file == nil {
 		return 0, fmt.Errorf("can't write, there is no opened file")
 	}
 	return dio.file.WriteAt(block, offset)
 }
 
-func (dio directIO) readAt(block []byte, offset int64) (int, error) {
+func (dio *directIO) readAt(block []byte, offset int64) (int, error) {
 	if dio.file == nil {
 		return 0, fmt.Errorf("can't read, there is no opened file")
 	}
 	return dio.file.ReadAt(block, offset)
 }
 
-func (dio directIO) lockFileRegion(readWrite bool, offset int64, length int64, timeout time.Duration) error {
+func (dio *directIO) lockFileRegion(ctx context.Context, readWrite bool, offset int64, length int64, timeout time.Duration) error {
 	if dio.file == nil {
 		return fmt.Errorf("can't lock file region, there is no opened file")
 	}
+
+	if dio.useCacheForFileRegionLocks {
+		lk := dio.cache.CreateLockKeys(fmt.Sprintf("%s%s%v", lockKeyPrefix, dio.filename, offset))
+		if err := dio.cache.Lock(ctx, lockFileRegionDuration, lk...); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	var t int16 = syscall.F_WRLCK
 	if !readWrite {
 		t = syscall.F_RDLCK
@@ -107,10 +123,16 @@ func (dio directIO) lockFileRegion(readWrite bool, offset int64, length int64, t
 	}
 }
 
-func (dio directIO) isRegionLocked(readWrite bool, offset int64, length int64) (bool, error) {
+func (dio *directIO) isRegionLocked(ctx context.Context, readWrite bool, offset int64, length int64) (bool, error) {
 	if dio.file == nil {
 		return false, fmt.Errorf("can't check if region is locked, there is no opened file")
 	}
+
+	if dio.useCacheForFileRegionLocks {
+		lk := dio.cache.FormatLockKey(fmt.Sprintf("%s%s%v", lockKeyPrefix, dio.filename, offset))
+		return dio.cache.IsLockedByOthers(ctx, lk)
+	}
+
 	var t int16 = syscall.F_WRLCK
 	if !readWrite {
 		t = syscall.F_RDLCK
@@ -132,10 +154,19 @@ func (dio directIO) isRegionLocked(readWrite bool, offset int64, length int64) (
 	return flock.Type != syscall.F_UNLCK, nil
 }
 
-func (dio directIO) unlockFileRegion(offset int64, length int64) error {
+func (dio *directIO) unlockFileRegion(ctx context.Context, offset int64, length int64) error {
 	if dio.file == nil {
 		return fmt.Errorf("can't unlock file region, there is no opened file")
 	}
+
+	if dio.useCacheForFileRegionLocks {
+		lk := dio.cache.CreateLockKeys(fmt.Sprintf("%s%s%v", lockKeyPrefix, dio.filename, offset))
+		if err := dio.cache.Unlock(ctx, lk...); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	flock := syscall.Flock_t{
 		Type:  syscall.F_UNLCK, // Unlock
 		Start: offset,

--- a/fs/direct_io.go
+++ b/fs/direct_io.go
@@ -15,7 +15,6 @@ import (
 type directIO struct {
 	file     *os.File
 	filename string
-	cache    sop.Cache
 }
 
 const (
@@ -26,9 +25,7 @@ var errBlocked = errors.New("acquiring lock is blocked by another process")
 
 // Instantiate a direct File IO object.
 func newDirectIO(cache sop.Cache) *directIO {
-	return &directIO{
-		cache: cache,
-	}
+	return &directIO{}
 }
 
 // Open the file with a given filename.

--- a/fs/direct_io.go
+++ b/fs/direct_io.go
@@ -38,6 +38,14 @@ func (dio *directIO) open(filename string, flag int, permission os.FileMode) err
 	return nil
 }
 
+func (dio directIO) isFileEmpty(filePath string) (bool, error) {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return false, err
+	}
+	return fileInfo.Size() == 0, nil
+}
+
 // Create a buffer that is aligned to the file sector size, usable as buffer for reading file data, directly.
 func (dio directIO) createAlignedBlock() []byte {
 	return dio.createAlignedBlockOfSize(directio.BlockSize)

--- a/fs/hashmap.go
+++ b/fs/hashmap.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -11,13 +12,7 @@ import (
 
 /*
 	Hashmap on disk manages registry on file. Each Handle record is persisted to a block and the address of this block is determined using
-	"modulo hash". Each block can store up to 66 Handles with the last 4 bytes optionally containing a file offset to the "extended blocks"
-	location beyond the file segment. Extended blocks' location is an area of the file beyond the regular border of the file segment. This
-	area is allocated half of the file segment.
-
-	To give illustration, for example, if the computed file segment is 1GB, the total will be 1.5GB including the extended location. This gives
-	some hash mod number to have a "linked list" of allocated blocks. The extended area was designed to accommodate "module hash collision" edge cases.
-	This should allow "denser" file segments & reduce empty or unused space.
+	"modulo hash" operator. Each block can store up to 66 Handle "records". A registry can span across one or more segment files.
 */
 
 type hashmap struct {
@@ -25,14 +20,16 @@ type hashmap struct {
 	replicationTracker *replicationTracker
 	readWrite          bool
 	// File handles of all known (traversed & opened) data segment file of the hash map.
-	fileHandles map[string]directIO
+	fileHandles                map[string]*directIO
+	cache                      sop.Cache
+	useCacheForFileRegionLocks bool
 }
 
 // File reqion details is a response struct of 'findAndLock' function. It puts together
 // details about discovered (file &) location, i.e. - file offset, of a given UUID & its current record's
 // value (unmarshalled to a Handle) read from the file.
 type fileRegionDetails struct {
-	dio    directIO
+	dio    *directIO
 	offset int64
 	handle sop.Handle
 }
@@ -41,36 +38,39 @@ const (
 	fullPermission        = 0644
 	handlesPerBlock       = 66
 	lockFileRegionTimeout = time.Duration(5 * time.Minute)
+	// Growing the file needs more time to complete.
+	lockPreallocateFileTimeout = time.Duration(25 * time.Minute)
+	registryFileIOLockKey      = "infs_reg"
 )
 
 type HashModValueType int
 
 const (
-	MinimumModValue   = 100000 // 100k, should generate 400MB file segment, 600MB total
-	SuperTinyModValue = 125000 // 125k, should generate 500MB file segment, 750MB total
-	TinyModValue      = 200000 // 200k, should generate 800MB file segment, 1.2GB total
-	DefaultModValue   = TinyModValue
-	SmallModValue     = 250000  // 250k, should generate 1GB file segment, 1.5GB total
-	MediumModValue    = 300000  // 300k, should generate 1.2GB file segment, 1.8GB total
-	LargeModValue     = 500000  // 500k, 2GB file segment, 3GB total
-	XLModValue        = 750000  // 750k, 3GB file segment, 4.5GB total
-	DoubleXLModValue  = 1000000 // 1m, 4GB file segment, 6GB total
+	MinimumModValue   = 100000  // 100k, should generate 400MB file segment
+	SuperTinyModValue = 125000  // 125k, should generate 500MB file segment
+	TinyModValue      = 200000  // 200k, should generate 800MB file segment
+	SmallModValue     = 250000  // 250k, should generate 1GB file segment
+	MediumModValue    = 350000  // 350k, should generate 1.4GB file segment
+	LargeModValue     = 500000  // 500k, 2GB file segment
+	XLModValue        = 750000  // 750k, 3GB file segment
+	XXLModValue       = 1000000 // 1m, 4GB file segment
 )
 
 // Hashmap constructor, hashModValue can't be negative nor beyond 10mil otherwise it will be reset to 250k.
-func newHashmap(readWrite bool, hashModValue HashModValueType, replicationTracker *replicationTracker) *hashmap {
+func newHashmap(readWrite bool, hashModValue HashModValueType, replicationTracker *replicationTracker, cache sop.Cache, useCacheForFileRegionLocks bool) *hashmap {
 	return &hashmap{
-		hashModValue:       hashModValue,
-		replicationTracker: replicationTracker,
-		readWrite:          readWrite,
-		fileHandles:        make(map[string]directIO, 5),
+		hashModValue:               hashModValue,
+		replicationTracker:         replicationTracker,
+		readWrite:                  readWrite,
+		fileHandles:                make(map[string]*directIO, 5),
+		cache:                      cache,
+		useCacheForFileRegionLocks: useCacheForFileRegionLocks,
 	}
 }
 
-// Total file size is hash mod value X 4096 X 3. We pre-allocate the file to have three segments.
-// That is up to three blocks to accommodate collisions. A block can contain 66 handles, that means
-// 66 * 3 = 198 slots to accomodate collisions before triggering to add a new file.
-func (hm *hashmap) getTotalFileSize() int64 {
+// Maximum file size is segment file size (hash mod value X 4096) + (.5 of segment file size).
+// Upon reaching this max file size, hashmap should create a new file on succeeding block insert.
+func (hm *hashmap) getMaxFileSize() int64 {
 	smfs := hm.getSegmentFileSize()
 	return smfs + (smfs / 2)
 }
@@ -79,13 +79,33 @@ func (hm *hashmap) getSegmentFileSize() int64 {
 	return int64(hm.hashModValue) * blockSize
 }
 
+func (hm *hashmap) getBlockOffsetAndHandleInBlockOffset(id sop.UUID) (int64, int64) {
+	// Split UUID into high & low int64 parts.
+	bytes := id[:]
+
+	var high int64
+	for i := 0; i < 8; i++ {
+		high = high<<8 | int64(bytes[i])
+	}
+
+	var low int64
+	for i := 8; i < 16; i++ {
+		low = low<<8 | int64(bytes[i])
+	}
+
+	blockOffset := high % int64(hm.hashModValue)
+	offsetInBlock := low % handlesPerBlock
+
+	return blockOffset * blockSize, offsetInBlock * sop.HandleSizeInBytes
+}
+
 // Iterate through the entire set of hashmap (bucket) files, from 1 to the last bucket file.
-// Each bucket file is allocated about 250,000 "sector blocks" and in total, contains ~16,650,000
-// addressable virtual ID (handle). Typically, there should be only one bucket file as this file
+// Each bucket file is allocated about 250,000 "sector blocks"(configurable) and in total, contains ~16,650,000
+// addressable virtual IDs (handles). Typically, there should be only one bucket file as this file
 // with the default numbers shown, can be used to hold 825 million items of the B-Tree, given a
 // slot length of 500.
-func (hm *hashmap) findAndLock(forWriting bool, filename string, id sop.UUID) (fileRegionDetails, error) {
-	var dio directIO
+func (hm *hashmap) findAndLock(ctx context.Context, forWriting bool, filename string, id sop.UUID) (fileRegionDetails, error) {
+	var dio *directIO
 	var result fileRegionDetails
 	var createdNewFile bool
 
@@ -95,60 +115,101 @@ func (hm *hashmap) findAndLock(forWriting bool, filename string, id sop.UUID) (f
 		if f, ok := hm.fileHandles[fn]; ok {
 			dio = f
 		} else {
-			dio = *newDirectIO()
+			dio = newDirectIO(hm.cache, hm.useCacheForFileRegionLocks)
 			flag := os.O_CREATE | os.O_RDWR
 			if !hm.readWrite {
 				flag = os.O_RDONLY
 			}
-			fileEmpty, err := dio.isFileEmpty(fn)
-			if err != nil {
-				return result, err
-			}
-			if err := dio.open(fn, flag, fullPermission); err != nil {
-				return result, err
-			}
-			// Pre-allocate if new file.
-			if forWriting && fileEmpty {
-				if err := dio.file.Truncate(hm.getTotalFileSize()); err != nil {
+			fileExists := dio.fileExists(fn)
+			if !fileExists {
+				if !forWriting {
+					return result, fmt.Errorf("can't read a registry file(%s) that is missing", fn)
+				}
+
+				lk := hm.cache.CreateLockKeys(registryFileIOLockKey)
+				if err := hm.cache.Lock(ctx, lockPreallocateFileTimeout, lk...); err != nil {
 					return result, err
 				}
-				createdNewFile = true
+
+				if err := dio.open(fn, flag, fullPermission); err != nil {
+					hm.cache.Unlock(ctx, lk...)
+					return result, err
+				}
+
+				// Handle properly a newly created file.
+				// Pre-allocate entire segment if new file. Should we Redis lock to allow only one process to win Truncate?
+				// NFS should be able to allow one and others to fail, error out.
+				if err := dio.file.Truncate(hm.getSegmentFileSize()); err != nil {
+					hm.cache.Unlock(ctx, lk...)
+					return result, err
+				}
+				hm.cache.Unlock(ctx, lk...)
+
+				hm.fileHandles[fn] = dio
+				// New file, 'prepare to let caller write the new handle to this block's first slot.
+				blockOffset, handleInBlockOffset := hm.getBlockOffsetAndHandleInBlockOffset(id)
+				result.offset = blockOffset + handleInBlockOffset
+				if ok, err := dio.isRegionLocked(ctx, forWriting, result.offset, sop.HandleSizeInBytes); ok || err != nil {
+					if ok {
+						err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %v as it is locked", forWriting, result.offset)
+					}
+					return result, err
+				}
+				if err := dio.lockFileRegion(ctx, forWriting, result.offset, sop.HandleSizeInBytes, lockFileRegionTimeout); err != nil {
+					return result, err
+				}
+				result.dio = dio
+				return result, nil
 			}
 			hm.fileHandles[fn] = dio
 		}
 
-		// Split UUID into high & low int64 parts.
-		bytes := id[:]
-
-		var high int64
-		for i := 0; i < 8; i++ {
-			high = high<<8 | int64(bytes[i])
-		}
-		var low int64
-		for i := 8; i < 16; i++ {
-			low = low<<8 | int64(bytes[i])
-		}
-
-		blockOffset := high % int64(hm.hashModValue)
-		offsetInBlock := low % handlesPerBlock
-
-		// Compute bucket file offset.
-		offset := (blockOffset * blockSize) + (offsetInBlock * sop.HandleSizeInBytes)
+		// Read entire block for the ID hash mod, deserialize each Handle and check if anyone matches the one we are trying to find.
+		// For add use-case with "collision", when there is no more slot on the block, we need to automatically create a new segment file.
 		ba := dio.createAlignedBlock()
+		blockOffset, handleInBlockOffset := hm.getBlockOffsetAndHandleInBlockOffset(id)
 
-		n, err := dio.readAt(ba, offset)
+		n, err := dio.readAt(ba, blockOffset)
 		if err != nil {
 			return result, err
 		}
 		if n != len(ba) {
-			return result, fmt.Errorf("only able to read partially (%d bytes) the Handle record at offset %v", n, offset)
+			return result, fmt.Errorf("only able to read partially (%d bytes) the block record at offset %v", n, blockOffset)
 		}
 
-		// Handle empty block.
-		if isZeroData(ba) {
-			result.offset = offset
-			result.dio = dio
-			return result, nil
+		// Unmarshal and check if this is the Handler record we are looking for.
+		m := encoding.NewHandleMarshaler()
+		bao := 0
+		for i := 0; i < handlesPerBlock; i++ {
+			var h sop.Handle
+			hbuf := ba[bao : bao+sop.HandleSizeInBytes]
+
+			// Handle properly a zero block.
+			if isZeroData(hbuf) {
+				if !forWriting {
+					return result, fmt.Errorf("can't lock for reading, handle record at %v is zero block", blockOffset+int64(bao))
+				}
+
+				// Try to lock (for writing) the block.
+				if ok, err := dio.isRegionLocked(ctx, forWriting, blockOffset+int64(bao), sop.HandleSizeInBytes); ok || err != nil {
+					if ok {
+						err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %v as it is locked", forWriting, blockOffset+int64(bao))
+					}
+					return result, err
+				}
+				if err := dio.lockFileRegion(forWriting, blockOffset+int64(bao), sop.HandleSizeInBytes, lockFileRegionTimeout); err != nil {
+					return result, err
+				}
+				result.dio = dio
+				result.offset = blockOffset + +int64(bao)
+				return result, nil
+
+			}
+			if err := m.Unmarshal(hbuf, &h); err != nil {
+				return result, err
+			}
+
+			bao += sop.HandleSizeInBytes
 		}
 
 		// Unmarshal and check if this is the Handler record we are looking for.
@@ -160,13 +221,13 @@ func (hm *hashmap) findAndLock(forWriting bool, filename string, id sop.UUID) (f
 		if h.LogicalID == id {
 			result.offset = offset
 			result.handle = h
-			if ok, err := dio.isRegionLocked(forWriting, offset, sop.HandleSizeInBytes); ok || err != nil {
+			if ok, err := dio.isRegionLocked(ctx, forWriting, offset, sop.HandleSizeInBytes); ok || err != nil {
 				if ok {
-					err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %d as it is locked", forWriting, offset)
+					err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %v as it is locked", forWriting, offset)
 				}
 				return result, err
 			}
-			if err := dio.lockFileRegion(forWriting, offset, sop.HandleSizeInBytes, lockFileRegionTimeout); err != nil {
+			if err := dio.lockFileRegion(ctx, forWriting, offset, sop.HandleSizeInBytes, lockFileRegionTimeout); err != nil {
 				return result, err
 			}
 			result.dio = dio
@@ -185,15 +246,15 @@ func (hm *hashmap) findAndLock(forWriting bool, filename string, id sop.UUID) (f
 
 // Lock file region(s) that a set of UUIDs correlate to and return these region(s)' offsett/Handle if in case
 // useful to the caller.
-func (hm *hashmap) lockFileRegion(forWriting bool, filename string, ids ...sop.UUID) ([]fileRegionDetails, error) {
+func (hm *hashmap) lockFileRegion(ctx context.Context, forWriting bool, filename string, ids ...sop.UUID) ([]fileRegionDetails, error) {
 	undo := func(items []fileRegionDetails) {
 		for _, item := range items {
-			item.dio.unlockFileRegion(item.offset, sop.HandleSizeInBytes)
+			item.dio.unlockFileRegion(ctx, item.offset, sop.HandleSizeInBytes)
 		}
 	}
 	completedItems := make([]fileRegionDetails, 0, len(ids))
 	for _, id := range ids {
-		frd, err := hm.findAndLock(hm.readWrite, filename, id)
+		frd, err := hm.findAndLock(ctx, hm.readWrite, filename, id)
 		if err != nil {
 			undo(completedItems)
 			return nil, err
@@ -204,11 +265,12 @@ func (hm *hashmap) lockFileRegion(forWriting bool, filename string, ids ...sop.U
 }
 
 // Unlock file region(s).
-func (hm *hashmap) unlockFileRegion(fileRegionDetails ...fileRegionDetails) error {
+func (hm *hashmap) unlockFileRegion(ctx context.Context, fileRegionDetails ...fileRegionDetails) error {
+
 	return nil
 }
 
-func (hm *hashmap) updateFileRegion(fileRegionDetails ...fileRegionDetails) error {
+func (hm *hashmap) updateFileRegion(ctx context.Context, fileRegionDetails ...fileRegionDetails) error {
 	return nil
 }
 

--- a/fs/hashmap_file_region.go
+++ b/fs/hashmap_file_region.go
@@ -1,0 +1,59 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/SharedCode/sop"
+)
+
+func (hm *hashmap) formatLockKey(filename string, offset int64) string {
+	return hm.cache.FormatLockKey(fmt.Sprintf("%s%s%v", lockFileRegionKeyPrefix, filename, offset))
+}
+
+func (hm *hashmap) lockFoundFileRegion(ctx context.Context, fileRegionDetails ...*fileRegionDetails) error {
+	for _, frd := range fileRegionDetails {
+		if hm.useCacheForFileRegionLocks {
+			frd.lockKey = hm.cache.CreateLockKeys(hm.formatLockKey(frd.dio.filename, frd.offset))[0]
+			if err := hm.cache.Lock(ctx, lockFileRegionDuration, frd.lockKey); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := frd.dio.lockFileRegion(ctx, hm.readWrite, frd.offset, sop.HandleSizeInBytes, lockFileRegionTimeout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Unlock file region(s).
+func (hm *hashmap) unlockFileRegion(ctx context.Context, fileRegionDetails ...fileRegionDetails) error {
+	for _, frd := range fileRegionDetails {
+		if hm.useCacheForFileRegionLocks {
+			if err := hm.cache.Unlock(ctx, frd.lockKey); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := frd.dio.unlockFileRegion(ctx, frd.offset, sop.HandleSizeInBytes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (hm *hashmap) isRegionLocked(ctx context.Context, dio *directIO, offset int64) (bool, error) {
+	if hm.useCacheForFileRegionLocks {
+		lkn := hm.formatLockKey(dio.filename, offset)
+		return hm.cache.IsLockedByOthers(ctx, lkn)
+	}
+	return dio.isRegionLocked(ctx, hm.readWrite, offset, sop.HandleSizeInBytes)
+}
+
+func (hm *hashmap) updateFileRegion(ctx context.Context, fileRegionDetails ...fileRegionDetails) error {
+	// for _, frd := range fileRegionDetails {
+	// 	frd.dio.writeAt()
+	// }
+	return nil
+}

--- a/fs/hashmap_test.go
+++ b/fs/hashmap_test.go
@@ -10,7 +10,6 @@ import (
 
 const (
 	hashModValue = 500000
-	blockItemCount = 66
 )
 // This hashing algorithm tend to be denser as more data segment file is used. At two, it can fill around 66% avg.
 // At one segment file, it fills up around 55%. SOP b-tree (w/ load distribution)
@@ -18,7 +17,7 @@ const (
 // At 4, it should be able to fill 75%.
 
 func TestHashModDistribution(t *testing.T) {
-	hashTable1 := make([][blockItemCount]sop.UUID, hashModValue)
+	hashTable1 := make([][handlesPerBlock]sop.UUID, hashModValue)
 	//hashTable2 := make([][66]sop.UUID, hashModValue)
 	collisionCount := 0
 	fmt.Printf("Start %v", time.Now())
@@ -37,7 +36,7 @@ func TestHashModDistribution(t *testing.T) {
 		}
 
 		bucket := high % hashModValue 
-		bucketOffset := low%blockItemCount
+		bucketOffset := low%handlesPerBlock
 
 		if hashTable1[bucket][bucketOffset] != sop.NilUUID {
 			foundASlot := false
@@ -76,7 +75,7 @@ func TestHashModDistribution(t *testing.T) {
 	notFoundCount := 0
 
 	for i := 0; i < len(hashTable1); i++ {
-		for ii := 0; ii < blockItemCount; ii++ {
+		for ii := 0; ii < handlesPerBlock; ii++ {
 			if hashTable1[i][ii] == sop.NilUUID {
 				notUsedSlot++
 				continue
@@ -102,7 +101,7 @@ func TestHashModDistribution(t *testing.T) {
 	fmt.Printf("End %v", time.Now())
 }
 
-func findItem(ht [][blockItemCount]sop.UUID, id sop.UUID) bool {
+func findItem(ht [][handlesPerBlock]sop.UUID, id sop.UUID) bool {
 	bytes := id[:]
 	var high uint64
 	for i := 0; i < 8; i++ {
@@ -114,12 +113,12 @@ func findItem(ht [][blockItemCount]sop.UUID, id sop.UUID) bool {
 	}
 
 	bucket := high % hashModValue 
-	bucketOffset := low%blockItemCount
+	bucketOffset := low%handlesPerBlock
 
 	if ht[bucket][bucketOffset] == id {
 		return true
 	}
-	for i := 0; i < blockItemCount; i++ {
+	for i := 0; i < handlesPerBlock; i++ {
 		if ht[bucket][i] == id {
 			return true
 		}

--- a/fs/hashmap_test.go
+++ b/fs/hashmap_test.go
@@ -9,19 +9,20 @@ import (
 )
 
 const (
-	hashModValue = 500000
+	hashModValue = DefaultModValue
 )
+
 // This hashing algorithm tend to be denser as more data segment file is used. At two, it can fill around 66% avg.
 // At one segment file, it fills up around 55%. SOP b-tree (w/ load distribution)
 // can fill up around 55%-67%, so, this is at par. BUT better because each Handle is a very small sized data (record).
 // At 4, it should be able to fill 75%.
 
 func TestHashModDistribution(t *testing.T) {
-	hashTable1 := make([][handlesPerBlock]sop.UUID, hashModValue)
+	hashTable1 := make([][handlesPerBlock * 3]sop.UUID, hashModValue)
 	//hashTable2 := make([][66]sop.UUID, hashModValue)
 	collisionCount := 0
 	fmt.Printf("Start %v", time.Now())
-	for i := 0; i < 23000000; i++ {
+	for i := 0; i < (hashModValue*handlesPerBlock*2)+2000000; i++ {
 		// Split UUID into high & low int64 parts.
 		id := sop.NewUUID()
 		bytes := id[:]
@@ -35,12 +36,12 @@ func TestHashModDistribution(t *testing.T) {
 			low = low<<8 | uint64(bytes[i])
 		}
 
-		bucket := high % hashModValue 
-		bucketOffset := low%handlesPerBlock
+		bucket := high % hashModValue
+		bucketOffset := low % uint64(len(hashTable1[0]))
 
 		if hashTable1[bucket][bucketOffset] != sop.NilUUID {
 			foundASlot := false
-			for ii := 0; ii < 66; ii++ {
+			for ii := 0; ii < len(hashTable1[0]); ii++ {
 				if hashTable1[bucket][ii] == sop.NilUUID {
 					hashTable1[bucket][ii] = id
 					foundASlot = true
@@ -75,7 +76,7 @@ func TestHashModDistribution(t *testing.T) {
 	notFoundCount := 0
 
 	for i := 0; i < len(hashTable1); i++ {
-		for ii := 0; ii < handlesPerBlock; ii++ {
+		for ii := 0; ii < len(hashTable1[0]); ii++ {
 			if hashTable1[i][ii] == sop.NilUUID {
 				notUsedSlot++
 				continue
@@ -101,7 +102,7 @@ func TestHashModDistribution(t *testing.T) {
 	fmt.Printf("End %v", time.Now())
 }
 
-func findItem(ht [][handlesPerBlock]sop.UUID, id sop.UUID) bool {
+func findItem(ht [][handlesPerBlock * 3]sop.UUID, id sop.UUID) bool {
 	bytes := id[:]
 	var high uint64
 	for i := 0; i < 8; i++ {
@@ -112,13 +113,13 @@ func findItem(ht [][handlesPerBlock]sop.UUID, id sop.UUID) bool {
 		low = low<<8 | uint64(bytes[i])
 	}
 
-	bucket := high % hashModValue 
-	bucketOffset := low%handlesPerBlock
+	bucket := high % hashModValue
+	bucketOffset := low % uint64(len(ht[0]))
 
 	if ht[bucket][bucketOffset] == id {
 		return true
 	}
-	for i := 0; i < handlesPerBlock; i++ {
+	for i := 0; i < len(ht[0]); i++ {
 		if ht[bucket][i] == id {
 			return true
 		}

--- a/fs/hashmap_test.go
+++ b/fs/hashmap_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	hashModValue = DefaultModValue
+	hashModValue = SmallModValue
 )
 
 // This hashing algorithm tend to be denser as more data segment file is used. At two, it can fill around 66% avg.

--- a/fs/registry.go
+++ b/fs/registry.go
@@ -28,12 +28,9 @@ const (
 )
 
 // NewRegistry manages the Handle in memory for mocking.
-func NewRegistry(rt *replicationTracker, cache sop.Cache, readWrite bool, hashModValue int) Registry {
-	if hashModValue <= 0 {
-		hashModValue = 250000
-	}
+func NewRegistry(readWrite bool, rt *replicationTracker, cache sop.Cache, hashModValue HashModValueType) Registry {
 	return &registryOnDisk{
-		hashmap:            newRegistryMap(hashModValue, rt, readWrite),
+		hashmap:            newRegistryMap(readWrite, hashModValue, rt),
 		replicationTracker: rt,
 		cache:              cache,
 	}

--- a/fs/registry_map.go
+++ b/fs/registry_map.go
@@ -78,7 +78,7 @@ func (rm registryMap) set(allOrNothing bool, areItemsLocked func() error, items 
 	return nil
 }
 
-func (rm registryMap) get(keys ...sop.Tuple[string, []sop.UUID]) ([]sop.Tuple[string, []sop.Handle], error) {	
+func (rm registryMap) get(keys ...sop.Tuple[string, []sop.UUID]) ([]sop.Tuple[string, []sop.Handle], error) {
 	result := make([]sop.Tuple[string, []sop.Handle], len(keys), 0)
 	for _, k := range keys {
 		frds, err := rm.hashmap.lockFileRegion(false, k.First, k.Second...)
@@ -96,7 +96,7 @@ func (rm registryMap) get(keys ...sop.Tuple[string, []sop.UUID]) ([]sop.Tuple[st
 		}
 
 		result = append(result, sop.Tuple[string, []sop.Handle]{
-			First: k.First,
+			First:  k.First,
 			Second: handles,
 		})
 	}

--- a/fs/registry_map.go
+++ b/fs/registry_map.go
@@ -8,9 +8,9 @@ type registryMap struct {
 	hashmap *hashmap
 }
 
-func newRegistryMap(hashModValue int, replicationTracker *replicationTracker, readWrite bool) *registryMap {
+func newRegistryMap(readWrite bool, hashModValue HashModValueType, replicationTracker *replicationTracker) *registryMap {
 	return &registryMap{
-		hashmap: newHashmap(hashModValue, replicationTracker, readWrite),
+		hashmap: newHashmap(readWrite, hashModValue, replicationTracker),
 	}
 }
 
@@ -79,7 +79,6 @@ func (rm registryMap) set(allOrNothing bool, areItemsLocked func() error, items 
 }
 
 func (rm registryMap) get(keys ...sop.Tuple[string, []sop.UUID]) ([]sop.Tuple[string, []sop.Handle], error) {	
-	// Individually manage/update the file area occupied by the handle so we don't create "lock pressure".
 	result := make([]sop.Tuple[string, []sop.Handle], len(keys), 0)
 	for _, k := range keys {
 		frds, err := rm.hashmap.lockFileRegion(false, k.First, k.Second...)

--- a/fs/store_repository.go
+++ b/fs/store_repository.go
@@ -23,7 +23,7 @@ type storeRepository struct {
 }
 
 const (
-	lockStoreListKey      = "sr_infs"
+	lockStoreListKey      = "infs_sr"
 	lockStoreListDuration = time.Duration(10 * time.Minute)
 	storeListFilename     = "storelist.txt"
 	storeInfoFilename     = "storeinfo.txt"

--- a/in_red_fs/transaction.go
+++ b/in_red_fs/transaction.go
@@ -11,8 +11,8 @@ import (
 )
 
 // NewTransaction is a convenience function to create an enduser facing transaction object that wraps the two phase commit transaction.
-func NewTransaction(storesBaseFolder string, mode sop.TransactionMode, maxTime time.Duration, registryHashModValue fs.HashModValueType) (sop.Transaction, error) {
-	twoPT, err := NewTwoPhaseCommitTransaction(storesBaseFolder, mode, maxTime, nil, registryHashModValue)
+func NewTransaction(storesBaseFolder string, mode sop.TransactionMode, maxTime time.Duration, registryHashModValue fs.HashModValueType, cache sop.Cache, useCacheForFileRegionLocks bool) (sop.Transaction, error) {
+	twoPT, err := NewTwoPhaseCommitTransaction(storesBaseFolder, mode, maxTime, registryHashModValue, cache, useCacheForFileRegionLocks)
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +21,7 @@ func NewTransaction(storesBaseFolder string, mode sop.TransactionMode, maxTime t
 
 // NewTwoPhaseCommitTransaction will instantiate a transaction object for writing(forWriting=true)
 // or for reading(forWriting=false). Pass in -1 on maxTime to default to 15 minutes of max "commit" duration.
-func NewTwoPhaseCommitTransaction(storesBaseFolder string, mode sop.TransactionMode, maxTime time.Duration, cache sop.Cache, registryHashModValue fs.HashModValueType) (sop.TwoPhaseCommitTransaction, error) {
+func NewTwoPhaseCommitTransaction(storesBaseFolder string, mode sop.TransactionMode, maxTime time.Duration, registryHashModValue fs.HashModValueType, cache sop.Cache, useCacheForFileRegionLocks bool) (sop.TwoPhaseCommitTransaction, error) {
 	if !IsInitialized() {
 		return nil, fmt.Errorf("Redis was not initialized")
 	}
@@ -33,12 +33,12 @@ func NewTwoPhaseCommitTransaction(storesBaseFolder string, mode sop.TransactionM
 	if err != nil {
 		return nil, err
 	}
-	return common.NewTwoPhaseCommitTransaction(mode, maxTime, true, fs.NewBlobStore(nil), sr, fs.NewRegistry(mode == sop.ForWriting, replicationTracker, cache, registryHashModValue), cache, fs.NewTransactionLog())
+	return common.NewTwoPhaseCommitTransaction(mode, maxTime, true, fs.NewBlobStore(nil), sr, fs.NewRegistry(mode == sop.ForWriting, registryHashModValue, replicationTracker, cache, useCacheForFileRegionLocks), cache, fs.NewTransactionLog())
 }
 
 // Create a transaction that supports replication, via custom SOP replicaiton on StoreRepository & Registry and then Erasure Coding on Blob Store.
-func NewTransactionWithReplication(storesBaseFolders []string, mode sop.TransactionMode, maxTime time.Duration, cache sop.Cache, registryHashModValue fs.HashModValueType, erasureConfig map[string]fs.ErasureCodingConfig) (sop.Transaction, error) {
-	twoPT, err := NewTwoPhaseCommitTransactionWithReplication(storesBaseFolders, mode, maxTime, cache, registryHashModValue, erasureConfig)
+func NewTransactionWithReplication(storesBaseFolders []string, mode sop.TransactionMode, maxTime time.Duration, registryHashModValue fs.HashModValueType, erasureConfig map[string]fs.ErasureCodingConfig, cache sop.Cache, useCacheForFileRegionLocks bool) (sop.Transaction, error) {
+	twoPT, err := NewTwoPhaseCommitTransactionWithReplication(storesBaseFolders, mode, maxTime, registryHashModValue, erasureConfig, cache, useCacheForFileRegionLocks)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func NewTransactionWithReplication(storesBaseFolders []string, mode sop.Transact
 
 // Create a transaction that supports replication, via custom SOP replicaiton on StoreRepository & Registry and then Erasure Coding on Blob Store.
 // Returns sop.TwoPhaseCommitTransaction type useful for integration with your custom application transaction where code would like to get access to SOP's two phase commit transaction API.
-func NewTwoPhaseCommitTransactionWithReplication(storesBaseFolders []string, mode sop.TransactionMode, maxTime time.Duration, cache sop.Cache, registryHashModValue fs.HashModValueType, erasureConfig map[string]fs.ErasureCodingConfig) (sop.TwoPhaseCommitTransaction, error) {
+func NewTwoPhaseCommitTransactionWithReplication(storesBaseFolders []string, mode sop.TransactionMode, maxTime time.Duration, registryHashModValue fs.HashModValueType, erasureConfig map[string]fs.ErasureCodingConfig, cache sop.Cache, useCacheForFileRegionLocks bool) (sop.TwoPhaseCommitTransaction, error) {
 	if erasureConfig == nil {
 		erasureConfig = fs.GetGlobalErasureConfig()
 		if erasureConfig == nil {
@@ -72,5 +72,5 @@ func NewTwoPhaseCommitTransactionWithReplication(storesBaseFolders []string, mod
 	if err != nil {
 		return nil, err
 	}
-	return common.NewTwoPhaseCommitTransaction(mode, maxTime, true, bs, sr, fs.NewRegistry(mode == sop.ForWriting, replicationTracker, cache, registryHashModValue), cache, fs.NewTransactionLog())
+	return common.NewTwoPhaseCommitTransaction(mode, maxTime, true, bs, sr, fs.NewRegistry(mode == sop.ForWriting, registryHashModValue, replicationTracker, cache, useCacheForFileRegionLocks), cache, fs.NewTransactionLog())
 }

--- a/redis/locker.go
+++ b/redis/locker.go
@@ -57,6 +57,36 @@ func (c client) Lock(ctx context.Context, duration time.Duration, lockKeys ...*s
 	return nil
 }
 
+// Lock (shared mode) a set of keys.
+func (c client) SharedLock(ctx context.Context, duration time.Duration, lockKeys ...*sop.LockKey) error {
+	for _, lk := range lockKeys {
+		readItem, err := c.Get(ctx, lk.Key)
+		if err != nil {
+			if !c.KeyNotFound(err) {
+				return err
+			}
+			// Item does not exist, upsert it.
+			if err := c.Set(ctx, lk.Key, lk.LockID.String(), duration); err != nil {
+				return err
+			}
+			// Use a 2nd "get" to ensure we "won" the lock attempt & fail if not.
+			if readItem2, err := c.Get(ctx, lk.Key); err != nil {
+				return err
+			} else if readItem2 == lk.LockID.String() {
+				// We got the item locked, ensure we can unlock it.
+				lk.IsLockOwner = true
+			}
+			continue
+		}
+		// Item found in Redis.
+		if readItem == lk.LockID.String() {
+			lk.IsLockOwner = true
+		}
+	}
+	// Successfully locked.
+	return nil
+}
+
 // Returns true if lockKeys have claimed lock equivalent.
 func (c client) IsLocked(ctx context.Context, lockKeys ...*sop.LockKey) error {
 	for _, lk := range lockKeys {

--- a/redis/locker.go
+++ b/redis/locker.go
@@ -77,6 +77,21 @@ func (c client) IsLocked(ctx context.Context, lockKeys ...*sop.LockKey) error {
 	return nil
 }
 
+// Returns true if lockKeyNames are all locked.
+func (c client) IsLockedByOthers(ctx context.Context, lockKeyNames ...string) (bool, error) {
+	for _, lkn := range lockKeyNames {
+		_, err := c.Get(ctx, lkn)
+		if err != nil {
+			if c.KeyNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		// Item found in Redis means other process has a lock on it.
+	}
+	return true, nil
+}
+
 // Unlock a set of keys.
 func (c client) Unlock(ctx context.Context, lockKeys ...*sop.LockKey) error {
 	var lastErr error

--- a/repository.go
+++ b/repository.go
@@ -193,6 +193,9 @@ type Cache interface {
 	Lock(ctx context.Context, duration time.Duration, lockKeys ...*LockKey) error
 	// Returns whether a set of keys are all locked.
 	IsLocked(ctx context.Context, lockKeys ...*LockKey) error
+	// Returns true if a set of keys are all locked, most likely by other processes.
+	// Use-case is for checking if a certain set of keys are locked by other processes.
+	IsLockedByOthers(ctx context.Context, lockKeyNames ...string) (bool, error)
 	// Unlock a given set of keys.
 	Unlock(ctx context.Context, lockKeys ...*LockKey) error
 }


### PR DESCRIPTION
Checking in progress to master before potential battery of tests' changes for testing in_red_fs Registry & StoreRepository implementations.

* Registry hash map on disk was coded, solution is very much satisfactory. Perhaps the most low latency storage engine can be achieved, parallel IOs, minimal lock contention without losing data integrity. :)

* StoreRepository in FS will allow us to solidify the "Update" method and will benefit from "replication" in FS. Yep, when StoreRepo Update fails & transaction rolled back, there is a backup copy we can use to save the day. It seems better in "grip" how to implement a rock solid StoreRepository "update" logic, that can occur highly parallel. We want Count not to lose count, hehe.
