### PR TITLE
Added support for clearing the cache (Redis) on in_red_fs.RemoveBtree…

### DIFF
--- a/common/mocks/mock_redis.go
+++ b/common/mocks/mock_redis.go
@@ -100,3 +100,8 @@ func (m *mockRedis) IsLockedByOthers(ctx context.Context, lockKeys ...string) (b
 func (m *mockRedis) Unlock(ctx context.Context, lockKeys ...*sop.LockKey) error {
 	return nil
 }
+
+func (m *mockRedis) Clear(ctx context.Context) error {
+	m.lookup = make(map[string][]byte)
+	return nil
+}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -39,6 +39,11 @@ func (c client) Ping(ctx context.Context) error {
 	return nil
 }
 
+// Clear the cache. Be cautions calling this method as it will clear the Redis cache.
+func (c client) Clear(ctx context.Context) error {
+	return connection.Client.FlushDB(ctx).Err()
+}
+
 // Set executes the redis Set command
 func (c client) Set(ctx context.Context, key string, value string, expiration time.Duration) error {
 	if connection == nil {

--- a/repository.go
+++ b/repository.go
@@ -202,4 +202,7 @@ type Cache interface {
 	IsLockedByOthers(ctx context.Context, lockKeyNames ...string) (bool, error)
 	// Unlock a given set of keys.
 	Unlock(ctx context.Context, lockKeys ...*LockKey) error
+
+	// Clear out the backend Cache database of all items.
+	Clear(ctx context.Context) error
 }


### PR DESCRIPTION
… so you don't have to manually clear in Redis. This function is geared for administrators actually. And only used in integration_tests automated tests thus, no risk at all.