### PR TITLE
The ideal B-tree MRU caching is in. A B-tree can no longer cause out-…

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,83 @@
+// Package contains the L1 (MRU) Cache implementtion.
+package cache
+
+// Generic Cache is useful for general MRU cache needs.
+type Cache[TK any, TV any] interface {
+	Clear()
+	Set(key TK, value TV)
+	Get(key TK) TV
+	Delete(key TK)
+	Count() int
+	IsFull() bool
+	Evict()
+}
+
+type cacheEntry[TK, TV any] struct {
+	data TV
+	dllNode  *node[TK]
+}
+
+type cache[TK comparable, TV any] struct {
+	lookup       map[TK]*cacheEntry[TK, TV]
+	mru          *mru[TK, TV]
+}
+
+// Instantiate a new instance of this Cache w/ MRU management logic.
+func NewCache[TK comparable, TV any](minCapacity, maxCapacity int) Cache[TK, TV] {
+	c := cache[TK, TV]{
+		lookup:       make(map[TK]*cacheEntry[TK, TV], maxCapacity),
+	}
+	c.mru = newMru(&c, minCapacity, maxCapacity)
+	return &c
+}
+
+func (c *cache[TK, TV]) Clear() {
+	c.lookup = make(map[TK]*cacheEntry[TK, TV], c.mru.maxCapacity)
+	c.mru = newMru(c, c.mru.minCapacity, c.mru.maxCapacity)
+}
+
+func (c *cache[TK, TV]) Set(key TK, value TV) {
+	if v, ok := c.lookup[key]; ok {
+		v.data = value
+		c.mru.remove(v.dllNode)
+		v.dllNode = c.mru.add(key)
+		return
+	}
+	n := c.mru.add(key)
+	c.lookup[key] = &cacheEntry[TK, TV]{
+		data: value,
+		dllNode: n,
+	}
+
+	c.Evict()
+}
+
+func (c *cache[TK, TV]) Get(key TK) TV {
+	if v, ok := c.lookup[key]; ok {
+		c.mru.remove(v.dllNode)
+		v.dllNode = c.mru.add(key)
+		return v.data
+	}
+	var d TV
+	return d
+}
+
+func (c *cache[TK, TV]) Delete(key TK) {
+	if v, ok := c.lookup[key]; ok {
+		c.mru.remove(v.dllNode)
+		v.dllNode = nil
+		delete(c.lookup, key)
+	}
+}
+
+// Returns the count of items store in this L1 Cache.
+func (c *cache[TK, TV]) Count() int {
+	return len(c.lookup)
+}
+
+func (c *cache[TK, TV]) IsFull() bool {
+	return c.mru.isFull()
+}
+func (c *cache[TK, TV]) Evict() {
+	c.mru.evict()
+}

--- a/cache/l1_mru.go
+++ b/cache/l1_mru.go
@@ -1,0 +1,45 @@
+package cache
+
+import "github.com/SharedCode/sop"
+
+type l1_mru struct {
+	minCapacity int
+	maxCapacity int
+	dll         *doublyLinkedList[sop.UUID]
+	l1Cache     *L1Cache
+}
+
+func newL1Mru(l1c *L1Cache, minCapacity, maxCapacity int) *l1_mru {
+	return &l1_mru{
+		l1Cache:     l1c,
+		minCapacity: minCapacity,
+		maxCapacity: maxCapacity,
+		dll:         newDoublyLinkedList[sop.UUID](),
+	}
+}
+
+func (m *l1_mru) add(id sop.UUID) *node[sop.UUID] {
+	return m.dll.addToHead(id)
+}
+func (m *l1_mru) remove(n *node[sop.UUID]) {
+	m.dll.delete(n)
+}
+func (m *l1_mru) evict() {
+	for {
+		if !m.isFull() {
+			break
+		}
+		if id, ok := m.dll.deleteFromTail(); ok {
+			if v, found := m.l1Cache.lookup[id]; found {
+				v.nodeData = nil
+				v.dllNode = nil
+				delete(m.l1Cache.lookup, id)
+			}
+		} else {
+			break
+		}
+	}
+}
+func (m *l1_mru) isFull() bool {
+	return m.dll.count() >= m.maxCapacity
+}

--- a/common/manage_btree.go
+++ b/common/manage_btree.go
@@ -145,6 +145,7 @@ func refetchAndMergeClosure[TK btree.Ordered, TV any](si *StoreInterface[TK, TV]
 		// Clear the backend "cache" so we can force B-Tree to re-fetch from Redis(or BlobStore).
 		si.ItemActionTracker.(*itemActionTracker[TK, TV]).items = make(map[sop.UUID]cacheItem[TK, TV])
 		si.backendNodeRepository.localCache = make(map[sop.UUID]cachedNode)
+		si.backendNodeRepository.readNodesCache.Clear()
 		// Reset StoreInfo of B-Tree in prep to replay the "actions".
 		storeInfo, err := sr.GetWithTTL(ctx, b3.StoreInfo.CacheConfig.IsStoreInfoCacheTTL, b3.StoreInfo.CacheConfig.StoreInfoCacheDuration, b3.StoreInfo.Name)
 		if err != nil {

--- a/common/node_repository_frontend.go
+++ b/common/node_repository_frontend.go
@@ -34,10 +34,14 @@ func (nr *nodeRepositoryFrontEnd[TK, TV]) Get(ctx context.Context, nodeID sop.UU
 }
 
 func (nr *nodeRepositoryFrontEnd[TK, TV]) Fetched(nodeID sop.UUID) {
-	c := nr.backendNodeRepository.localCache[nodeID]
-	if c.action == defaultAction {
-		c.action = getAction
-		nr.backendNodeRepository.localCache[nodeID] = c
+	n := nr.backendNodeRepository.readNodesCache.Get(nodeID)
+	if n != nil {
+		nr.backendNodeRepository.localCache[nodeID] = cachedNode{
+			action: getAction,
+			node: n,
+		}
+		// Remove now from MRU since node got migrated to local cache and is now "tracked".
+		nr.backendNodeRepository.readNodesCache.Delete(nodeID)
 	}
 }
 

--- a/in_red_fs/integration_tests/transaction_test.go
+++ b/in_red_fs/integration_tests/transaction_test.go
@@ -379,6 +379,9 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 	// Search them all. Searching 90,000 items just took few seconds in my laptop.
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
 
+	b3.Last(ctx)
+	b3.First(ctx)
+
 	for i := start; i <= end; i++ {
 		lname := fmt.Sprintf("reepper%d", i)
 		pk, _ := newPerson("jack", lname, "male", "email very very long long long", "phone123")


### PR DESCRIPTION
…of-memory condition BUT at same time, each instance has good level of MRU caching, without compromising ability to do bulk management operations.

But still, a transaction is recommended not to do too "many mgmt"(create, update, explicit fetch, delete) per B-tree instance. However, you can navigate("walk" or find) the B-tree as much as you want, the MRU (read nodes) will manage the memory for this.