### PR TITLE
In red fs package is somewhat stable

### DIFF
--- a/fs/hashmap.go
+++ b/fs/hashmap.go
@@ -123,7 +123,7 @@ func (hm *hashmap) findAndLock(ctx context.Context, forWriting bool, filename st
 				return frd, err
 			} else {
 				flag := os.O_RDWR
-				if !forWriting {
+				if !hm.readWrite {
 					flag = os.O_RDONLY
 				}
 				if err := dio.open(fn, flag, fullPermission); err != nil {

--- a/fs/hashmap_file_region.go
+++ b/fs/hashmap_file_region.go
@@ -15,14 +15,6 @@ func (hm *hashmap) lockFoundFileRegion(ctx context.Context, fileRegionDetails ..
 	for _, frd := range fileRegionDetails {
 		if hm.useCacheForFileRegionLocks {
 			return nil
-			// frd.lockKey = hm.cache.CreateLockKeys(hm.formatLockKey(frd.dio.filename, frd.getOffset()))[0]
-			// if ok, err := hm.cache.Lock(ctx, lockFileRegionDuration, frd.lockKey); ok {
-			// 	continue
-			// } else if err == nil {
-			// 	return fmt.Errorf("can't lock file (%s) region offset %v, already locked", frd.dio.filename, frd.getOffset())
-			// } else {
-			// 	return err
-			// }
 		}
 		if err := frd.dio.lockFileRegion(ctx, frd.getOffset(), sop.HandleSizeInBytes, lockFileRegionAttemptTimeout); err != nil {
 			return err
@@ -37,12 +29,6 @@ func (hm *hashmap) unlockFileRegion(ctx context.Context, fileRegionDetails ...fi
 		return nil
 	}
 	for _, frd := range fileRegionDetails {
-		// if hm.useCacheForFileRegionLocks {
-		// 	if err := hm.cache.Unlock(ctx, frd.lockKey); err != nil {
-		// 		return err
-		// 	}
-		// 	continue
-		// }
 		if err := frd.dio.unlockFileRegion(frd.getOffset(), sop.HandleSizeInBytes); err != nil {
 			return err
 		}
@@ -53,7 +39,6 @@ func (hm *hashmap) unlockFileRegion(ctx context.Context, fileRegionDetails ...fi
 func (hm *hashmap) isRegionLocked(ctx context.Context, dio *directIO, offset int64) (bool, error) {
 	if hm.useCacheForFileRegionLocks {
 		return false, nil
-		// return hm.cache.IsLockedByOthers(ctx, hm.formatLockKey(dio.filename, offset))
 	}
 	return dio.isRegionLocked(ctx, true, offset, sop.HandleSizeInBytes)
 }

--- a/in_red_fs/integration_tests/transaction_edge_cases_test.go
+++ b/in_red_fs/integration_tests/transaction_edge_cases_test.go
@@ -637,7 +637,6 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 		IsUnique:                 true,
 		IsValueDataInNodeSegment: true,
 		LeafLoadBalancing:        true,
-		Description:              "",
 	}, t1, nil)
 	// Add a single item so we persist "root node".
 	b3.Add(ctx, 1, "I am the value with 500 key.")
@@ -654,11 +653,7 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 		b3.Add(ctx2, 50, "I am the value with 5000 key.")
 		b3.Add(ctx2, 51, "I am the value with 5001 key.")
 		b3.Add(ctx2, 52, "I am also a value with 5000 key.")
-		err := t1.Commit(ctx2)
-		if err != nil {
-			log.Error(fmt.Sprintf("f1 commit failed, details: %v", err))
-		}
-		return err
+		return t1.Commit(ctx2)
 	}
 
 	f2 := func() error {
@@ -668,11 +663,7 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 		b32.Add(ctx3, 550, "I am the value with 5000 key.")
 		b32.Add(ctx3, 551, "I am the value with 5001 key.")
 		b32.Add(ctx3, 552, "I am the value with 5001 key.")
-		err := t2.Commit(ctx3)
-		if err != nil {
-			log.Error(fmt.Sprintf("f2 commit failed, details: %v", err))
-		}
-		return err
+		return t2.Commit(ctx3)
 	}
 
 	f3 := func() error {
@@ -681,11 +672,7 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 		b32, _ := in_red_fs.OpenBtree[int, string](ctx4, "tablex2", t3, nil)
 		b32.Add(ctx4, 550, "random foo.")
 		b32.Add(ctx4, 551, "bar hello.")
-		err := t3.Commit(ctx4)
-		if err != nil {
-			log.Error(fmt.Sprintf("f3 commit failed, details: %v", err))
-		}
-		return err
+		return t3.Commit(ctx4)
 	}
 
 	eg.Go(f1)


### PR DESCRIPTION
Only replication on "store repository" & "registry" left to be done and we're golden. :)

* in_red_fs performs really well, (using in_red_cfs w/ Cassandra) from 3mins & 29 seconds to complete entire integration_tests that includes stress tests (& heavy transaction "merges"!) down to 2mins & 23 seconds with pure 100% SOP storage engine.
If this is accurate, we've cut down or increased performance by a factor of ~33%, or say, 28% after "replication" is done.

This is 28% better than using Cassandra (in optimal manner, all parallel IO, consistency of Local_Quorum). That is, 28% better ererytime, sustained throughput. If you have busy data processing cluster that takes 10 days to process a batch of data, it will take 7.72 days with using 100% SOP (in_red_fs).

Now, if your data processing does NOT involve many "transaction conflicts & data merges", it will even be more performant than that.

Test machine: single laptop w/ SSD HDD hosting both Redis & the Golang tests.