### PR TITLE
In red fs: Removed file region locking, standardized on application level unified locks

### DIFF
--- a/fs/hashmap.go
+++ b/fs/hashmap.go
@@ -21,9 +21,8 @@ type hashmap struct {
 	replicationTracker *replicationTracker
 	readWrite          bool
 	// File handles of all known (traversed & opened) data segment file of the hash map.
-	fileHandles                map[string]*directIO
-	cache                      sop.Cache
-	useCacheForFileRegionLocks bool
+	fileHandles map[string]*directIO
+	cache       sop.Cache
 }
 
 // File reqion details is a response struct of 'findAndLock' function. It puts together
@@ -73,19 +72,17 @@ func newHashmap(readWrite bool, hashModValue int, replicationTracker *replicatio
 		readWrite:          readWrite,
 		fileHandles:        make(map[string]*directIO, 5),
 		cache:              cache,
-
-		// Support cache(e.g. - Redis) based file region locks so it can work across different OS like Windows, OSX & Linux, etc...
-		// All that are supported by the Golang compiler can work in the SOP enterprise cluster. :)
-		useCacheForFileRegionLocks: true, //useCacheForFileRegionLocks,
 	}
 }
 
-// Iterate through the entire set of hashmap (bucket) files, from 1 to the last bucket file.
+// Iterate through the entire set of hashmap (bucket) files, from 1 to the last bucket file to findOneFileRegion the file region
+// containing the item (handle record) with 'id' (if for read), or a place for it (if for write).
+//
 // Each bucket file is allocated about 250,000 "sector blocks"(configurable) and in total, contains ~16,650,000
 // addressable virtual IDs (handles). Typically, there should be only one bucket file as this file
 // with the default numbers shown, can be used to hold 825 million items of the B-Tree, given a
 // slot length of 500.
-func (hm *hashmap) findAndLock(ctx context.Context, forWriting bool, filename string, id sop.UUID) (fileRegionDetails, error) {
+func (hm *hashmap) findOneFileRegion(ctx context.Context, forWriting bool, filename string, id sop.UUID) (fileRegionDetails, error) {
 	var dio *directIO
 	var result fileRegionDetails
 
@@ -143,14 +140,8 @@ func (hm *hashmap) findAndLock(ctx context.Context, forWriting bool, filename st
 				if forWriting {
 					result.blockOffset = blockOffset
 					result.handleInBlockOffset = handleInBlockOffset
-					if ok, err := hm.isRegionLocked(ctx, dio, result.getOffset()); ok || err != nil {
-						if ok {
-							err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %v as it is locked", forWriting, result.getOffset())
-						}
-						return result, err
-					}
 					result.dio = dio
-					return result, hm.lockFoundFileRegion(ctx, &result)
+					return result, nil
 				}
 				// If for read, check the next file or break the loop if this is the last file segment.
 				continue
@@ -172,14 +163,8 @@ func (hm *hashmap) findAndLock(ctx context.Context, forWriting bool, filename st
 			if forWriting {
 				result.blockOffset = blockOffset
 				result.handleInBlockOffset = handleInBlockOffset
-				if ok, err := hm.isRegionLocked(ctx, dio, result.getOffset()); ok || err != nil {
-					if ok {
-						err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %v as it is locked", forWriting, result.getOffset())
-					}
-					return result, err
-				}
 				result.dio = dio
-				return result, hm.lockFoundFileRegion(ctx, &result)
+				return result, nil
 			}
 		} else {
 			if lid, err := m.UnmarshalLogicalID(hbuf); err != nil {
@@ -196,13 +181,7 @@ func (hm *hashmap) findAndLock(ctx context.Context, forWriting bool, filename st
 				if !forWriting {
 					return result, nil
 				}
-				if ok, err := hm.isRegionLocked(ctx, dio, result.getOffset()); ok || err != nil {
-					if ok {
-						err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %v as it is locked", forWriting, result.getOffset())
-					}
-					return result, err
-				}
-				return result, hm.lockFoundFileRegion(ctx, &result)
+				return result, nil
 			}
 		}
 
@@ -222,14 +201,8 @@ func (hm *hashmap) findAndLock(ctx context.Context, forWriting bool, filename st
 
 			if isZeroData(hbuf) {
 				if forWriting {
-					if ok, err := hm.isRegionLocked(ctx, dio, result.getOffset()); ok || err != nil {
-						if ok {
-							err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %v as it is locked", forWriting, result.getOffset())
-						}
-						return result, err
-					}
 					result.dio = dio
-					return result, hm.lockFoundFileRegion(ctx, &result)
+					return result, nil
 				}
 			} else {
 				if lid, err := m.UnmarshalLogicalID(hbuf); err != nil {
@@ -241,16 +214,7 @@ func (hm *hashmap) findAndLock(ctx context.Context, forWriting bool, filename st
 					}
 					result.handle = h
 					result.dio = dio
-					if !forWriting {
-						return result, nil
-					}
-					if ok, err := hm.isRegionLocked(ctx, dio, result.getOffset()); ok || err != nil {
-						if ok {
-							err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %v as it is locked", forWriting, result.getOffset())
-						}
-						return result, err
-					}
-					return result, hm.lockFoundFileRegion(ctx, &result)
+					return result, nil
 				}
 			}
 
@@ -263,7 +227,7 @@ func (hm *hashmap) findAndLock(ctx context.Context, forWriting bool, filename st
 func (hm *hashmap) get(ctx context.Context, filename string, ids ...sop.UUID) ([]sop.Handle, error) {
 	completedItems := make([]sop.Handle, 0, len(ids))
 	for _, id := range ids {
-		frd, err := hm.findAndLock(ctx, false, filename, id)
+		frd, err := hm.findOneFileRegion(ctx, false, filename, id)
 		if err != nil {
 			if strings.Contains(err.Error(), idNotFoundErr) {
 				continue
@@ -284,19 +248,13 @@ func (hm *hashmap) get(ctx context.Context, filename string, ids ...sop.UUID) ([
 	return completedItems, nil
 }
 
-// Lock file region(s) that a set of UUIDs correlate to and return these region(s)' offsett/Handle if in case
+// Find the file region(s) that a set of UUIDs correlate to and return these region(s)' offsett/Handle if in case
 // useful to the caller.
-func (hm *hashmap) findAndLockFileRegion(ctx context.Context, filename string, ids ...sop.UUID) ([]fileRegionDetails, error) {
-	undo := func(items []fileRegionDetails) {
-		for _, item := range items {
-			hm.unlockFileRegion(ctx, item)
-		}
-	}
+func (hm *hashmap) findFileRegion(ctx context.Context, filename string, ids ...sop.UUID) ([]fileRegionDetails, error) {
 	completedItems := make([]fileRegionDetails, 0, len(ids))
 	for _, id := range ids {
-		frd, err := hm.findAndLock(ctx, true, filename, id)
+		frd, err := hm.findOneFileRegion(ctx, true, filename, id)
 		if err != nil {
-			undo(completedItems)
 			return nil, err
 		}
 		completedItems = append(completedItems, frd)
@@ -357,16 +315,7 @@ func (hm *hashmap) setupNewFile(ctx context.Context, forWriting bool, filename s
 	blockOffset, handleInBlockOffset := hm.getBlockOffsetAndHandleInBlockOffset(id)
 	result.blockOffset = blockOffset
 	result.handleInBlockOffset = handleInBlockOffset
-	if ok, err := hm.isRegionLocked(ctx, dio, result.getOffset()); ok || err != nil {
-		if ok {
-			err = fmt.Errorf("can't lock (forWriting=%v) file region w/ offset %v as it is locked", forWriting, result.getOffset())
-		}
-		return result, err
-	}
 	result.dio = dio
-	if err := hm.lockFoundFileRegion(ctx, &result); err != nil {
-		return result, err
-	}
 	return result, nil
 }
 

--- a/fs/hashmap.go
+++ b/fs/hashmap.go
@@ -251,15 +251,15 @@ func (hm *hashmap) get(ctx context.Context, filename string, ids ...sop.UUID) ([
 // Find the file region(s) that a set of UUIDs correlate to and return these region(s)' offsett/Handle if in case
 // useful to the caller.
 func (hm *hashmap) findFileRegion(ctx context.Context, filename string, ids ...sop.UUID) ([]fileRegionDetails, error) {
-	completedItems := make([]fileRegionDetails, 0, len(ids))
+	foundItems := make([]fileRegionDetails, 0, len(ids))
 	for _, id := range ids {
 		frd, err := hm.findOneFileRegion(ctx, true, filename, id)
 		if err != nil {
 			return nil, err
 		}
-		completedItems = append(completedItems, frd)
+		foundItems = append(foundItems, frd)
 	}
-	return completedItems, nil
+	return foundItems, nil
 }
 
 // Close all files opened by this hashmap on disk.

--- a/fs/registry.go
+++ b/fs/registry.go
@@ -28,9 +28,9 @@ const (
 )
 
 // NewRegistry manages the Handle in memory for mocking.
-func NewRegistry(readWrite bool, hashModValue int, rt *replicationTracker, cache sop.Cache, useCacheForFileRegionLocks bool) Registry {
+func NewRegistry(readWrite bool, hashModValue int, rt *replicationTracker, cache sop.Cache) Registry {
 	return &registryOnDisk{
-		hashmap:            newRegistryMap(readWrite, hashModValue, rt, cache, useCacheForFileRegionLocks),
+		hashmap:            newRegistryMap(readWrite, hashModValue, rt, cache),
 		replicationTracker: rt,
 		cache:              cache,
 	}

--- a/fs/registry_map.go
+++ b/fs/registry_map.go
@@ -11,9 +11,9 @@ type registryMap struct {
 	hashmap *hashmap
 }
 
-func newRegistryMap(readWrite bool, hashModValue int, replicationTracker *replicationTracker, cache sop.Cache, useCacheForFileRegionLocks bool) *registryMap {
+func newRegistryMap(readWrite bool, hashModValue int, replicationTracker *replicationTracker, cache sop.Cache) *registryMap {
 	return &registryMap{
-		hashmap: newHashmap(readWrite, hashModValue, replicationTracker, cache, useCacheForFileRegionLocks),
+		hashmap: newHashmap(readWrite, hashModValue, replicationTracker, cache, true),
 	}
 }
 

--- a/fs/registry_map.go
+++ b/fs/registry_map.go
@@ -22,23 +22,18 @@ func (rm registryMap) add(ctx context.Context, items ...sop.Tuple[string, []sop.
 	// Individually write to the file area occupied by the handle so we don't create "lock pressure".
 	for _, item := range items {
 		for _, h := range item.Second {
-			frd, err := rm.hashmap.findAndLockFileRegion(ctx, item.First, h.LogicalID)
+			frd, err := rm.hashmap.findFileRegion(ctx, item.First, h.LogicalID)
 			if err != nil {
 				return err
 			}
 
 			// Fail if item exists in target.
 			if !frd[0].handle.IsEmpty() {
-				rm.hashmap.unlockFileRegion(ctx, frd...)
 				return fmt.Errorf("registryMap.add failed, can't overwrite an item at offset=%v, item details: %v", frd[0].getOffset(), frd[0].handle)
 			}
 
 			frd[0].handle = h
 			if err := rm.hashmap.updateFileRegion(ctx, frd...); err != nil {
-				rm.hashmap.unlockFileRegion(ctx, frd...)
-				return err
-			}
-			if err := rm.hashmap.unlockFileRegion(ctx, frd...); err != nil {
 				return err
 			}
 		}
@@ -49,18 +44,10 @@ func (rm registryMap) add(ctx context.Context, items ...sop.Tuple[string, []sop.
 // Update a given set of Handle(s) record(s) on file(s) where they are stored in.
 func (rm registryMap) set(ctx context.Context, allOrNothing bool, items ...sop.Tuple[string, []sop.Handle]) error {
 	if allOrNothing {
-		// Supports update (including update to prepare for deleting) of Handle records.
-		unlockItemFileRegions := func(items ...fileRegionDetails) error {
-			if err := rm.hashmap.unlockFileRegion(ctx, items...); err != nil {
-				return err
-			}
-			return nil
-		}
 		lockedItems := make([]fileRegionDetails, 0, len(items))
 		for _, item := range items {
-			frds, err := rm.hashmap.findAndLockFileRegion(ctx, item.First, getIDs(item.Second...)...)
+			frds, err := rm.hashmap.findFileRegion(ctx, item.First, getIDs(item.Second...)...)
 			if err != nil {
-				unlockItemFileRegions(lockedItems...)
 				return err
 			}
 			// Update the Handles read w/ the items' values.
@@ -69,7 +56,6 @@ func (rm registryMap) set(ctx context.Context, allOrNothing bool, items ...sop.T
 				if !frds[i].handle.IsEmpty() && frds[i].handle.LogicalID != item.Second[i].LogicalID {
 					// Fail if the record on target is different.
 					lockedItems = append(lockedItems, frds...)
-					unlockItemFileRegions(lockedItems...)
 					return fmt.Errorf("registryMap.set allOrNothing failed, an item(target lid=%v) at offset=%v is different (source lid=%v)",
 						frds[i].handle.LogicalID, frds[i].getOffset(), item.Second[i].LogicalID)
 				}
@@ -79,31 +65,25 @@ func (rm registryMap) set(ctx context.Context, allOrNothing bool, items ...sop.T
 			lockedItems = append(lockedItems, frds...)
 		}
 		if err := rm.hashmap.updateFileRegion(ctx, lockedItems...); err != nil {
-			unlockItemFileRegions(lockedItems...)
 			return err
 		}
-		return unlockItemFileRegions(lockedItems...)
+		return nil
 	}
 	// Individually manage/update the file area occupied by the handle so we don't create "lock pressure".
 	for _, item := range items {
 		for _, h := range item.Second {
-			frd, err := rm.hashmap.findAndLockFileRegion(ctx, item.First, h.LogicalID)
+			frd, err := rm.hashmap.findFileRegion(ctx, item.First, h.LogicalID)
 			if err != nil {
 				return err
 			}
 			// Check if the record in the target file region is different.
 			if !frd[0].handle.IsEmpty() && frd[0].handle.LogicalID != h.LogicalID {
-				rm.hashmap.unlockFileRegion(ctx, frd...)
 				return fmt.Errorf("registryMap.set failed, an item(target lid=%v) at offset=%v is different (source lid=%v)",
 					frd[0].handle.LogicalID, frd[0].getOffset(), h.LogicalID)
 			}
 
 			frd[0].handle = h
 			if err := rm.hashmap.updateFileRegion(ctx, frd...); err != nil {
-				rm.hashmap.unlockFileRegion(ctx, frd...)
-				return err
-			}
-			if err := rm.hashmap.unlockFileRegion(ctx, frd...); err != nil {
 				return err
 			}
 		}
@@ -132,29 +112,23 @@ func (rm registryMap) remove(ctx context.Context, keys ...sop.Tuple[string, []so
 	// Individually delete the file area occupied by the handle so we don't create "lock pressure".
 	for _, key := range keys {
 		for _, id := range key.Second {
-			frd, err := rm.hashmap.findAndLockFileRegion(ctx, key.First, id)
+			frd, err := rm.hashmap.findFileRegion(ctx, key.First, id)
 			if err != nil {
 				return err
 			}
 			// If read handle is empty, it means the item is already marked deleted in disk.
 			if frd[0].handle.IsEmpty() {
 				// Fail if there is no record on target, can't delete a missing item.
-				rm.hashmap.unlockFileRegion(ctx, frd...)
 				return fmt.Errorf("registryMap.remove failed, an item at offset=%v was not found, can't delete a missing item", frd[0].getOffset())
 			}
 			// Check if the record in the target file region is different.
 			if frd[0].handle.LogicalID != id {
 				// Fail if the found record on target is different.
-				rm.hashmap.unlockFileRegion(ctx, frd...)
 				return fmt.Errorf("registryMap.remove failed, an item(target lid=%v) at offset=%v is different (source lid=%v)",
 					frd[0].handle.LogicalID, frd[0].getOffset(), id)
 			}
 
 			if err := rm.hashmap.markDeleteFileRegion(ctx, frd...); err != nil {
-				rm.hashmap.unlockFileRegion(ctx, frd...)
-				return err
-			}
-			if err := rm.hashmap.unlockFileRegion(ctx, frd...); err != nil {
 				return err
 			}
 		}

--- a/fs/registry_map_test.go
+++ b/fs/registry_map_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestRegistryMapAdd(t *testing.T) {
-	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false),
-		redis.NewClient(), false)
+	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false), redis.NewClient())
 
 	h := sop.NewHandle(uuid)
 
@@ -24,8 +23,7 @@ func TestRegistryMapAdd(t *testing.T) {
 }
 
 func TestRegistryMapSet(t *testing.T) {
-	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false),
-		redis.NewClient(), false)
+	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false), redis.NewClient())
 
 	h := sop.NewHandle(uuid)
 
@@ -40,8 +38,7 @@ func TestRegistryMapSet(t *testing.T) {
 }
 
 func TestRegistryMapGet(t *testing.T) {
-	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false),
-		redis.NewClient(), false)
+	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false), redis.NewClient())
 
 	if res, err := r.get(ctx, sop.Tuple[string, []sop.UUID]{
 		First:  "regtest",
@@ -58,8 +55,7 @@ func TestRegistryMapGet(t *testing.T) {
 }
 
 func TestRegistryMapRemove(t *testing.T) {
-	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false),
-		redis.NewClient(), false)
+	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false), redis.NewClient())
 
 	if err := r.remove(ctx, sop.Tuple[string, []sop.UUID]{
 		First:  "regtest",
@@ -72,8 +68,7 @@ func TestRegistryMapRemove(t *testing.T) {
 }
 
 func TestRegistryMapFailedSet(t *testing.T) {
-	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false),
-		redis.NewClient(), false)
+	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false), redis.NewClient())
 
 	h := sop.NewHandle(uuid)
 
@@ -102,8 +97,7 @@ func TestRegistryMapFailedSet(t *testing.T) {
 }
 
 func TestRegistryMapRecyAddRemoveAdd(t *testing.T) {
-	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false),
-		redis.NewClient(), false)
+	r := newRegistryMap(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false), redis.NewClient())
 
 	h := sop.NewHandle(uuid)
 

--- a/fs/registry_test.go
+++ b/fs/registry_test.go
@@ -20,7 +20,7 @@ var uuid, _ = sop.ParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 var hashMod = MinimumModValue
 
 func TestRegistryAddThenRead(t *testing.T) {
-	r := NewRegistry(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false), redis.NewClient(), false)
+	r := NewRegistry(true, hashMod, NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false), redis.NewClient())
 
 	h := sop.NewHandle(uuid)
 

--- a/in_red_fs/transaction.go
+++ b/in_red_fs/transaction.go
@@ -37,7 +37,7 @@ func NewTwoPhaseCommitTransaction(to TransationOptions) (sop.TwoPhaseCommitTrans
 	tl := fs.NewTransactionLog(to.Cache, replicationTracker)
 	return common.NewTwoPhaseCommitTransaction(to.Mode, to.MaxTime, true,
 		fs.NewBlobStore(nil), sr, fs.NewRegistry(to.Mode == sop.ForWriting,
-			to.RegistryHashModValue, replicationTracker, to.Cache, to.UseCacheForFileRegionLocks), to.Cache, tl)
+			to.RegistryHashModValue, replicationTracker, to.Cache), to.Cache, tl)
 }
 
 // Create a transaction that supports replication, via custom SOP replicaiton on StoreRepository & Registry and then Erasure Coding on Blob Store.
@@ -80,5 +80,5 @@ func NewTwoPhaseCommitTransactionWithReplication(towr TransationOptionsWithRepli
 	tl := fs.NewTransactionLog(towr.Cache, replicationTracker)
 
 	return common.NewTwoPhaseCommitTransaction(towr.Mode, towr.MaxTime, true, bs, sr,
-		fs.NewRegistry(towr.Mode == sop.ForWriting, towr.RegistryHashModValue, replicationTracker, towr.Cache, towr.UseCacheForFileRegionLocks), towr.Cache, tl)
+		fs.NewRegistry(towr.Mode == sop.ForWriting, towr.RegistryHashModValue, replicationTracker, towr.Cache), towr.Cache, tl)
 }

--- a/in_red_fs/transaction_options.go
+++ b/in_red_fs/transaction_options.go
@@ -21,9 +21,6 @@ type TransationOptions struct {
 	RegistryHashModValue int
 	// Cache interface, will default to Redis if not specified.
 	Cache sop.Cache
-	// true will tell registry's hashmap to use Redis for file region locking, otherwise
-	// it will use the syscall API for lock managements on file.
-	UseCacheForFileRegionLocks bool
 }
 
 type TransationOptionsWithReplication struct {
@@ -39,9 +36,6 @@ type TransationOptionsWithReplication struct {
 	RegistryHashModValue int
 	// Cache interface, will default to Redis if not specified.
 	Cache sop.Cache
-	// true will tell registry's hashmap to use Redis for file region locking, otherwise
-	// it will use the syscall API for lock managements on file.
-	UseCacheForFileRegionLocks bool
 	// Erasure Config contains config data useful for Erasure Coding based file IO (& replication).
 	ErasureConfig map[string]fs.ErasureCodingConfig
 }


### PR DESCRIPTION
Application registry (virtual ID) based locks is useable as is even on "file region" locking granularity. The former achieved the atomicity level of file region locking, thus, removed the file region based locking code set.

Code is a lot simpler without the removed bits.