### PR TITLE
in_red_fs Replication "failover" & "replication write failure" handlers are in, 'will get more unit tests next.

### DIFF
--- a/common/btree_with_transaction_test.go
+++ b/common/btree_with_transaction_test.go
@@ -21,7 +21,15 @@ func Test_TransactionInducedErrorOnNew(t *testing.T) {
 	trans := t3.(*Transaction)
 
 	// Simulate having an existing fooStore store in the backend.
-	trans.storeRepository.Add(ctx, *sop.NewStoreInfo("fooStore", 5, false, false, true, ""))
+	si := sop.StoreOptions{
+		Name:                     "fooStore",
+		SlotLength:               5,
+		IsUnique:                 false,
+		IsValueDataInNodeSegment: false,
+		LeafLoadBalancing:        true,
+		Description:              "",
+	}
+	trans.storeRepository.Add(ctx, *sop.NewStoreInfo(si))
 
 	// This call should fail and cause rollback because slotLength is being asked to 99 which will
 	// fail spec check vs the "existing" store created above (w/ slot length 5).

--- a/common/manage_btree.go
+++ b/common/manage_btree.go
@@ -65,17 +65,7 @@ func NewBtree[TK btree.Ordered, TV any](ctx context.Context, si sop.StoreOptions
 		trans.Rollback(ctx)
 		return nil, err
 	}
-	ns := sop.NewStoreInfoExt(si.Name, si.SlotLength, si.IsUnique, si.IsValueDataInNodeSegment, si.IsValueDataActivelyPersisted, si.IsValueDataGloballyCached, si.LeafLoadBalancing, si.Description, si.BlobStoreBaseFolderPath, si.CacheConfig)
-
-	// Allow caller to use the same name for blob store and the store name.
-	if si.DisableBlobStoreFormatting {
-		ns.BlobTable = ns.Name
-	}
-	// Allow caller to use the same name for registry store and the store name.
-	if si.DisableRegistryStoreFormatting {
-		ns.RegistryTable = ns.Name
-	}
-
+	ns := sop.NewStoreInfo(si)
 	if len(stores) == 0 || stores[0].IsEmpty() {
 		// Add to store repository if store not found.
 		if ns.RootNodeID.IsNil() {

--- a/common/two_phase_commit_transaction.go
+++ b/common/two_phase_commit_transaction.go
@@ -49,7 +49,7 @@ type Transaction struct {
 	logger    *transactionLog
 
 	// Handle replication related error.
-	HandleReplicationRelatedError func(ioError error, rollbackSucceeded bool) bool
+	HandleReplicationRelatedError func(ioError error, rollbackSucceeded bool)
 
 	// Phase 1 commit generated objects required for phase 2 commit.
 	updatedNodeHandles []sop.RegistryPayload[sop.Handle]

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -12,9 +12,12 @@ type Marshaler interface {
 	Unmarshal(data []byte, v any) error
 }
 
+// Global Default marshaller.
+var DefaultMarshaler = NewMarshaler()
+
 // Global BlobMarshaler takes care of packing and unpacking to/from blob object & byte array.
 // You can replace with your desired Marshaler implementation if needed. Defaults to use JSON Marshal.
-var BlobMarshaler = NewMarshaler()
+var BlobMarshaler = DefaultMarshaler
 
 type defaultMarshaler struct{}
 

--- a/fs/blob_store.go
+++ b/fs/blob_store.go
@@ -20,7 +20,7 @@ const permission os.FileMode = os.ModeSticky | os.ModePerm
 // NewBlobStore instantiates a new blobstore for File System storage.
 func NewBlobStore(toFilePath ToFilePathFunc, fileIO FileIO) sop.BlobStore {
 	if fileIO == nil {
-		fileIO = NewDefaultFileIO(DefaultToFilePath)
+		fileIO = NewDefaultFileIO()
 	}
 	if toFilePath == nil {
 		toFilePath = DefaultToFilePath

--- a/fs/blob_store.go
+++ b/fs/blob_store.go
@@ -10,7 +10,7 @@ import (
 
 // BlobStore has no caching built in because blobs are huge, caller code can apply caching on top of it.
 type blobStore struct {
-	fileIO FileIO
+	fileIO     FileIO
 	toFilePath ToFilePathFunc
 }
 
@@ -26,7 +26,7 @@ func NewBlobStore(toFilePath ToFilePathFunc, fileIO FileIO) sop.BlobStore {
 		toFilePath = DefaultToFilePath
 	}
 	return &blobStore{
-		fileIO: fileIO,
+		fileIO:     fileIO,
 		toFilePath: toFilePath,
 	}
 }

--- a/fs/blob_store_with_ec.go
+++ b/fs/blob_store_with_ec.go
@@ -67,7 +67,7 @@ func NewBlobStoreWithEC(toFilePath ToFilePathFunc, fileIO FileIO, erasureConfig 
 		}
 	}
 	if fileIO == nil {
-		fileIO = NewDefaultFileIO(DefaultToFilePath)
+		fileIO = NewDefaultFileIO()
 	}
 	return &blobStoreWithEC{
 		fileIO:                      fileIO,

--- a/fs/blob_store_with_ec.go
+++ b/fs/blob_store_with_ec.go
@@ -17,7 +17,7 @@ const (
 // BlobStore has no caching built in because blobs are huge, caller code can apply caching on top of it.
 type blobStoreWithEC struct {
 	fileIO                      FileIO
-	toFilePath  ToFilePathFunc
+	toFilePath                  ToFilePathFunc
 	erasure                     map[string]*erasure.Erasure
 	baseFolderPathsAcrossDrives map[string][]string
 	repairCorruptedShards       bool
@@ -71,7 +71,7 @@ func NewBlobStoreWithEC(toFilePath ToFilePathFunc, fileIO FileIO, erasureConfig 
 	}
 	return &blobStoreWithEC{
 		fileIO:                      fileIO,
-		toFilePath: toFilePath,
+		toFilePath:                  toFilePath,
 		erasure:                     e,
 		baseFolderPathsAcrossDrives: baseFolderPathsAcrossDrives,
 		repairCorruptedShards:       repairCorruptedShards,

--- a/fs/file_io.go
+++ b/fs/file_io.go
@@ -2,8 +2,6 @@ package fs
 
 import (
 	"os"
-
-	"github.com/SharedCode/sop"
 )
 
 // Functions for File I/O defaults to "os" file I/O functions.
@@ -19,17 +17,10 @@ type FileIO interface {
 }
 
 type DefaultFileIO struct {
-	toFilePath ToFilePathFunc
 }
 
-func NewDefaultFileIO(toFilePath ToFilePathFunc) FileIO {
-	return &DefaultFileIO{
-		toFilePath: toFilePath,
-	}
-}
-
-func (dio DefaultFileIO) ToFilePath(basePath string, id sop.UUID) string {
-	return dio.toFilePath(basePath, id)
+func NewDefaultFileIO() FileIO {
+	return &DefaultFileIO{}
 }
 
 func (dio DefaultFileIO) WriteFile(name string, data []byte, perm os.FileMode) error {

--- a/fs/file_io_with_replication.go
+++ b/fs/file_io_with_replication.go
@@ -19,7 +19,7 @@ type fileIO struct {
 var FileIOSim FileIO
 
 func newFileIOWithReplication(replicationTracker *replicationTracker, manageStore sop.ManageStore, trackActions bool) *fileIO {
-	fio := NewDefaultFileIO(nil)
+	fio := NewDefaultFileIO()
 
 	// Allow unit test to inject unit test "fake" for File IO.
 	if FileIOSim != nil {

--- a/fs/hashmap.go
+++ b/fs/hashmap.go
@@ -41,7 +41,6 @@ func (fr *fileRegionDetails) getOffset() int64 {
 }
 
 const (
-	fullPermission         = 0644
 	handlesPerBlock        = 66
 	preallocateFileLockKey = "infs_reg"
 	// Growing the file needs more time to complete.
@@ -124,7 +123,7 @@ func (hm *hashmap) findOneFileRegion(ctx context.Context, forWriting bool, filen
 				if !hm.readWrite {
 					flag = os.O_RDONLY
 				}
-				if err := dio.Open(fn, flag, fullPermission); err != nil {
+				if err := dio.Open(fn, flag, permission); err != nil {
 					return result, err
 				}
 				dio.filename = segmentFilename
@@ -298,7 +297,7 @@ func (hm *hashmap) setupNewFile(ctx context.Context, forWriting bool, filename s
 		return result, err
 	}
 
-	if err := dio.Open(filename, flag, fullPermission); err != nil {
+	if err := dio.Open(filename, flag, permission); err != nil {
 		hm.cache.Unlock(ctx, lk)
 		return result, err
 	}

--- a/fs/replication_tracker.go
+++ b/fs/replication_tracker.go
@@ -12,8 +12,8 @@ import (
 )
 
 type replicationStatus struct {
-	IsInDeltaSync       bool
-	FailedToReplicate   bool
+	IsInDeltaSync     bool
+	FailedToReplicate bool
 }
 
 type replicationTracker struct {
@@ -26,12 +26,12 @@ type replicationTracker struct {
 	replicationStatus   replicationStatus
 }
 
-const(
+const (
 	replicationStatusFilename = "repl_stat.txt"
 )
 
 var globalReplicationTracker *replicationTracker
-var	globalReplicationTrackerLocker sync.Mutex = sync.Mutex{}
+var globalReplicationTrackerLocker sync.Mutex = sync.Mutex{}
 
 // Instantiates a replication tracker.
 func NewReplicationTracker(storesBaseFolders []string, replicate bool) (*replicationTracker, error) {
@@ -75,7 +75,7 @@ func NewReplicationTracker(storesBaseFolders []string, replicate bool) (*replica
 
 // Handle replication related error is invoked from a transaction when an IO error is encountered.
 // This function should handle the act of failing over to the passive destinations making them as active and the actives to be passives.
-func (r *replicationTracker)HandleReplicationRelatedError(ioError error, rollbackSucceeded bool) {
+func (r *replicationTracker) HandleReplicationRelatedError(ioError error, rollbackSucceeded bool) {
 	if !r.replicate {
 		return
 	}
@@ -201,7 +201,7 @@ func (r *replicationTracker) readStatusFromHomeFolder() error {
 	return r.readReplicationStatus(r.formatActiveFolderEntity(replicationStatusFilename))
 }
 
-func (r *replicationTracker)writeReplicationStatus(filename string) error {
+func (r *replicationTracker) writeReplicationStatus(filename string) error {
 	fio := NewDefaultFileIO()
 	ba, _ := encoding.DefaultMarshaler.Marshal(r.replicationStatus)
 	if err := fio.WriteFile(filename, ba, permission); err != nil {
@@ -211,7 +211,7 @@ func (r *replicationTracker)writeReplicationStatus(filename string) error {
 	return nil
 }
 
-func (r *replicationTracker)readReplicationStatus(filename string) error {
+func (r *replicationTracker) readReplicationStatus(filename string) error {
 	fio := NewDefaultFileIO()
 	// Read the delta sync status.
 	ba, err := fio.ReadFile(filename)

--- a/fs/store_repository.go
+++ b/fs/store_repository.go
@@ -37,13 +37,13 @@ func NewStoreRepository(rt *replicationTracker, manageStore sop.ManageStore, cac
 		return nil, fmt.Errorf("'storesBaseFolders' needs to be exactly two elements if 'replicate' parameter is true")
 	}
 	if manageStore == nil {
-		fio := NewDefaultFileIO(DefaultToFilePath)
+		fio := NewDefaultFileIO()
 		manageStore = NewManageStoreFolder(fio)
 	}
 	return &StoreRepository{
 		cache:              cache,
 		manageStore:        manageStore,
-		fileIO:             NewDefaultFileIO(DefaultToFilePath),
+		fileIO:             NewDefaultFileIO(),
 		replicationTracker: rt,
 	}, nil
 }

--- a/in_memory/instantiate_btree.go
+++ b/in_memory/instantiate_btree.go
@@ -20,7 +20,14 @@ const itemsPerNode = 8
 // NewBtree will create an in-memory B-Tree & its required data stores. You can use it to store
 // and access key/value pairs similar to a map but which, sorts items & allows "range queries".
 func NewBtree[TK btree.Ordered, TV any](isUnique bool) BtreeInterface[TK, TV] {
-	s := sop.NewStoreInfo("", itemsPerNode, isUnique, true, true, "")
+	so := sop.StoreOptions{
+		Name: "",
+		SlotLength: itemsPerNode,
+		IsUnique: isUnique,
+		IsValueDataInNodeSegment: true,
+		IsValueDataActivelyPersisted: true,
+	}
+	s := sop.NewStoreInfo(so)
 	si := btree.StoreInterface[TK, TV]{
 		NodeRepository:    newNodeRepository[TK, TV](),
 		ItemActionTracker: newDumbItemActionTracker[TK, TV](),

--- a/in_memory/instantiate_btree.go
+++ b/in_memory/instantiate_btree.go
@@ -21,10 +21,10 @@ const itemsPerNode = 8
 // and access key/value pairs similar to a map but which, sorts items & allows "range queries".
 func NewBtree[TK btree.Ordered, TV any](isUnique bool) BtreeInterface[TK, TV] {
 	so := sop.StoreOptions{
-		Name: "",
-		SlotLength: itemsPerNode,
-		IsUnique: isUnique,
-		IsValueDataInNodeSegment: true,
+		Name:                         "",
+		SlotLength:                   itemsPerNode,
+		IsUnique:                     isUnique,
+		IsValueDataInNodeSegment:     true,
 		IsValueDataActivelyPersisted: true,
 	}
 	s := sop.NewStoreInfo(so)

--- a/in_red_cfs/transaction.go
+++ b/in_red_cfs/transaction.go
@@ -21,7 +21,7 @@ func NewTransaction(mode sop.TransactionMode, maxTime time.Duration, logging boo
 //
 // See SOP FileSystem(sop/fs) package's DefaultToFilePath function for an example how to implement one.
 func NewTransactionExt(toFilePath fs.ToFilePathFunc, mode sop.TransactionMode, maxTime time.Duration, logging bool) (sop.Transaction, error) {
-	fio := fs.NewDefaultFileIO(toFilePath)
+	fio := fs.NewDefaultFileIO()
 	bs := fs.NewBlobStore(fs.DefaultToFilePath, fio)
 	mbsf := fs.NewManageStoreFolder(fio)
 	twoPT, err := in_red_ck.NewTwoPhaseCommitTransaction(mode, maxTime, logging, bs, cas.NewStoreRepository(mbsf))
@@ -39,7 +39,7 @@ func NewTransactionWithEC(mode sop.TransactionMode, maxTime time.Duration, loggi
 			return nil, fmt.Errorf("erasureConfig can't be nil")
 		}
 	}
-	fio := fs.NewDefaultFileIO(fs.DefaultToFilePath)
+	fio := fs.NewDefaultFileIO()
 	bs, err := fs.NewBlobStoreWithEC(fs.DefaultToFilePath, fio, erasureConfig)
 	if err != nil {
 		return nil, err

--- a/in_red_ck/try_in_docker/main.go
+++ b/in_red_ck/try_in_docker/main.go
@@ -26,7 +26,14 @@ func main() {
 	if err := in_red_ck.Initialize(cassConfig, redisConfig); err != nil {
 		writeAndExit(err.Error())
 	}
-	storeInfo := *sop.NewStoreInfo("foobar", 4, true, true, true, "")
+	so := sop.StoreOptions{
+		Name: "foobar",
+		SlotLength: 4,
+		IsValueDataInNodeSegment: true,
+		IsValueDataActivelyPersisted: true,
+		IsValueDataGloballyCached: true,
+	}
+	storeInfo := *sop.NewStoreInfo(so)
 	storeInfo.RootNodeID = sop.NewUUID()
 	repo := cas.NewStoreRepository(nil)
 	sis, err := repo.Get(ctx, "foobar")

--- a/in_red_ck/try_in_docker/main.go
+++ b/in_red_ck/try_in_docker/main.go
@@ -27,11 +27,11 @@ func main() {
 		writeAndExit(err.Error())
 	}
 	so := sop.StoreOptions{
-		Name: "foobar",
-		SlotLength: 4,
-		IsValueDataInNodeSegment: true,
+		Name:                         "foobar",
+		SlotLength:                   4,
+		IsValueDataInNodeSegment:     true,
 		IsValueDataActivelyPersisted: true,
-		IsValueDataGloballyCached: true,
+		IsValueDataGloballyCached:    true,
 	}
 	storeInfo := *sop.NewStoreInfo(so)
 	storeInfo.RootNodeID = sop.NewUUID()

--- a/in_red_fs/transaction.go
+++ b/in_red_fs/transaction.go
@@ -70,7 +70,7 @@ func NewTwoPhaseCommitTransactionWithReplication(towr TransationOptionsWithRepli
 	}
 	bs, err := fs.NewBlobStoreWithEC(fs.DefaultToFilePath, fio, towr.ErasureConfig)
 	if err != nil {
-		return nil, err 
+		return nil, err
 	}
 	mbsf := fs.NewManageStoreFolder(fio)
 	if towr.Cache == nil {

--- a/in_red_fs/transaction.go
+++ b/in_red_fs/transaction.go
@@ -27,7 +27,7 @@ func NewTwoPhaseCommitTransaction(to TransationOptions) (sop.TwoPhaseCommitTrans
 	if to.Cache == nil {
 		to.Cache = redis.NewClient()
 	}
-	fio := fs.NewDefaultFileIO(fs.DefaultToFilePath)
+	fio := fs.NewDefaultFileIO()
 	replicationTracker, err := fs.NewReplicationTracker([]string{to.StoresBaseFolder}, false)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func NewTwoPhaseCommitTransactionWithReplication(towr TransationOptionsWithRepli
 			return nil, fmt.Errorf("erasureConfig can't be nil")
 		}
 	}
-	fio := fs.NewDefaultFileIO(fs.DefaultToFilePath)
+	fio := fs.NewDefaultFileIO()
 	replicationTracker, err := fs.NewReplicationTracker(towr.StoresBaseFolders, true)
 	if err != nil {
 		return nil, err

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -125,7 +125,7 @@ func (c client) SetStruct(ctx context.Context, key string, value interface{}, ex
 	}
 
 	// serialize User object to JSON
-	ba, err := encoding.BlobMarshaler.Marshal(value)
+	ba, err := encoding.DefaultMarshaler.Marshal(value)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func (c client) GetStruct(ctx context.Context, key string, target interface{}) (
 	}
 	ba, err := c.conn.Client.Get(ctx, key).Bytes()
 	if err == nil {
-		err = encoding.BlobMarshaler.Unmarshal(ba, target)
+		err = encoding.DefaultMarshaler.Unmarshal(ba, target)
 	}
 
 	// Convert key not found into returning false and nil err.
@@ -163,7 +163,7 @@ func (c client) GetStructEx(ctx context.Context, key string, target interface{},
 	}
 	ba, err := c.conn.Client.GetEx(ctx, key, expiration).Bytes()
 	if err == nil {
-		err = encoding.BlobMarshaler.Unmarshal(ba, target)
+		err = encoding.DefaultMarshaler.Unmarshal(ba, target)
 	}
 
 	// Convert key not found into returning false and nil err.


### PR DESCRIPTION
Also refactored the StoreOptions' usage made it first class to allow simple control of blobStore & registry table (or file) names.