### PR TITLE
Debugging related... tests create a new context instead of using glob…

### DIFF
--- a/cassandra/registry.go
+++ b/cassandra/registry.go
@@ -77,6 +77,11 @@ func (v *registry) Update(ctx context.Context, allOrNothing bool, storesHandles 
 			for _, h := range sh.IDs {
 				var h2 sop.Handle
 				if err := v.cache.GetStruct(ctx, h.LogicalID.String(), &h2); err != nil {
+					if !v.cache.KeyNotFound(err) {
+						err = &sop.UpdateAllOrNothingError{
+							Err: fmt.Errorf("Registry Update failed, handle %s not in cache", h.LogicalID.String()),
+						}
+					}
 					// Unlock the object Keys before return.
 					v.cache.Unlock(ctx, handleKeys...)
 					return err

--- a/fs/hashmap.go
+++ b/fs/hashmap.go
@@ -75,7 +75,7 @@ func newHashmap(readWrite bool, hashModValue int, replicationTracker *replicatio
 		cache:              cache,
 
 		// Support cache(e.g. - Redis) based file region locks so it can work across different OS like Windows, OSX & Linux, etc...
-		// All supported by the Golang compiler. :)
+		// All that are supported by the Golang compiler can work in the SOP enterprise cluster. :)
 		useCacheForFileRegionLocks: true, //useCacheForFileRegionLocks,
 	}
 }

--- a/fs/registry.go
+++ b/fs/registry.go
@@ -69,6 +69,11 @@ func (r registryOnDisk) Update(ctx context.Context, allOrNothing bool, storesHan
 			for _, h := range sh.IDs {
 				var h2 sop.Handle
 				if err := r.cache.GetStruct(ctx, h.LogicalID.String(), &h2); err != nil {
+					if !r.cache.KeyNotFound(err) {
+						err = &sop.UpdateAllOrNothingError{
+							Err: fmt.Errorf("Registry Update failed, handle %s not in cache", h.LogicalID.String()),
+						}
+					}
 					// Unlock the object Keys before return.
 					r.cache.Unlock(ctx, handleKeys...)
 					return err

--- a/fs/registry_map.go
+++ b/fs/registry_map.go
@@ -64,7 +64,7 @@ func (rm registryMap) set(ctx context.Context, allOrNothing bool, items ...sop.T
 				return err
 			}
 			// Update the Handles read w/ the items' values.
-			for i := 0; i < len(frds); i++ {
+			for i := range frds {
 				// Check if the record in the target file region is different.
 				if !frds[i].handle.IsEmpty() && frds[i].handle.LogicalID != item.Second[i].LogicalID {
 					// Fail if the record on target is different.

--- a/in_red_fs/integration_tests/basic_ec_test.go
+++ b/in_red_fs/integration_tests/basic_ec_test.go
@@ -2,6 +2,7 @@ package integration_tests
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -31,6 +32,7 @@ func initErasureCoding() {
 }
 
 func Test_Basic_EC(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptionsWithReplication(nil, sop.ForWriting, -1, fs.MinimumModValue, nil)
 	trans, err := in_red_fs.NewTransactionWithReplication(to)
 	if err != nil {
@@ -72,6 +74,7 @@ func Test_Basic_EC(t *testing.T) {
 }
 
 func Test_Basic_EC_Get(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptionsWithReplication(nil, sop.ForWriting, -1, fs.MinimumModValue, nil)
 	trans, err := in_red_fs.NewTransactionWithReplication(to)
 	if err != nil {

--- a/in_red_fs/integration_tests/basic_test.go
+++ b/in_red_fs/integration_tests/basic_test.go
@@ -35,14 +35,15 @@ func init() {
 	initErasureCoding()
 
 	cache := redis.NewClient()
+	log.Info("about to issue cache.Clear")
+	ctx := context.Background()
 	if err := cache.Clear(ctx); err != nil {
 		log.Error(fmt.Sprintf("cache.Clear failed, details: %v", err))
 	}
 }
 
-var ctx = context.Background()
-
 func Test_GetStoreList(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {
@@ -55,6 +56,7 @@ func Test_GetStoreList(t *testing.T) {
 
 // Create an empty store on 1st run, add one item(max) on succeeding runs.
 func Test_CreateEmptyStore(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {
@@ -93,6 +95,7 @@ func Test_CreateEmptyStore(t *testing.T) {
 }
 
 func Test_TransactionStory_OpenVsNewBTree(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {
@@ -123,6 +126,7 @@ func Test_TransactionStory_SingleBTree_Get(t *testing.T) {
 	// 2. Instantiate a BTree
 	// 3. Do CRUD on BTree
 	// 4. Commit Transaction
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {
@@ -159,6 +163,7 @@ func Test_TransactionStory_SingleBTree_Get(t *testing.T) {
 }
 
 func Test_TransactionStory_SingleBTree(t *testing.T) {
+	ctx := context.Background()
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	// Demo NewTransactionExt specifying custom "to file path" lambda function.
@@ -206,6 +211,7 @@ func Test_TransactionStory_SingleBTree(t *testing.T) {
 }
 
 func Test_RegistryZeroDurationCache(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {
@@ -253,6 +259,7 @@ func Test_RegistryZeroDurationCache(t *testing.T) {
 }
 
 func Test_StoreCaching(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {
@@ -294,6 +301,7 @@ func Test_StoreCaching(t *testing.T) {
 }
 
 func Test_StoreCachingTTL(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {

--- a/in_red_fs/integration_tests/delete_btree_test.go
+++ b/in_red_fs/integration_tests/delete_btree_test.go
@@ -1,6 +1,7 @@
 package integration_tests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/SharedCode/sop/in_red_fs"
@@ -9,6 +10,7 @@ import (
 // Add Test_ prefix if you want to run this test.
 // It drops the blob & registry tables of the B-Tree, thus, the test was removed from the set.
 func DeleteBTree(t *testing.T) {
+	ctx := context.Background()
 	tableList := []string{
 		"fooStore", "fooStore1", "fooStore2", "persondb", "twophase", "twophase2", "twophase3",
 		"twophase22", "persondb7", "persondb77", "person2db", "barStore1",

--- a/in_red_fs/integration_tests/streaming_data_store_test.go
+++ b/in_red_fs/integration_tests/streaming_data_store_test.go
@@ -1,6 +1,7 @@
 package integration_tests
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -12,6 +13,7 @@ import (
 )
 
 func Test_StreamingDataStoreInvalidCases(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)
 	trans.Begin()
@@ -30,6 +32,7 @@ func Test_StreamingDataStoreInvalidCases(t *testing.T) {
 }
 
 func Test_StreamingDataStoreBasicUse(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)
 	trans.Begin()
@@ -74,6 +77,7 @@ func Test_StreamingDataStoreBasicUse(t *testing.T) {
 }
 
 func Test_StreamingDataStoreMultipleItems(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)
 	trans.Begin()
@@ -123,6 +127,7 @@ func Test_StreamingDataStoreMultipleItems(t *testing.T) {
 }
 
 func Test_StreamingDataStoreDeleteAnItem(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)
 	trans.Begin()
@@ -175,6 +180,7 @@ func Test_StreamingDataStoreDeleteAnItem(t *testing.T) {
 }
 
 func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
+	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)
@@ -234,6 +240,7 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 }
 
 func Test_StreamingDataStoreUpdateWithCountCheck(t *testing.T) {
+	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)
@@ -259,6 +266,7 @@ func Test_StreamingDataStoreUpdateWithCountCheck(t *testing.T) {
 }
 
 func Test_StreamingDataStoreUpdateExtend(t *testing.T) {
+	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)
@@ -285,6 +293,7 @@ func Test_StreamingDataStoreUpdateExtend(t *testing.T) {
 }
 
 func Test_StreamingDataStoreUpdate(t *testing.T) {
+	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)
@@ -309,6 +318,7 @@ func Test_StreamingDataStoreUpdate(t *testing.T) {
 }
 
 func Test_StreamingDataStoreDelete(t *testing.T) {
+	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)

--- a/in_red_fs/integration_tests/transaction_logging_test.go
+++ b/in_red_fs/integration_tests/transaction_logging_test.go
@@ -1,6 +1,7 @@
 package integration_tests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 )
 
 func MultipleExpiredTransCleanup(t *testing.T) {
+	ctx := context.Background()
 	in_red_fs.RemoveBtree(ctx, dataPath, "ztab1")
 
 	// Seed with good records.
@@ -73,6 +75,7 @@ func MultipleExpiredTransCleanup(t *testing.T) {
 }
 
 func Cleanup(t *testing.T) {
+	ctx := context.Background()
 	yesterday := time.Now().Add(time.Duration(-24 * time.Hour))
 	sop.Now = func() time.Time { return yesterday }
 

--- a/in_red_fs/integration_tests/transaction_test.go
+++ b/in_red_fs/integration_tests/transaction_test.go
@@ -2,6 +2,7 @@ package integration_tests
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"testing"
 
@@ -49,6 +50,7 @@ const tableName1 = "person2db"
 const tableName2 = "twophase22"
 
 func Test_SimpleAddPerson(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {
@@ -96,6 +98,7 @@ func Test_SimpleAddPerson(t *testing.T) {
 }
 
 func Test_TwoTransactionsWithNoConflict(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {
@@ -137,6 +140,7 @@ func Test_TwoTransactionsWithNoConflict(t *testing.T) {
 }
 
 func Test_AddAndSearchManyPersons(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, err := in_red_fs.NewTransaction(to)
 	if err != nil {
@@ -205,6 +209,7 @@ func Test_AddAndSearchManyPersons(t *testing.T) {
 
 // This test took about 3 minutes from empty to finish in my laptop.
 func Test_VolumeAddThenSearch(t *testing.T) {
+	ctx := context.Background()
 	start := 9001
 	end := 100000
 
@@ -267,6 +272,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 
 // Add prefix Test_ if wanting to run this test.
 func Test_VolumeDeletes(t *testing.T) {
+	ctx := context.Background()
 	start := 9001
 	end := 100000
 
@@ -307,6 +313,7 @@ func Test_VolumeDeletes(t *testing.T) {
 // Mixed CRUD operations.
 // Add prefix Test_ if wanting to run this test.
 func Test_MixedOperations(t *testing.T) {
+	ctx := context.Background()
 	start := 9000
 	end := 14000
 
@@ -395,6 +402,7 @@ func Test_MixedOperations(t *testing.T) {
 }
 
 func Test_TwoPhaseCommitRolledback(t *testing.T) {
+	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	t1, _ := in_red_fs.NewTransaction(to)
 	t1.Begin()

--- a/sleep.go
+++ b/sleep.go
@@ -20,15 +20,21 @@ func TimedOut(ctx context.Context, name string, startTime time.Time, maxTime tim
 	return nil
 }
 
+// Random sleep also but you can specify a value of sleep unit amount.
+func RandomSleepWithUnit(ctx context.Context, unit time.Duration) {
+	sleepTime := time.Duration(rand.Intn(5))
+	if sleepTime == 0 {
+		sleepTime = 1
+	}
+	st := sleepTime*unit
+	log.Debug(fmt.Sprintf("sleep for %d * %d unit", sleepTime, unit))
+	Sleep(ctx, st)
+}
+
 // Sleep in random milli-seconds to allow different conflicting (Node modifying) transactions
 // to retry on different times, thus, increasing chance to succeed one after the other.
 func RandomSleep(ctx context.Context) {
-	sleepTime := rand.Intn(5) * 20
-	if sleepTime == 0 {
-		sleepTime = 2
-	}
-	log.Debug(fmt.Sprintf("sleep for %d millis", sleepTime))
-	Sleep(ctx, time.Duration(sleepTime)*time.Millisecond)
+	RandomSleepWithUnit(ctx, 20*time.Millisecond)
 }
 
 // sleep with context.


### PR DESCRIPTION
…al context, not to affect each other.

There is an area in get data from cache where a retry was added instead of failing if data was not found, due to cache is "crowded" reason in this case, the data got lost(pruned).