### PR TITLE
If CacheDuration is < 0, Redis wrapper code will not encache the item…

### DIFF
--- a/in_red_cfs/integration_tests/transaction_test.go
+++ b/in_red_cfs/integration_tests/transaction_test.go
@@ -209,7 +209,8 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 	t1, _ := in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 	t1.Begin()
 	so := sop.NewStoreCacheConfig(time.Duration(5*time.Minute), false)
-	// so.NodeCacheDuration = 0
+	// NodeCacheDuration of -1 means don't cache node.
+	so.NodeCacheDuration = -1
 	so.RegistryCacheDuration = time.Duration(10 * time.Minute)
 	b3, _ := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -47,8 +47,8 @@ func (c client) Set(ctx context.Context, key string, value string, expiration ti
 	if expiration < 0 {
 		expiration = connection.Options.GetDefaultDuration()
 	}
-	// Don't cache if zero expiration.
-	if expiration == 0 {
+	// No caching if expiration < 0.
+	if expiration < 0 {
 		return nil
 	}
 	return connection.Client.Set(ctx, key, value, expiration).Err()
@@ -80,12 +80,8 @@ func (c client) SetStruct(ctx context.Context, key string, value interface{}, ex
 	if err != nil {
 		return err
 	}
-	// SET object
+	// No caching if expiration < 0.
 	if expiration < 0 {
-		expiration = connection.Options.GetDefaultDuration()
-	}
-	// Don't cache if zero expiration.
-	if expiration == 0 {
 		return nil
 	}
 	return connection.Client.Set(ctx, key, ba, expiration).Err()

--- a/store_info.go
+++ b/store_info.go
@@ -59,7 +59,7 @@ func (scc *StoreCacheConfig) enforceMinimumRule() {
 	if scc.NodeCacheDuration == 0 && scc.IsNodeCacheTTL {
 		scc.IsNodeCacheTTL = false
 	}
-	// scc.NodeCacheDuration can be 0, meaning no caching.
+	// scc.NodeCacheDuration can be -1, meaning no caching.
 	if scc.RegistryCacheDuration > 0 && scc.RegistryCacheDuration < minCacheDuration {
 		scc.RegistryCacheDuration = time.Duration(10 * time.Minute)
 	}

--- a/store_options.go
+++ b/store_options.go
@@ -64,7 +64,7 @@ var defaultCacheConfig StoreCacheConfig = StoreCacheConfig{
 	RegistryCacheDuration:  time.Duration(15 * time.Minute),
 	ValueDataCacheDuration: time.Duration(10 * time.Minute),
 	// Nodes are bigger data, thus, we want them minimally cached. You can set to 0 if needed.
-	NodeCacheDuration:      time.Duration(5 * time.Minute),
+	NodeCacheDuration: time.Duration(5 * time.Minute),
 }
 
 // Assigns to the global default cache duration config.


### PR DESCRIPTION
…. So developer can assign -1 to NodeCacheDuration (for example) and thus, disable caching the B-Tree node blobs.