### PR TITLE
Refactors in preparation for implementing L1 Cache that can live betw…

### DIFF
--- a/btree/btree.go
+++ b/btree/btree.go
@@ -99,6 +99,10 @@ func New[TK Ordered, TV any](storeInfo *sop.StoreInfo, si *StoreInterface[TK, TV
 	return &b3, nil
 }
 
+func (btree *Btree[TK, TV]) Lock(ctx context.Context, forWriting bool) error {
+	return nil
+}
+
 // Returns the details about this B-Tree.
 func (btree *Btree[TK, TV]) GetStoreInfo() sop.StoreInfo {
 	return *btree.StoreInfo

--- a/btree/btree_with_transaction.go
+++ b/btree/btree_with_transaction.go
@@ -23,6 +23,17 @@ func NewBtreeWithTransaction[TK Ordered, TV any](t sop.TwoPhaseCommitTransaction
 	}
 }
 
+/*
+	- Implement Lock & unlock on commit.
+	- Implement Node early persist.
+	- Implement MRU caching.
+*/
+
+func (b3 *btreeWithTransaction[TK, TV]) Lock(ctx context.Context, forWriting bool) error {
+	// TODO
+	return nil
+}
+
 // Returns the store info of this B-Tree.
 func (b3 *btreeWithTransaction[TK, TV]) GetStoreInfo() sop.StoreInfo {
 	return b3.btree.GetStoreInfo()

--- a/btree/store_interfaces.go
+++ b/btree/store_interfaces.go
@@ -69,6 +69,10 @@ type BtreeInterface[TK Ordered, TV any] interface {
 
 	// Returns StoreInfo which contains the details about this B-Tree.
 	GetStoreInfo() sop.StoreInfo
+
+	// Lock the B-Tree for writing (if param is true) or for reading (if param is false).
+	// Upon transaction commit, lock on any B-Trees are automatically released, why there is no "Unlock" function.
+	Lock(ctx context.Context, forWriting bool) error
 }
 
 // NodeRepository interface specifies the node repository.

--- a/common/btree_with_induced_errors_test.go
+++ b/common/btree_with_induced_errors_test.go
@@ -19,6 +19,10 @@ func newBTreeWithInducedErrors[TK btree.Ordered, TV any](t *testing.T) *b3WithIn
 	return &b3WithInducedErrors[TK, TV]{t: t}
 }
 
+func (b3 b3WithInducedErrors[TK, TV]) Lock(ctx context.Context, forWriting bool) error {
+	return nil
+}
+
 func (b3 b3WithInducedErrors[TK, TV]) Count() int64 {
 	return 0
 }

--- a/common/mocks/mock_redis.go
+++ b/common/mocks/mock_redis.go
@@ -85,6 +85,14 @@ func (m *mockRedis) CreateLockKeys(keys []string) []*sop.LockKey {
 	return nil
 }
 
+func (m *mockRedis) LockTTL(ctx context.Context, duration time.Duration, lockKeys []*sop.LockKey) (bool, error) {
+	return false, nil
+}
+
+func (m *mockRedis) IsLockedTTL(ctx context.Context, duration time.Duration, lockKeys []*sop.LockKey) (bool, error) {
+	return false, nil
+}
+
 func (m *mockRedis) Lock(ctx context.Context, duration time.Duration, lockKeys []*sop.LockKey) (bool, error) {
 	return false, nil
 }

--- a/common/node_repository_front_end.go
+++ b/common/node_repository_front_end.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"context"
+
+	"github.com/SharedCode/sop"
+	"github.com/SharedCode/sop/btree"
+)
+
+// Frontend facing Node Repository. Implements the NodeRepository interface CRUD methods.
+
+type nodeRepositoryFrontEnd[TK btree.Ordered, TV any] struct {
+	backendNodeRepository *nodeRepositoryBackend
+}
+
+// Add will upsert node to the map.
+func (nr *nodeRepositoryFrontEnd[TK, TV]) Add(n *btree.Node[TK, TV]) {
+	nr.backendNodeRepository.add(n.ID, n)
+}
+
+// Update will upsert node to the map.
+func (nr *nodeRepositoryFrontEnd[TK, TV]) Update(n *btree.Node[TK, TV]) {
+	nr.backendNodeRepository.update(n.ID, n)
+}
+
+// Get will retrieve a node with nodeID from the map.
+func (nr *nodeRepositoryFrontEnd[TK, TV]) Get(ctx context.Context, nodeID sop.UUID) (*btree.Node[TK, TV], error) {
+	var target btree.Node[TK, TV]
+	n, err := nr.backendNodeRepository.get(ctx, nodeID, &target)
+	if n == nil {
+		return nil, err
+	}
+	return n.(*btree.Node[TK, TV]), err
+}
+
+func (nr *nodeRepositoryFrontEnd[TK, TV]) Fetched(nodeID sop.UUID) {
+	c := nr.backendNodeRepository.localCache[nodeID]
+	if c.action == defaultAction {
+		c.action = getAction
+		nr.backendNodeRepository.localCache[nodeID] = c
+	}
+}
+
+// Remove will remove a node with nodeID from the map.
+func (nr *nodeRepositoryFrontEnd[TK, TV]) Remove(nodeID sop.UUID) {
+	nr.backendNodeRepository.remove(nodeID)
+}

--- a/common/store_interfaces.go
+++ b/common/store_interfaces.go
@@ -8,5 +8,5 @@ import (
 type StoreInterface[TK btree.Ordered, TV any] struct {
 	btree.StoreInterface[TK, TV]
 	// Non-generics node repository, used in transaction commit to process modified Nodes.
-	backendNodeRepository *nodeRepository
+	backendNodeRepository *nodeRepositoryBackend
 }

--- a/common/two_phase_commit_transaction.go
+++ b/common/two_phase_commit_transaction.go
@@ -11,7 +11,7 @@ import (
 )
 
 type btreeBackend struct {
-	nodeRepository *nodeRepository
+	nodeRepository *nodeRepositoryBackend
 	// Following are function references because BTree is generic typed for Key & Value,
 	// and these functions being references allow the backend to deal without requiring knowing data types.
 	refetchAndMerge    func(ctx context.Context) error
@@ -28,7 +28,7 @@ type btreeBackend struct {
 }
 
 type Transaction struct {
-	id        sop.UUID
+	id sop.UUID
 	// B-Tree instances, & their backend bits, managed within the transaction session.
 	btreesBackend []btreeBackend
 	// Needed by NodeRepository & ValueDataRepository for Node/Value data merging to the backend storage systems.
@@ -49,9 +49,9 @@ type Transaction struct {
 	removedNodeHandles []sop.RegistryPayload[sop.Handle]
 
 	// Phase 1 commit generated objects required for "replication" in phase 2 commit.
-	addedNodeHandles []sop.RegistryPayload[sop.Handle]
+	addedNodeHandles   []sop.RegistryPayload[sop.Handle]
 	newRootNodeHandles []sop.RegistryPayload[sop.Handle]
-	updatedStoresInfo []sop.StoreInfo
+	updatedStoresInfo  []sop.StoreInfo
 
 	// Used for transaction level locking.
 	nodesKeys []*sop.LockKey
@@ -426,7 +426,7 @@ func (t *Transaction) phase2Commit(ctx context.Context) error {
 		return err
 	}
 
-	// Replicate to passive target paths.	
+	// Replicate to passive target paths.
 	t.registry.Replicate(ctx, t.newRootNodeHandles, t.addedNodeHandles, t.updatedNodeHandles, t.removedNodeHandles)
 	t.storeRepository.Replicate(ctx, t.updatedStoresInfo)
 

--- a/common/two_phase_commit_transaction2.go
+++ b/common/two_phase_commit_transaction2.go
@@ -259,7 +259,7 @@ func (t *Transaction) classifyModifiedNodes() ([]sop.Tuple[*sop.StoreInfo, []int
 	var storesUpdatedNodes, storesRemovedNodes, storesAddedNodes, storesFetchedNodes, storesRootNodes []sop.Tuple[*sop.StoreInfo, []interface{}]
 	for i, s := range t.btreesBackend {
 		var updatedNodes, removedNodes, addedNodes, fetchedNodes, rootNodes []interface{}
-		for _, cacheNode := range s.nodeRepository.nodeLocalCache {
+		for _, cacheNode := range s.nodeRepository.localCache {
 			// Allow newly created root nodes to get merged between transactions.
 			if s.nodeRepository.count == 0 &&
 				cacheNode.action == addAction && t.btreesBackend[i].getStoreInfo().RootNodeID == cacheNode.node.(btree.MetaDataType).GetID() {

--- a/in_red_fs/integration_tests/transaction_test.go
+++ b/in_red_fs/integration_tests/transaction_test.go
@@ -94,7 +94,7 @@ func Test_SimpleAddPerson(t *testing.T) {
 	}
 }
 
-func AddToBreakNodeThenRemoveAllPerson(t *testing.T) {
+func AddToBreakNodeThenRemoveAll(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(to)

--- a/mru/mru.go
+++ b/mru/mru.go
@@ -1,0 +1,5 @@
+package mru
+
+type mru struct {
+	
+}

--- a/repository.go
+++ b/repository.go
@@ -181,6 +181,12 @@ type Cache interface {
 	FormatLockKey(k string) string
 	// Create lock keys.
 	CreateLockKeys(keys []string) []*LockKey
+
+	// Lock a set of keys & with TTL.
+	LockTTL(ctx context.Context, duration time.Duration, lockKeys []*LockKey) (bool, error)
+	// Returns whether a set of keys are all locked & with TTL.
+	IsLockedTTL(ctx context.Context, duration time.Duration, lockKeys []*LockKey) (bool, error)
+
 	// Lock a set of keys.
 	Lock(ctx context.Context, duration time.Duration, lockKeys []*LockKey) (bool, error)
 	// Returns whether a set of keys are all locked.


### PR DESCRIPTION
…een transactions.

* Idea is to massage the common NodeRepository code set so we can easily add in the L1 Cache code artifact(s). Terms/Object (structs) names need to be aligned at the high level so they can be easily comprehensible. Needs to identify the layover between L2 cache & L1 cache and the node repository's (NR) "local cache" which stores/tracks the management actions within the NR.