### PR TITLE
in_red_fs: Refactors to allow code to flow the error via trans.Rollback(..) so it can get handled

### DIFF
--- a/btree/btree_with_transaction.go
+++ b/btree/btree_with_transaction.go
@@ -41,12 +41,12 @@ func (b3 *btreeWithTransaction[TK, TV]) Add(ctx context.Context, key TK, value T
 		return false, errTransHasNotBegunMsg
 	}
 	if b3.transaction.GetMode() != sop.ForWriting {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, fmt.Errorf("can't add item, transaction is not for writing")
 	}
 	r, err := b3.BtreeInterface.Add(ctx, key, value)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -59,12 +59,12 @@ func (b3 *btreeWithTransaction[TK, TV]) AddIfNotExist(ctx context.Context, key T
 		return false, errTransHasNotBegunMsg
 	}
 	if b3.transaction.GetMode() != sop.ForWriting {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, fmt.Errorf("can't add item, transaction is not for writing")
 	}
 	r, err := b3.BtreeInterface.AddIfNotExist(ctx, key, value)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -75,12 +75,12 @@ func (b3 *btreeWithTransaction[TK, TV]) Upsert(ctx context.Context, key TK, valu
 		return false, errTransHasNotBegunMsg
 	}
 	if b3.transaction.GetMode() != sop.ForWriting {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, fmt.Errorf("can't update item, transaction is not for writing")
 	}
 	r, err := b3.BtreeInterface.Upsert(ctx, key, value)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -91,12 +91,12 @@ func (b3 *btreeWithTransaction[TK, TV]) Update(ctx context.Context, key TK, valu
 		return false, errTransHasNotBegunMsg
 	}
 	if b3.transaction.GetMode() != sop.ForWriting {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, fmt.Errorf("can't update item, transaction is not for writing")
 	}
 	r, err := b3.BtreeInterface.Update(ctx, key, value)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -108,12 +108,12 @@ func (b3 *btreeWithTransaction[TK, TV]) UpdateCurrentItem(ctx context.Context, v
 		return false, errTransHasNotBegunMsg
 	}
 	if b3.transaction.GetMode() != sop.ForWriting {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, fmt.Errorf("can't update item, transaction is not for writing")
 	}
 	r, err := b3.BtreeInterface.UpdateCurrentItem(ctx, value)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -124,12 +124,12 @@ func (b3 *btreeWithTransaction[TK, TV]) Remove(ctx context.Context, key TK) (boo
 		return false, errTransHasNotBegunMsg
 	}
 	if b3.transaction.GetMode() != sop.ForWriting {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, fmt.Errorf("can't update item, transaction is not for writing")
 	}
 	r, err := b3.BtreeInterface.Remove(ctx, key)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -140,12 +140,12 @@ func (b3 *btreeWithTransaction[TK, TV]) RemoveCurrentItem(ctx context.Context) (
 		return false, errTransHasNotBegunMsg
 	}
 	if b3.transaction.GetMode() != sop.ForWriting {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, fmt.Errorf("can't remove item, transaction is not for writing")
 	}
 	r, err := b3.BtreeInterface.RemoveCurrentItem(ctx)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -157,23 +157,23 @@ func (b3 *btreeWithTransaction[TK, TV]) RemoveCurrentItem(ctx context.Context) (
 // Use the CurrentKey/CurrentValue to retrieve the "current item" details(key &/or value).
 func (b3 *btreeWithTransaction[TK, TV]) FindOne(ctx context.Context, key TK, firstItemWithKey bool) (bool, error) {
 	if !b3.transaction.HasBegun() {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, errTransHasNotBegunMsg
 	}
 	r, err := b3.BtreeInterface.FindOne(ctx, key, firstItemWithKey)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
 func (b3 *btreeWithTransaction[TK, TV]) FindOneWithID(ctx context.Context, key TK, id sop.UUID) (bool, error) {
 	if !b3.transaction.HasBegun() {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, errTransHasNotBegunMsg
 	}
 	r, err := b3.BtreeInterface.FindOneWithID(ctx, key, id)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -191,12 +191,12 @@ func (b3 *btreeWithTransaction[TK, TV]) GetCurrentKey() TK {
 func (b3 *btreeWithTransaction[TK, TV]) GetCurrentValue(ctx context.Context) (TV, error) {
 	var zero TV
 	if !b3.transaction.HasBegun() {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return zero, errTransHasNotBegunMsg
 	}
 	v, err := b3.BtreeInterface.GetCurrentValue(ctx)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return v, err
 }
@@ -205,12 +205,12 @@ func (b3 *btreeWithTransaction[TK, TV]) GetCurrentValue(ctx context.Context) (TV
 func (b3 *btreeWithTransaction[TK, TV]) GetCurrentItem(ctx context.Context) (Item[TK, TV], error) {
 	var zero Item[TK, TV]
 	if !b3.transaction.HasBegun() {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return zero, errTransHasNotBegunMsg
 	}
 	r, err := b3.BtreeInterface.GetCurrentItem(ctx)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -219,12 +219,12 @@ func (b3 *btreeWithTransaction[TK, TV]) GetCurrentItem(ctx context.Context) (Ite
 // Use the CurrentKey/CurrentValue to retrieve the "current item" details(key &/or value).
 func (b3 *btreeWithTransaction[TK, TV]) First(ctx context.Context) (bool, error) {
 	if !b3.transaction.HasBegun() {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, errTransHasNotBegunMsg
 	}
 	r, err := b3.BtreeInterface.First(ctx)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -233,12 +233,12 @@ func (b3 *btreeWithTransaction[TK, TV]) First(ctx context.Context) (bool, error)
 // Use the CurrentKey/CurrentValue to retrieve the "current item" details(key &/or value).
 func (b3 *btreeWithTransaction[TK, TV]) Last(ctx context.Context) (bool, error) {
 	if !b3.transaction.HasBegun() {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, errTransHasNotBegunMsg
 	}
 	r, err := b3.BtreeInterface.Last(ctx)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -247,12 +247,12 @@ func (b3 *btreeWithTransaction[TK, TV]) Last(ctx context.Context) (bool, error) 
 // Use the CurrentKey/CurrentValue to retrieve the "current item" details(key &/or value).
 func (b3 *btreeWithTransaction[TK, TV]) Next(ctx context.Context) (bool, error) {
 	if !b3.transaction.HasBegun() {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, errTransHasNotBegunMsg
 	}
 	r, err := b3.BtreeInterface.Next(ctx)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }
@@ -261,12 +261,12 @@ func (b3 *btreeWithTransaction[TK, TV]) Next(ctx context.Context) (bool, error) 
 // Use the CurrentKey/CurrentValue to retrieve the "current item" details(key &/or value).
 func (b3 *btreeWithTransaction[TK, TV]) Previous(ctx context.Context) (bool, error) {
 	if !b3.transaction.HasBegun() {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, nil)
 		return false, errTransHasNotBegunMsg
 	}
 	r, err := b3.BtreeInterface.Previous(ctx)
 	if err != nil {
-		b3.transaction.Rollback(ctx)
+		b3.transaction.Rollback(ctx, err)
 	}
 	return r, err
 }

--- a/common/basic_test.go
+++ b/common/basic_test.go
@@ -153,7 +153,7 @@ func Test_UniqueKeyBTreeOnMultipleCommits(t *testing.T) {
 func Test_StoreCachingMinRuleCheck(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	trans.Begin()
 	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{
@@ -184,7 +184,7 @@ func Test_StoreCachingMinRuleCheck(t *testing.T) {
 func Test_StoreCachingDefaultCacheApplied(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	trans.Begin()
 	b3, _ := NewBtree[int, string](ctx, sop.StoreOptions{

--- a/common/two_phase_commit_test.go
+++ b/common/two_phase_commit_test.go
@@ -29,7 +29,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
 		if err2 := my3rdPartyDBlogic(true); err2 != nil {
-			twoPhase.Rollback(ctx)
+			twoPhase.Rollback(ctx, err2)
 			return
 		}
 		t.Error("Should not go here.")
@@ -111,7 +111,7 @@ func Test_TwoPhaseCommitRolledbackThenCommitted(t *testing.T) {
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
 		// Call 3rd party DB integration, failure.
 		if err2 := my3rdPartyDBlogic(true); err2 != nil {
-			twoPhase.Rollback(ctx)
+			twoPhase.Rollback(ctx, err2)
 
 			t1, _ = newMockTransaction(t, sop.ForWriting, -1)
 			t1.Begin()

--- a/fs/registry_map.go
+++ b/fs/registry_map.go
@@ -80,7 +80,7 @@ func (rm registryMap) fetch(ctx context.Context, keys ...sop.Tuple[string, []sop
 	for _, k := range keys {
 		handles, err := rm.hashmap.fetch(ctx, k.First, k.Second)
 		if err != nil {
-			return nil, fmt.Errorf("registryMap.get failed, details: %v", err)
+			return nil,  fmt.Errorf("registryMap.fetch failed, details: %w", err)
 		}
 		result = append(result, sop.Tuple[string, []sop.Handle]{
 			First:  k.First,

--- a/fs/store_repository.go
+++ b/fs/store_repository.go
@@ -174,7 +174,7 @@ func (sr *StoreRepository) Update(ctx context.Context, stores []sop.StoreInfo) (
 		return nil, err
 	}
 
-	storeWriter := newFileIOWithReplication(sr.replicationTracker, sr.manageStore, false)
+	storeWriter := newFileIOWithReplication(sr.replicationTracker, sr.manageStore, true)
 
 	undo := func(endIndex int, original []sop.StoreInfo) {
 		// Attempt to undo changes, 'ignores error as it is a last attempt to cleanup.

--- a/in_red_cfs/integration_tests/transaction_test.go
+++ b/in_red_cfs/integration_tests/transaction_test.go
@@ -418,7 +418,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	twoPhase := t1.GetPhasedTransaction()
 
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
-		if err = twoPhase.Rollback(ctx); err != nil {
+		if err = twoPhase.Rollback(ctx, nil); err != nil {
 			t.Errorf("Rollback error: %v", err)
 		}
 

--- a/in_red_cfs/integration_tests/value_data_segment/transaction_test.go
+++ b/in_red_cfs/integration_tests/value_data_segment/transaction_test.go
@@ -409,7 +409,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	twoPhase := t1.GetPhasedTransaction()
 
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
-		twoPhase.Rollback(ctx)
+		twoPhase.Rollback(ctx, nil)
 
 		t1, _ = in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 		t1.Begin()

--- a/in_red_ck/integration_tests/transaction_test.go
+++ b/in_red_ck/integration_tests/transaction_test.go
@@ -441,7 +441,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	twoPhase := t1.GetPhasedTransaction()
 
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
-		twoPhase.Rollback(ctx)
+		twoPhase.Rollback(ctx, nil)
 
 		t1, _ = in_red_ck.NewTransaction(sop.ForWriting, -1, false)
 		t1.Begin()

--- a/in_red_ck/integration_tests/value_data_segment/transaction_test.go
+++ b/in_red_ck/integration_tests/value_data_segment/transaction_test.go
@@ -438,7 +438,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	twoPhase := t1.GetPhasedTransaction()
 
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
-		twoPhase.Rollback(ctx)
+		twoPhase.Rollback(ctx, nil)
 
 		t1, _ = in_red_ck.NewTransaction(sop.ForWriting, -1, false)
 		t1.Begin()

--- a/in_red_cs3/integration_tests/transaction_test.go
+++ b/in_red_cs3/integration_tests/transaction_test.go
@@ -441,7 +441,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	twoPhase := t1.GetPhasedTransaction()
 
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
-		if err = twoPhase.Rollback(ctx); err != nil {
+		if err = twoPhase.Rollback(ctx, nil); err != nil {
 			t.Errorf("Rollback error: %v", err)
 		}
 

--- a/in_red_cs3/integration_tests/value_data_segment/transaction_test.go
+++ b/in_red_cs3/integration_tests/value_data_segment/transaction_test.go
@@ -438,7 +438,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	twoPhase := t1.GetPhasedTransaction()
 
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
-		twoPhase.Rollback(ctx)
+		twoPhase.Rollback(ctx, nil)
 
 		t1, _ = in_red_cs3.NewTransaction(s3Client, sop.ForWriting, -1, false, region)
 		t1.Begin()

--- a/in_red_fs/integration_tests/transaction_test.go
+++ b/in_red_fs/integration_tests/transaction_test.go
@@ -554,7 +554,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	twoPhase := t1.GetPhasedTransaction()
 
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
-		if err = twoPhase.Rollback(ctx); err != nil {
+		if err = twoPhase.Rollback(ctx, nil); err != nil {
 			t.Errorf("Rollback error: %v", err)
 		}
 

--- a/in_red_fs/integration_tests/value_data_segment/transaction_test.go
+++ b/in_red_fs/integration_tests/value_data_segment/transaction_test.go
@@ -405,7 +405,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	twoPhase := t1.GetPhasedTransaction()
 
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
-		twoPhase.Rollback(ctx)
+		twoPhase.Rollback(ctx, nil)
 
 		t1, _ = in_red_fs.NewTransaction(to)
 		t1.Begin()

--- a/in_red_fs/manage_btree.go
+++ b/in_red_fs/manage_btree.go
@@ -48,6 +48,11 @@ func OpenBtree[TK btree.Ordered, TV any](ctx context.Context, name string, t sop
 // and the parameters checked if matching. If you know that it exists, then it is more convenient and more readable to call
 // the OpenBtree function.
 func NewBtree[TK btree.Ordered, TV any](ctx context.Context, si sop.StoreOptions, t sop.Transaction, comparer btree.ComparerFunc[TK]) (btree.BtreeInterface[TK, TV], error) {
+	if ct, ok := t.GetPhasedTransaction().(*common.Transaction); ok {
+		if ct.HandleReplicationRelatedError != nil {
+			return nil, fmt.Errorf("failed in NewBtree as transaction has replication enabled, use NewBtreeWithReplication instead")
+		}
+	}
 	si.DisableRegistryStoreFormatting = true
 	trans, _ := t.GetPhasedTransaction().(*common.Transaction)
 	sr := trans.GetStoreRepository().(*fs.StoreRepository)

--- a/in_red_fs/transaction.go
+++ b/in_red_fs/transaction.go
@@ -41,7 +41,6 @@ func NewTwoPhaseCommitTransaction(to TransationOptions) (sop.TwoPhaseCommitTrans
 	t, err := common.NewTwoPhaseCommitTransaction(to.Mode, to.MaxTime, true,
 		fs.NewBlobStore(fs.DefaultToFilePath, nil), sr, fs.NewRegistry(to.Mode == sop.ForWriting,
 			to.RegistryHashModValue, replicationTracker, to.Cache), to.Cache, tl)
-	t.HandleReplicationRelatedError = replicationTracker.HandleReplicationRelatedError
 	return t, err
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -58,7 +58,8 @@ type TwoPhaseCommitTransaction interface {
 	// Phase2Commit of the transaction.
 	Phase2Commit(ctx context.Context) error
 	// Rollback the transaction.
-	Rollback(ctx context.Context) error
+	// Gives option to flow the error (if there is) that caused rollback to be invoked.
+	Rollback(ctx context.Context, err error) error
 	// Returns true if transaction has begun, false otherwise.
 	HasBegun() bool
 	// Returns the Transaction mode, it can be for reading or for writing.
@@ -154,10 +155,10 @@ func (t *singlePhaseTransaction) Commit(ctx context.Context) error {
 // Rollback the transaction. If multiple transaction rollbacks errored,
 // this will return the last error.
 func (t *singlePhaseTransaction) Rollback(ctx context.Context) error {
-	t.sopPhaseCommitTransaction.Rollback(ctx)
+	t.sopPhaseCommitTransaction.Rollback(ctx, nil)
 	var lastErr error
 	for _, ot := range t.otherTransactions {
-		if err := ot.Rollback(ctx); err != nil {
+		if err := ot.Rollback(ctx, nil); err != nil {
 			lastErr = err
 		}
 	}


### PR DESCRIPTION
if it is appropriate to trigger a failover to passive.