### PR TITLE
in_red_fs: replication tracker is now capable of using l2 cache (redi…

### DIFF
--- a/cache/l1_cache.go
+++ b/cache/l1_cache.go
@@ -37,7 +37,7 @@ const (
 var Global *L1Cache
 
 // Instantiate the global cache.
-func CreateGlobalCache(l2CacheNodes sop.Cache, minCapacity, maxCapacity int) *L1Cache {
+func NewGlobalCache(l2CacheNodes sop.Cache, minCapacity, maxCapacity int) *L1Cache {
 	if Global == nil || Global.mru.minCapacity != minCapacity || Global.mru.maxCapacity != maxCapacity {
 		Global = NewL1Cache(l2CacheNodes, minCapacity, maxCapacity)
 	}
@@ -48,7 +48,7 @@ func CreateGlobalCache(l2CacheNodes sop.Cache, minCapacity, maxCapacity int) *L1
 func GetGlobalCache() *L1Cache {
 	if Global == nil {
 		c := redis.NewClient()
-		CreateGlobalCache(c, DefaultMinCapacity, DefaultMaxCapacity)
+		NewGlobalCache(c, DefaultMinCapacity, DefaultMaxCapacity)
 	}
 	return Global
 }

--- a/common/basic_test.go
+++ b/common/basic_test.go
@@ -2,11 +2,21 @@ package common
 
 import (
 	"cmp"
+	"os"
 	"testing"
 	"time"
 
+	log "log/slog"
+
 	"github.com/SharedCode/sop"
 )
+
+func init() {
+	l := log.New(log.NewJSONHandler(os.Stdout, &log.HandlerOptions{
+		Level: log.LevelDebug,
+	}))
+	log.SetDefault(l) // configures log package to print with LevelInfo
+}
 
 func Test_OpenVsNewBTree(t *testing.T) {
 	trans, _ := newMockTransaction(t, sop.ForWriting, -1)

--- a/common/btree_with_transaction_test.go
+++ b/common/btree_with_transaction_test.go
@@ -14,7 +14,7 @@ var ctx = context.Background()
 func Test_TransactionInducedErrorOnNew(t *testing.T) {
 	t2, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	t2.Begin()
 	var t3 interface{} = t2.GetPhasedTransaction()
@@ -49,7 +49,7 @@ func Test_TransactionInducedErrorOnNew(t *testing.T) {
 func Test_TransactionInducedErrorOnOpen(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	trans.Begin()
 	OpenBtree[int, string](ctx, "fooStore33", trans, cmp.Compare)

--- a/common/transaction_edge_cases_test.go
+++ b/common/transaction_edge_cases_test.go
@@ -437,10 +437,10 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		t.Errorf("T1 & T2 Commits got 2 success, want 1 fail.")
 	}
 	if err1 != nil {
-		t.Logf(err1.Error())
+		t.Log(err1.Error())
 	}
 	if err2 != nil {
-		t.Logf(err2.Error())
+		t.Log(err2.Error())
 	}
 }
 

--- a/common/transaction_test.go
+++ b/common/transaction_test.go
@@ -86,7 +86,7 @@ func Test_Rollback(t *testing.T) {
 func Test_SimpleAddPerson(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	trans.Begin()
 
@@ -133,7 +133,7 @@ func Test_SimpleAddPerson(t *testing.T) {
 func Test_NoCheckCommitAddFail(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.NoCheck, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	trans.Begin()
 
@@ -156,7 +156,7 @@ func Test_NoCheckCommitAddFail(t *testing.T) {
 func Test_NoCheckCommit(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	trans.Begin()
 
@@ -178,7 +178,7 @@ func Test_NoCheckCommit(t *testing.T) {
 
 	trans, err = newMockTransaction(t, sop.NoCheck, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	trans.Begin()
 
@@ -191,7 +191,7 @@ func Test_NoCheckCommit(t *testing.T) {
 func Test_TwoTransactionsWithNoConflict(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	trans2, _ := newMockTransaction(t, sop.ForWriting, -1)
@@ -247,7 +247,7 @@ func Test_TwoTransactionsWithNoConflict(t *testing.T) {
 func Test_AddAndSearchManyPersons(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	trans.Begin()
@@ -276,20 +276,20 @@ func Test_AddAndSearchManyPersons(t *testing.T) {
 		}
 	}
 	if err := trans.Commit(ctx); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 		t.Fail()
 		return
 	}
 
 	trans, err = newMockTransaction(t, sop.ForReading, -1)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 		t.Fail()
 		return
 	}
 
 	if err := trans.Begin(); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 		t.Fail()
 		return
 	}

--- a/common/two_phase_commit_transaction.go
+++ b/common/two_phase_commit_transaction.go
@@ -49,7 +49,7 @@ type Transaction struct {
 	logger    *transactionLog
 
 	// Handle replication related error.
-	HandleReplicationRelatedError func(ioError error, rollbackSucceeded bool)
+	HandleReplicationRelatedError func(ctx context.Context, ioError error, rollbackSucceeded bool)
 
 	// Phase 1 commit generated objects required for phase 2 commit.
 	updatedNodeHandles []sop.RegistryPayload[sop.Handle]
@@ -140,7 +140,7 @@ func (t *Transaction) Phase1Commit(ctx context.Context) error {
 
 		// Allow replication handler to handle error related to replication, e.g. IO error.
 		if t.HandleReplicationRelatedError != nil {
-			t.HandleReplicationRelatedError(err, rerr == nil)
+			t.HandleReplicationRelatedError(ctx, err, rerr == nil)
 		}
 
 		if rerr != nil {
@@ -174,7 +174,7 @@ func (t *Transaction) Phase2Commit(ctx context.Context) error {
 
 		// Allow replication handler to handle error related to replication, e.g. IO error.
 		if t.HandleReplicationRelatedError != nil {
-			t.HandleReplicationRelatedError(err, rerr == nil)
+			t.HandleReplicationRelatedError(ctx, err, rerr == nil)
 		}
 
 		if rerr != nil {
@@ -201,7 +201,7 @@ func (t *Transaction) Rollback(ctx context.Context, err error) error {
 
 		// Allow replication handler to handle error related to replication, e.g. IO error.
 		if t.HandleReplicationRelatedError != nil {
-			t.HandleReplicationRelatedError(err, false)
+			t.HandleReplicationRelatedError(ctx, err, false)
 		}
 
 		return fmt.Errorf("rollback failed, details: %w", rerr)
@@ -210,7 +210,7 @@ func (t *Transaction) Rollback(ctx context.Context, err error) error {
 
 	// Allow replication handler to handle error related to replication, e.g. IO error.
 	if t.HandleReplicationRelatedError != nil {
-		t.HandleReplicationRelatedError(err, true)
+		t.HandleReplicationRelatedError(ctx, err, true)
 	}
 
 	return nil

--- a/common/value_data_separate_segment_test.go
+++ b/common/value_data_separate_segment_test.go
@@ -52,7 +52,7 @@ func Test_ValueDataInSeparateSegment_Rollback(t *testing.T) {
 func Test_ValueDataInSeparateSegment_SimpleAddPerson(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	trans.Begin()
 
@@ -100,7 +100,7 @@ func Test_ValueDataInSeparateSegment_SimpleAddPerson(t *testing.T) {
 func Test_ValueDataInSeparateSegment_TwoTransactionsWithNoConflict(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	trans2, _ := newMockTransaction(t, sop.ForWriting, -1)
@@ -158,7 +158,7 @@ func Test_ValueDataInSeparateSegment_TwoTransactionsWithNoConflict(t *testing.T)
 func Test_ValueDataInSeparateSegment_AddAndSearchManyPersons(t *testing.T) {
 	trans, err := newMockTransaction(t, sop.ForWriting, -1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	trans.Begin()
@@ -188,20 +188,20 @@ func Test_ValueDataInSeparateSegment_AddAndSearchManyPersons(t *testing.T) {
 		}
 	}
 	if err := trans.Commit(ctx); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 		t.Fail()
 		return
 	}
 
 	trans, err = newMockTransaction(t, sop.ForReading, -1)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 		t.Fail()
 		return
 	}
 
 	if err := trans.Begin(); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 		t.Fail()
 		return
 	}

--- a/fs/registry_map_test.go
+++ b/fs/registry_map_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 func TestRegistryMapAdd(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
-	r := newRegistryMap(true, hashMod, rt, redis.NewClient())
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
+	r := newRegistryMap(true, hashMod, rt, l2cache)
 
 	h := sop.NewHandle(uuid)
 
@@ -24,8 +25,9 @@ func TestRegistryMapAdd(t *testing.T) {
 }
 
 func TestRegistryMapSet(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
-	r := newRegistryMap(true, hashMod, rt, redis.NewClient())
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
+	r := newRegistryMap(true, hashMod, rt, l2cache)
 
 	h := sop.NewHandle(uuid)
 
@@ -40,7 +42,8 @@ func TestRegistryMapSet(t *testing.T) {
 }
 
 func TestRegistryMapGet(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
 	r := newRegistryMap(true, hashMod, rt, redis.NewClient())
 
 	if res, err := r.fetch(ctx, sop.Tuple[string, []sop.UUID]{
@@ -58,7 +61,8 @@ func TestRegistryMapGet(t *testing.T) {
 }
 
 func TestRegistryMapRemove(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
 	r := newRegistryMap(true, hashMod, rt, redis.NewClient())
 
 	if err := r.remove(ctx, sop.Tuple[string, []sop.UUID]{
@@ -72,7 +76,8 @@ func TestRegistryMapRemove(t *testing.T) {
 }
 
 func TestRegistryMapFailedSet(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
 	r := newRegistryMap(true, hashMod, rt, redis.NewClient())
 
 	h := sop.NewHandle(uuid)
@@ -102,7 +107,8 @@ func TestRegistryMapFailedSet(t *testing.T) {
 }
 
 func TestRegistryMapRecyAddRemoveAdd(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
 	r := newRegistryMap(true, hashMod, rt, redis.NewClient())
 
 	h := sop.NewHandle(uuid)

--- a/fs/registry_test.go
+++ b/fs/registry_test.go
@@ -20,8 +20,9 @@ var uuid, _ = sop.ParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 var hashMod = MinimumModValue
 
 func TestRegistryAddThenRead(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
-	r := NewRegistry(true, hashMod, rt, redis.NewClient())
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
+	r := NewRegistry(true, hashMod, rt, l2cache)
 
 	h := sop.NewHandle(uuid)
 

--- a/fs/replication_tracker.go
+++ b/fs/replication_tracker.go
@@ -1,15 +1,19 @@
 package fs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	log "log/slog"
 
+	"github.com/SharedCode/sop"
 	"github.com/SharedCode/sop/encoding"
+	"github.com/SharedCode/sop/redis"
 )
 
 type replicationStatus struct {
@@ -17,54 +21,75 @@ type replicationStatus struct {
 	FailedToReplicate bool
 }
 
-type replicationTracker struct {
-	// Array so we can use in replication across two folders, if in replication mode.
-	storesBaseFolders []string
+type replicationTrackedDetails struct {
+	replicationStatus
 	// If true, folder as specified in storesBaseFolders[0] will be the active folder,
 	// otherwise the 2nd folder, as specified in storesBaseFolders[1].
-	isFirstFolderActive bool
+	IsFirstFolderActive bool
+}
+func (a replicationTrackedDetails)isEqual(b replicationTrackedDetails) bool {
+	return a.IsInDeltaSync == b.IsInDeltaSync && a.IsFirstFolderActive == b.IsFirstFolderActive && a.FailedToReplicate == b.FailedToReplicate
+}
+
+type replicationTracker struct {
+	replicationTrackedDetails
+	// Array so we can use in replication across two folders, if in replication mode.
+	storesBaseFolders []string
 	replicate           bool
-	replicationStatus   replicationStatus
+	l2Cache            sop.Cache
 }
 
 const (
-	replicationStatusFilename = "repl_stat.txt"
+	replicationStatusFilename = "replstat.txt"
+	replicationStatusCacheKey = "Rreplstat"
+	replicationStatusCacheTTLDuration = 5*time.Minute
 )
 
-var globalReplicationTracker *replicationTracker
-var globalReplicationTrackerLocker sync.Mutex = sync.Mutex{}
+var globalReplicationDetails *replicationTrackedDetails
+var globalReplicationDetailsLocker sync.Mutex = sync.Mutex{}
 
 // Instantiates a replication tracker.
-func NewReplicationTracker(storesBaseFolders []string, replicate bool) (*replicationTracker, error) {
+func NewReplicationTracker(ctx context.Context, storesBaseFolders []string, replicate bool, l2Cache sop.Cache) (*replicationTracker, error) {
+	if l2Cache == nil {
+		l2Cache = redis.NewClient()
+	}
 	isFirstFolderActive := true
 	rt := replicationTracker{
 		storesBaseFolders:   storesBaseFolders,
-		isFirstFolderActive: isFirstFolderActive,
 		replicate:           replicate,
+		l2Cache: l2Cache,
 	}
+	rt.IsFirstFolderActive = isFirstFolderActive
 	if replicate {
+		if err := rt.syncWithL2Cache(ctx, false); err != nil {
+			log.Warn(fmt.Sprintf("error while updating global replication status & L2 cache, details: %v", err))
+		}
 		// Minimize reading the replication "status" if we have read it and is tracking it globally.
-		if globalReplicationTracker != nil {
-			globalReplicationTrackerLocker.Lock()
+		if globalReplicationDetails != nil {
+			globalReplicationDetailsLocker.Lock()
 
-			rt.isFirstFolderActive = globalReplicationTracker.isFirstFolderActive
-			rt.replicationStatus = globalReplicationTracker.replicationStatus
+			rt.IsFirstFolderActive = globalReplicationDetails.IsFirstFolderActive
+			rt.replicationStatus = globalReplicationDetails.replicationStatus
 
-			globalReplicationTrackerLocker.Unlock()
+			globalReplicationDetailsLocker.Unlock()
 		} else {
 			if err := rt.readStatusFromHomeFolder(); err != nil {
 				return nil, fmt.Errorf("failed reading replication status (%sº file, details: %v", replicationStatusFilename, err)
 			}
-			globalReplicationTrackerLocker.Lock()
+			globalReplicationDetailsLocker.Lock()
 
-			globalReplicationTracker = &replicationTracker{
-				isFirstFolderActive: isFirstFolderActive,
-				replicate:           replicate,
+			globalReplicationDetails = &replicationTrackedDetails{
+				IsFirstFolderActive: isFirstFolderActive,
 			}
-			globalReplicationTracker.isFirstFolderActive = rt.isFirstFolderActive
-			globalReplicationTracker.replicationStatus = rt.replicationStatus
+			globalReplicationDetails.IsFirstFolderActive = rt.IsFirstFolderActive
+			globalReplicationDetails.replicationStatus = rt.replicationStatus
 
-			globalReplicationTrackerLocker.Unlock()
+			// Sync l2 cache.
+			if err := rt.syncWithL2Cache(ctx, true); err != nil {
+				log.Warn(fmt.Sprintf("error while updating global replication status & L2 cache, details: %v", err))
+			}
+
+			globalReplicationDetailsLocker.Unlock()
 		}
 	}
 	if rt.replicationStatus.IsInDeltaSync {
@@ -75,7 +100,7 @@ func NewReplicationTracker(storesBaseFolders []string, replicate bool) (*replica
 
 // Handle replication related error is invoked from a transaction when an IO error is encountered.
 // This function should handle the act of failing over to the passive destinations making them as active and the active to be passive.
-func (r *replicationTracker) HandleReplicationRelatedError(ioError error, rollbackSucceeded bool) {
+func (r *replicationTracker) HandleReplicationRelatedError(ctx context.Context, ioError error, rollbackSucceeded bool) {
 	if !r.replicate {
 		return
 	}
@@ -88,41 +113,66 @@ func (r *replicationTracker) HandleReplicationRelatedError(ioError error, rollba
 	if ok1 || ok2 {
 		log.Error(fmt.Sprintf("a replication related error detected (rollback: %v), details: %v", rollbackSucceeded, err1.Error()))
 		// Cause a failover switch to passive destinations on succeeding transactions.
-		if err := r.failover(); err != nil {
+		if err := r.failover(ctx); err != nil {
 			log.Error(fmt.Sprintf("failover to folder %s failed, details: %v", r.getPassiveBaseFolder(), err.Error()))
 		}
 	}
 }
 
-func (r *replicationTracker) handleFailedToReplicate() {
+func (r *replicationTracker) handleFailedToReplicate(ctx context.Context) {
 	if !r.replicate || r.replicationStatus.FailedToReplicate {
 		return
 	}
-	globalReplicationTrackerLocker.Lock()
+
+	if err := r.syncWithL2Cache(ctx, false); err != nil {
+		log.Warn(fmt.Sprintf("error while updating global replication status & L2 cache, details: %v", err))
+	}
+
 	if r.replicationStatus.FailedToReplicate {
-		globalReplicationTrackerLocker.Unlock()
+		return
+	}
+
+	globalReplicationDetailsLocker.Lock()
+
+	if r.replicationStatus.FailedToReplicate {
+		globalReplicationDetailsLocker.Unlock()
 		return
 	}
 
 	r.replicationStatus.FailedToReplicate = true
-	globalReplicationTracker.replicationStatus.FailedToReplicate = true
+	globalReplicationDetails.replicationStatus.FailedToReplicate = true
 	if err := r.writeReplicationStatus(r.formatActiveFolderEntity(replicationStatusFilename)); err != nil {
 		log.Warn(fmt.Sprintf("handleFailedToReplicate writeReplicationStatus failed, details: %v", err))
 	}
 
-	globalReplicationTrackerLocker.Unlock()
+	// Sync l2 cache.
+	if err := r.syncWithL2Cache(ctx, true); err != nil {
+		log.Warn(fmt.Sprintf("error while updating global replication status & L2 cache, details: %v", err))
+	}
+
+	globalReplicationDetailsLocker.Unlock()
 }
 
-func (r *replicationTracker) failover() error {
-	if globalReplicationTracker.isFirstFolderActive == !r.isFirstFolderActive ||
+func (r *replicationTracker) failover(ctx context.Context) error {
+	if globalReplicationDetails.IsFirstFolderActive == !r.IsFirstFolderActive ||
 		r.replicationStatus.FailedToReplicate {
 		// Do nothing if global tracker already knows that a failover already occurred.
 		return nil
 	}
 
-	globalReplicationTrackerLocker.Lock()
-	if globalReplicationTracker.isFirstFolderActive == !r.isFirstFolderActive {
-		globalReplicationTrackerLocker.Unlock()
+	if err := r.syncWithL2Cache(ctx, false); err != nil {
+		log.Warn(fmt.Sprintf("error while updating global replication status & L2 cache, details: %v", err))
+	}
+
+	if globalReplicationDetails.IsFirstFolderActive == !r.IsFirstFolderActive ||
+		r.replicationStatus.FailedToReplicate {
+		// Do nothing if global tracker already knows that a failover already occurred.
+		return nil
+	}
+
+	globalReplicationDetailsLocker.Lock()
+	if globalReplicationDetails.IsFirstFolderActive == !r.IsFirstFolderActive {
+		globalReplicationDetailsLocker.Unlock()
 		// Do nothing if global tracker already knows that a failover already occurred.
 		return nil
 	}
@@ -132,29 +182,34 @@ func (r *replicationTracker) failover() error {
 	r.replicationStatus.FailedToReplicate = true
 
 	if err := r.writeReplicationStatus(r.formatPassiveFolderEntity(replicationStatusFilename)); err != nil {
-		globalReplicationTrackerLocker.Unlock()
+		globalReplicationDetailsLocker.Unlock()
 		return err
 	}
 
 	// Switch the passive into active & vice versa.
-	r.isFirstFolderActive = !r.isFirstFolderActive
-	globalReplicationTracker.isFirstFolderActive = r.isFirstFolderActive
-	globalReplicationTracker.replicationStatus = r.replicationStatus
+	r.IsFirstFolderActive = !r.IsFirstFolderActive
+	globalReplicationDetails.IsFirstFolderActive = r.IsFirstFolderActive
+	globalReplicationDetails.replicationStatus = r.replicationStatus
 
-	globalReplicationTrackerLocker.Unlock()
+	// Sync l2 cache.
+	if err := r.syncWithL2Cache(ctx, true); err != nil {
+		log.Warn(fmt.Sprintf("error while updating global replication status & L2 cache, details: %v", err))
+	}
+
+	globalReplicationDetailsLocker.Unlock()
 
 	log.Info(fmt.Sprintf("failover event occurred, newly active folder is, %s", r.getActiveBaseFolder()))
 	return nil
 }
 
 func (r *replicationTracker) getActiveBaseFolder() string {
-	if r.isFirstFolderActive {
+	if r.IsFirstFolderActive {
 		return r.storesBaseFolders[0]
 	}
 	return r.storesBaseFolders[1]
 }
 func (r *replicationTracker) getPassiveBaseFolder() string {
-	if r.isFirstFolderActive {
+	if r.IsFirstFolderActive {
 		return r.storesBaseFolders[1]
 	}
 	return r.storesBaseFolders[0]
@@ -187,7 +242,7 @@ func (r *replicationTracker) readStatusFromHomeFolder() error {
 		if fio.Exists(r.formatPassiveFolderEntity(replicationStatusFilename)) {
 			if err := r.readReplicationStatus(r.formatPassiveFolderEntity(replicationStatusFilename)); err == nil {
 				// Switch passive to active if we are able to read the delta sync status file.
-				r.isFirstFolderActive = !r.isFirstFolderActive
+				r.IsFirstFolderActive = !r.IsFirstFolderActive
 			}
 		}
 		// No Replication status file in both active & passive folders, we're good with default.
@@ -199,12 +254,12 @@ func (r *replicationTracker) readStatusFromHomeFolder() error {
 		if err != nil {
 			return err
 		}
-		r.isFirstFolderActive = !r.isFirstFolderActive
+		r.IsFirstFolderActive = !r.IsFirstFolderActive
 	} else {
 		stat2, err := os.Stat(r.formatPassiveFolderEntity(replicationStatusFilename))
 		if err == nil {
 			if stat2.ModTime().After(stat.ModTime()) {
-				r.isFirstFolderActive = !r.isFirstFolderActive
+				r.IsFirstFolderActive = !r.IsFirstFolderActive
 			}
 		}
 	}
@@ -231,5 +286,49 @@ func (r *replicationTracker) readReplicationStatus(filename string) error {
 	if err = encoding.DefaultMarshaler.Unmarshal(ba, &r.replicationStatus); err != nil {
 		return err
 	}
+	return nil
+}
+
+// Sync global and this replication trackers with the L2 cache record.
+func (r *replicationTracker)syncWithL2Cache(ctx context.Context, pushValue bool) error {
+
+	var rtd replicationTrackedDetails
+	// Update L2 cache of new value in global status.
+	if pushValue {
+		// When stable, perhaps we just issue a SetStruct here to sync L2 cache.
+		if found, err := r.l2Cache.GetStructEx(ctx, replicationStatusCacheKey, &rtd, replicationStatusCacheTTLDuration); err != nil {
+			return err
+		} else if !found {
+			if err := r.l2Cache.SetStruct(ctx, replicationStatusCacheKey, *globalReplicationDetails, replicationStatusCacheTTLDuration); err != nil {
+				return err
+			}
+			return nil
+		}
+		// Found in L2 cache, sync it if needed.
+		if rtd.isEqual(*globalReplicationDetails) {
+			log.Debug("global replication details & l2 Cache copy is found to be in sync")
+			return nil
+		}
+		if err := r.l2Cache.SetStruct(ctx, replicationStatusCacheKey, *globalReplicationDetails, replicationStatusCacheTTLDuration); err != nil {
+			return err
+		}
+		log.Debug(fmt.Sprintf("l2 cache had been updated with global replication details value: %v", globalReplicationDetails))
+		return nil
+	}
+	// pull or update global replication details with l2 cache copy.
+	if found, err := r.l2Cache.GetStructEx(ctx, replicationStatusCacheKey, &rtd, replicationStatusCacheTTLDuration); err != nil {
+		return err
+	} else if !found {
+		log.Debug("replication details not found in l2 cache")
+		return nil
+	}
+
+	log.Debug(fmt.Sprintf("global replication details & this repl object are being updated w/ l2 cache copy: %v", rtd))
+
+	// Just assign to global replication details the read rtd value from l2 cache.
+	globalReplicationDetails = &rtd
+	// Sync this object.
+	r.replicationTrackedDetails = rtd
+
 	return nil
 }

--- a/fs/transaction_log_test.go
+++ b/fs/transaction_log_test.go
@@ -16,8 +16,9 @@ type payload struct {
 var uuid2, _ = sop.ParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c9")
 
 func TestTransactionLogAdd(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
-	tl := NewTransactionLog(redis.NewClient(), rt)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
+	tl := NewTransactionLog(l2cache, rt)
 	ba, _ := json.Marshal(payload{
 		Abc: "abc", Xyc: 123,
 	})
@@ -28,8 +29,9 @@ func TestTransactionLogAdd(t *testing.T) {
 }
 
 func TestTransactionLogGetOne(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
-	tl := NewTransactionLog(redis.NewClient(), rt)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
+	tl := NewTransactionLog(l2cache, rt)
 	// ageLimit = 0
 	uid, hour, tlogdata, err := tl.GetOne(ctx)
 	if uid.IsNil() {
@@ -70,8 +72,9 @@ func TestTransactionLogGetOne(t *testing.T) {
 }
 
 func TestTransactionLogAdd2(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
-	tl := NewTransactionLog(redis.NewClient(), rt)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
+	tl := NewTransactionLog(l2cache, rt)
 	ba, _ := json.Marshal(payload{
 		Abc: "abc", Xyc: 123,
 	})
@@ -89,8 +92,9 @@ func TestTransactionLogAdd2(t *testing.T) {
 }
 
 func TestTransactionLogGetOne2(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
-	tl := NewTransactionLog(redis.NewClient(), rt)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
+	tl := NewTransactionLog(l2cache, rt)
 	// ageLimit = 0
 	uid, _, tlogdata, err := tl.GetOne(ctx)
 	if uid.IsNil() {
@@ -124,8 +128,9 @@ func TestTransactionLogGetOne2(t *testing.T) {
 }
 
 func TestTransactionLogRemove2(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
-	tl := NewTransactionLog(redis.NewClient(), rt)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
+	tl := NewTransactionLog(l2cache, rt)
 	err := tl.Remove(ctx, uuid2)
 	if err != nil {
 		t.Errorf("Remove err: %v", err)
@@ -133,8 +138,9 @@ func TestTransactionLogRemove2(t *testing.T) {
 }
 
 func TestTransactionLogAddRemove(t *testing.T) {
-	rt, _ := NewReplicationTracker([]string{"/Users/grecinto/sop_data/"}, false)
-	tl := NewTransactionLog(redis.NewClient(), rt)
+	l2cache := redis.NewClient()
+	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
+	tl := NewTransactionLog(l2cache, rt)
 	ba, _ := json.Marshal(payload{
 		Abc: "abc", Xyc: 123,
 	})

--- a/in_red_cfs/integration_tests/transaction_test.go
+++ b/in_red_cfs/integration_tests/transaction_test.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/SharedCode/sop"
 	"github.com/SharedCode/sop/in_red_cfs"
@@ -60,10 +59,7 @@ func Test_SimpleAddPerson(t *testing.T) {
 	b3, err := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
 		IsValueDataInNodeSegment: true,
-		LeafLoadBalancing:        false,
-		Description:              "",
 		BlobStoreBaseFolderPath:  dataPath,
 	}, trans, Compare)
 	if err != nil {
@@ -145,10 +141,7 @@ func Test_AddAndSearchManyPersons(t *testing.T) {
 	b3, err := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
 		IsValueDataInNodeSegment: true,
-		LeafLoadBalancing:        false,
-		Description:              "",
 		BlobStoreBaseFolderPath:  dataPath,
 	}, trans, Compare)
 	if err != nil {
@@ -208,19 +201,11 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 
 	t1, _ := in_red_cfs.NewTransaction(sop.ForWriting, -1, false)
 	t1.Begin()
-	so := sop.NewStoreCacheConfig(time.Duration(5*time.Minute), false)
-	// NodeCacheDuration of -1 means don't cache node.
-	so.NodeCacheDuration = -1
-	so.RegistryCacheDuration = time.Duration(10 * time.Minute)
 	b3, _ := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
 		IsValueDataInNodeSegment: true,
-		LeafLoadBalancing:        false,
-		Description:              "",
 		BlobStoreBaseFolderPath:  dataPath,
-		CacheConfig:              so,
 	}, t1, Compare)
 
 	// Populating 90,000 items took about few minutes. Not bad considering I did not use Kafka queue
@@ -276,10 +261,7 @@ func Test_VolumeDeletes(t *testing.T) {
 	b3, _ := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
 		IsValueDataInNodeSegment: true,
-		LeafLoadBalancing:        false,
-		Description:              "",
 		BlobStoreBaseFolderPath:  dataPath,
 	}, t1, Compare)
 
@@ -315,10 +297,7 @@ func Test_MixedOperations(t *testing.T) {
 	b3, _ := in_red_cfs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
 		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
 		IsValueDataInNodeSegment: true,
-		LeafLoadBalancing:        false,
-		Description:              "",
 		BlobStoreBaseFolderPath:  dataPath,
 	}, t1, Compare)
 

--- a/in_red_fs/integration_tests/basic_ec_test.go
+++ b/in_red_fs/integration_tests/basic_ec_test.go
@@ -34,7 +34,7 @@ func initErasureCoding() {
 func Test_Basic_EC(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptionsWithReplication(nil, sop.ForWriting, -1, fs.MinimumModValue, nil)
-	trans, err := in_red_fs.NewTransactionWithReplication(to)
+	trans, err := in_red_fs.NewTransactionWithReplication(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -76,7 +76,7 @@ func Test_Basic_EC(t *testing.T) {
 func Test_Basic_EC_Get(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptionsWithReplication(nil, sop.ForWriting, -1, fs.MinimumModValue, nil)
-	trans, err := in_red_fs.NewTransactionWithReplication(to)
+	trans, err := in_red_fs.NewTransactionWithReplication(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/in_red_fs/integration_tests/basic_test.go
+++ b/in_red_fs/integration_tests/basic_test.go
@@ -52,7 +52,7 @@ func init() {
 func Test_GetStoreList(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -65,7 +65,7 @@ func Test_GetStoreList(t *testing.T) {
 func Test_CreateEmptyStore(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -82,7 +82,7 @@ func Test_CreateEmptyStore(t *testing.T) {
 		trans.Commit(ctx)
 		return
 	}
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 
 	b3, err = in_red_fs.NewBtree[int, string](ctx, sop.StoreOptions{
@@ -104,7 +104,7 @@ func Test_CreateEmptyStore(t *testing.T) {
 func Test_TransactionStory_OpenVsNewBTree(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -135,7 +135,7 @@ func Test_TransactionStory_SingleBTree_Get(t *testing.T) {
 	// 4. Commit Transaction
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -174,7 +174,7 @@ func Test_TransactionStory_SingleBTree(t *testing.T) {
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	// Demo NewTransactionExt specifying custom "to file path" lambda function.
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -220,7 +220,7 @@ func Test_TransactionStory_SingleBTree(t *testing.T) {
 func Test_RegistryZeroDurationCache(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -268,7 +268,7 @@ func Test_RegistryZeroDurationCache(t *testing.T) {
 func Test_StoreCaching(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -310,7 +310,7 @@ func Test_StoreCaching(t *testing.T) {
 func Test_StoreCachingTTL(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/in_red_fs/integration_tests/streaming_data_store_test.go
+++ b/in_red_fs/integration_tests/streaming_data_store_test.go
@@ -15,7 +15,7 @@ import (
 func Test_StreamingDataStoreInvalidCases(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 
 	// Empty Store get/update methods test cases.
@@ -34,7 +34,7 @@ func Test_StreamingDataStoreInvalidCases(t *testing.T) {
 func Test_StreamingDataStoreBasicUse(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore", trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo")
@@ -44,7 +44,7 @@ func Test_StreamingDataStoreBasicUse(t *testing.T) {
 	trans.Commit(ctx)
 
 	// Read back the data. Pass false on 2nd argument will toggle to a "reader" transaction.
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStore", trans, nil)
 
@@ -79,7 +79,7 @@ func Test_StreamingDataStoreBasicUse(t *testing.T) {
 func Test_StreamingDataStoreMultipleItems(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreM", trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo")
@@ -94,7 +94,7 @@ func Test_StreamingDataStoreMultipleItems(t *testing.T) {
 
 	// Read back the data. Pass false on 2nd argument will toggle to a "reader" transaction.
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	trans, _ = in_red_fs.NewTransaction(to2)
+	trans, _ = in_red_fs.NewTransaction(ctx, to2)
 	trans.Begin()
 	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreM", trans, nil)
 
@@ -129,7 +129,7 @@ func Test_StreamingDataStoreMultipleItems(t *testing.T) {
 func Test_StreamingDataStoreDeleteAnItem(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreD", trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo")
@@ -146,7 +146,7 @@ func Test_StreamingDataStoreDeleteAnItem(t *testing.T) {
 	}
 	trans.Commit(ctx)
 
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ = in_red_fs.OpenStreamingDataStore[string](ctx, "videoStoreD", trans, nil)
 
@@ -183,7 +183,7 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreU", trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo2")
@@ -193,7 +193,7 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 	trans.Commit(ctx)
 
 	// Update the video.
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreU", trans, nil)
 	encoder, _ = sds.Update(ctx, "fooVideo2")
@@ -207,7 +207,7 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 
 	// Read back the video.
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	trans, _ = in_red_fs.NewTransaction(to2)
+	trans, _ = in_red_fs.NewTransaction(ctx, to2)
 	trans.Begin()
 	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreU", trans, nil)
 
@@ -243,7 +243,7 @@ func Test_StreamingDataStoreUpdateWithCountCheck(t *testing.T) {
 	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore2", trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo1")
@@ -251,7 +251,7 @@ func Test_StreamingDataStoreUpdateWithCountCheck(t *testing.T) {
 	trans.Commit(ctx)
 
 	// Update the video.
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStore2", trans, nil)
 	encoder, _ = sds.Update(ctx, "fooVideo1")
@@ -269,7 +269,7 @@ func Test_StreamingDataStoreUpdateExtend(t *testing.T) {
 	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore4", trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo3")
@@ -277,7 +277,7 @@ func Test_StreamingDataStoreUpdateExtend(t *testing.T) {
 	trans.Commit(ctx)
 
 	// Update the video.
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStore4", trans, nil)
 	encoder, _ = sds.Update(ctx, "fooVideo3")
@@ -296,7 +296,7 @@ func Test_StreamingDataStoreUpdate(t *testing.T) {
 	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore5", trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo")
@@ -304,7 +304,7 @@ func Test_StreamingDataStoreUpdate(t *testing.T) {
 	trans.Commit(ctx)
 
 	// Update the video.
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStore5", trans, nil)
 	encoder, _ = sds.Update(ctx, "fooVideo")
@@ -321,7 +321,7 @@ func Test_StreamingDataStoreDelete(t *testing.T) {
 	ctx := context.Background()
 	// Upload the video.
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore3", trans, nil)
 

--- a/in_red_fs/integration_tests/transaction_edge_cases_test.go
+++ b/in_red_fs/integration_tests/transaction_edge_cases_test.go
@@ -22,8 +22,8 @@ import (
 func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
-	t2, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
+	t2, _ := in_red_fs.NewTransaction(ctx, to)
 
 	t1.Begin()
 	t2.Begin()
@@ -31,10 +31,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	b3, err := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
 		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
 		IsValueDataInNodeSegment: true,
-		LeafLoadBalancing:        false,
-		Description:              "",
 	}, t1, Compare)
 	if err != nil {
 		t.Error(err.Error()) // most likely, the "persondb77" b-tree store has not been created yet.
@@ -49,7 +46,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 		b3.Add(ctx, pk, p)
 		b3.Add(ctx, pk2, p2)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "persondb77", t1, Compare)
 	}
@@ -77,7 +74,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 		t.Error("Commit #2, got = succeess, want = fail.")
 	}
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t1, _ = in_red_fs.NewTransaction(to2)
+	t1, _ = in_red_fs.NewTransaction(ctx, to2)
 	t1.Begin()
 	b3, _ = in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb77",
@@ -107,8 +104,8 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
-	t2, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
+	t2, _ := in_red_fs.NewTransaction(ctx, to)
 
 	t1.Begin()
 	t2.Begin()
@@ -131,7 +128,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 		b3.Add(ctx, pk, p)
 		b3.Add(ctx, pk2, p2)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb77",
@@ -170,9 +167,9 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t2, _ := in_red_fs.NewTransaction(to2)
+	t2, _ := in_red_fs.NewTransaction(ctx, to2)
 
 	t1.Begin()
 	t2.Begin()
@@ -195,7 +192,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 		b3.Add(ctx, pk, p)
 		b3.Add(ctx, pk2, p2)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb77",
@@ -235,9 +232,9 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t2, _ := in_red_fs.NewTransaction(to2)
+	t2, _ := in_red_fs.NewTransaction(ctx, to2)
 
 	t1.Begin()
 	t2.Begin()
@@ -262,7 +259,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 		b3.Add(ctx, pk2, p2)
 		b3.Add(ctx, pk3, p3)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb77",
@@ -301,8 +298,8 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
-	t2, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
+	t2, _ := in_red_fs.NewTransaction(ctx, to)
 
 	t1.Begin()
 	t2.Begin()
@@ -331,7 +328,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		b3.Add(ctx, pk4, p4)
 		b3.Add(ctx, pk5, p5)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "persondb77",
@@ -398,7 +395,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	in_red_fs.RemoveBtree(ctx, dataPath, "twophase3")
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "twophase3",
@@ -414,7 +411,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	eg2, ctx3 := errgroup.WithContext(ctx)
 
 	f1 := func() error {
-		t1, _ := in_red_fs.NewTransaction(to)
+		t1, _ := in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ := in_red_fs.NewBtree[int, string](ctx2, sop.StoreOptions{
 			Name:                     "twophase3",
@@ -429,7 +426,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	}
 
 	f2 := func() error {
-		t2, _ := in_red_fs.NewTransaction(to)
+		t2, _ := in_red_fs.NewTransaction(ctx, to)
 		t2.Begin()
 		b32, _ := in_red_fs.NewBtree[int, string](ctx3, sop.StoreOptions{
 			Name:                     "twophase3",
@@ -455,7 +452,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	}
 
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t1, _ = in_red_fs.NewTransaction(to2)
+	t1, _ = in_red_fs.NewTransaction(ctx, to2)
 	t1.Begin()
 
 	b3, _ = in_red_fs.OpenBtree[int, string](ctx, "twophase3", t1, nil)
@@ -488,7 +485,7 @@ func Test_ConcurrentCommitsComplexDupeAllowed(t *testing.T) {
 	cache.Clear(ctx)
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "tablex",
@@ -505,7 +502,7 @@ func Test_ConcurrentCommitsComplexDupeAllowed(t *testing.T) {
 	eg4, ctx4 := errgroup.WithContext(ctx)
 
 	f1 := func() error {
-		t1, _ := in_red_fs.NewTransaction(to)
+		t1, _ := in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ := in_red_fs.OpenBtree[int, string](ctx2, "tablex", t1, nil)
 		b3.Add(ctx2, 50, "I am the value with 5000 key.")
@@ -516,7 +513,7 @@ func Test_ConcurrentCommitsComplexDupeAllowed(t *testing.T) {
 	}
 
 	f2 := func() error {
-		t2, _ := in_red_fs.NewTransaction(to)
+		t2, _ := in_red_fs.NewTransaction(ctx, to)
 		t2.Begin()
 		b32, _ := in_red_fs.OpenBtree[int, string](ctx3, "tablex", t2, nil)
 		b32.Add(ctx3, 550, "I am the value with 5000 key.")
@@ -527,7 +524,7 @@ func Test_ConcurrentCommitsComplexDupeAllowed(t *testing.T) {
 	}
 
 	f3 := func() error {
-		t3, _ := in_red_fs.NewTransaction(to)
+		t3, _ := in_red_fs.NewTransaction(ctx, to)
 		t3.Begin()
 		b32, _ := in_red_fs.OpenBtree[int, string](ctx4, "tablex", t3, nil)
 		b32.Add(ctx4, 550, "random foo.")
@@ -557,7 +554,7 @@ func Test_ConcurrentCommitsComplexDupeAllowed(t *testing.T) {
 	}
 
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t1, _ = in_red_fs.NewTransaction(to2)
+	t1, _ = in_red_fs.NewTransaction(ctx, to2)
 	t1.Begin()
 
 	b3, _ = in_red_fs.OpenBtree[int, string](ctx, "tablex", t1, nil)
@@ -597,7 +594,7 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 	in_red_fs.RemoveBtree(ctx, dataPath, "tablex2")
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "tablex2",
@@ -615,7 +612,7 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 	eg4, ctx4 := errgroup.WithContext(ctx)
 
 	f1 := func() error {
-		t1, _ := in_red_fs.NewTransaction(to)
+		t1, _ := in_red_fs.NewTransaction(ctx2, to)
 		t1.Begin()
 		b3, _ := in_red_fs.OpenBtree[int, string](ctx2, "tablex2", t1, nil)
 		b3.Add(ctx2, 50, "I am the value with 5000 key.")
@@ -625,7 +622,7 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 	}
 
 	f2 := func() error {
-		t2, _ := in_red_fs.NewTransaction(to)
+		t2, _ := in_red_fs.NewTransaction(ctx3, to)
 		t2.Begin()
 		b32, _ := in_red_fs.OpenBtree[int, string](ctx3, "tablex2", t2, nil)
 		if ok, err := b32.Add(ctx3, 550, "I am the value with 5000 key."); !ok || err != nil {
@@ -647,7 +644,7 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 	}
 
 	f3 := func() error {
-		t3, _ := in_red_fs.NewTransaction(to)
+		t3, _ := in_red_fs.NewTransaction(ctx4, to)
 		t3.Begin()
 		b32, _ := in_red_fs.OpenBtree[int, string](ctx4, "tablex2", t3, nil)
 		if ok, err := b32.Add(ctx4, 550, "random foo."); !ok || err != nil {
@@ -688,7 +685,7 @@ func Test_ConcurrentCommitsComplexDupeNotAllowed(t *testing.T) {
 	}
 
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t1, _ = in_red_fs.NewTransaction(to2)
+	t1, _ = in_red_fs.NewTransaction(ctx, to2)
 	t1.Begin()
 
 	b3, _ = in_red_fs.OpenBtree[int, string](ctx, "tablex2", t1, nil)
@@ -719,7 +716,7 @@ func Test_ConcurrentCommitsComplexUpdateConflicts(t *testing.T) {
 	in_red_fs.RemoveBtree(ctx, dataPath, "tabley")
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "tabley",
@@ -739,7 +736,7 @@ func Test_ConcurrentCommitsComplexUpdateConflicts(t *testing.T) {
 	eg3, ctx4 := errgroup.WithContext(ctx)
 
 	f1 := func() error {
-		t1, _ := in_red_fs.NewTransaction(to)
+		t1, _ := in_red_fs.NewTransaction(ctx3, to)
 		t1.Begin()
 		b3, _ := in_red_fs.OpenBtree[int, string](ctx3, "tabley", t1, nil)
 		b3.Add(ctx3, 50, "I am the value with 5000 key.")
@@ -749,7 +746,7 @@ func Test_ConcurrentCommitsComplexUpdateConflicts(t *testing.T) {
 	}
 
 	f2 := func() error {
-		t2, _ := in_red_fs.NewTransaction(to)
+		t2, _ := in_red_fs.NewTransaction(ctx2, to)
 		t2.Begin()
 		b32, _ := in_red_fs.OpenBtree[int, string](ctx2, "tabley", t2, nil)
 		b32.Update(ctx2, 550, "I am the value with 5000 key.")
@@ -759,7 +756,7 @@ func Test_ConcurrentCommitsComplexUpdateConflicts(t *testing.T) {
 	}
 
 	f3 := func() error {
-		t3, _ := in_red_fs.NewTransaction(to)
+		t3, _ := in_red_fs.NewTransaction(ctx4, to)
 		t3.Begin()
 		b32, _ := in_red_fs.OpenBtree[int, string](ctx4, "tabley", t3, nil)
 		b32.Update(ctx4, 550, "random foo.")
@@ -792,7 +789,7 @@ func Test_ConcurrentCommitsComplexUpdateConflicts(t *testing.T) {
 
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
 
-	t1, _ = in_red_fs.NewTransaction(to2)
+	t1, _ = in_red_fs.NewTransaction(ctx, to2)
 	t1.Begin()
 
 	b3, _ = in_red_fs.OpenBtree[int, string](ctx, "tabley", t1, nil)

--- a/in_red_fs/integration_tests/transaction_logging_test.go
+++ b/in_red_fs/integration_tests/transaction_logging_test.go
@@ -20,7 +20,7 @@ func MultipleExpiredTransCleanup(t *testing.T) {
 	sop.Now = func() time.Time { return yesterday }
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 
 	b3, _ := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
@@ -40,7 +40,7 @@ func MultipleExpiredTransCleanup(t *testing.T) {
 	yesterday = time.Now().Add(time.Duration(-47 * time.Hour))
 	sop.Now = func() time.Time { return yesterday }
 
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 
 	b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "ztab1", trans, Compare)
@@ -53,7 +53,7 @@ func MultipleExpiredTransCleanup(t *testing.T) {
 	yesterday = time.Now().Add(time.Duration(-46 * time.Hour))
 	sop.Now = func() time.Time { return yesterday }
 
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 
 	b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "ztab1", trans, Compare)
@@ -65,7 +65,7 @@ func MultipleExpiredTransCleanup(t *testing.T) {
 	yesterday = time.Now()
 	sop.Now = func() time.Time { return yesterday }
 
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 
 	// Cleanup should be launched from this call.
 	trans.Begin()
@@ -77,7 +77,7 @@ func Cleanup(t *testing.T) {
 	sop.Now = func() time.Time { return yesterday }
 
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to2)
+	trans, _ := in_red_fs.NewTransaction(ctx, to2)
 	trans.Begin()
 	_, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "ztab1", trans, Compare)
 	trans.Commit(ctx)
@@ -85,7 +85,7 @@ func Cleanup(t *testing.T) {
 	yesterday = time.Now().Add(-time.Duration(23*time.Hour + 54*time.Minute))
 	sop.Now = func() time.Time { return yesterday }
 
-	trans, _ = in_red_fs.NewTransaction(to2)
+	trans, _ = in_red_fs.NewTransaction(ctx, to2)
 	trans.Begin()
 	_, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "ztab1", trans, Compare)
 	trans.Commit(ctx)

--- a/in_red_fs/integration_tests/transaction_test.go
+++ b/in_red_fs/integration_tests/transaction_test.go
@@ -52,7 +52,7 @@ const tableName2 = "twophase22"
 func Test_SimpleAddPerson(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
@@ -97,7 +97,7 @@ func Test_SimpleAddPerson(t *testing.T) {
 func AddToBreakNodeThenRemoveAll(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, _ := in_red_fs.NewTransaction(to)
+	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
 
 	pk, p := newPerson("foo", "bar", "male", "email", "phone")
@@ -113,7 +113,7 @@ func AddToBreakNodeThenRemoveAll(t *testing.T) {
 	}
 
 	trans.Commit(ctx)
-	trans, _ = in_red_fs.NewTransaction(to)
+	trans, _ = in_red_fs.NewTransaction(ctx, to)
 
 	trans.Begin()
 	b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "personfoo", trans, Compare)
@@ -129,7 +129,7 @@ func AddToBreakNodeThenRemoveAll(t *testing.T) {
 func Test_AddThenTripleUpdatesPerson(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
@@ -154,7 +154,7 @@ func Test_AddThenTripleUpdatesPerson(t *testing.T) {
 		t.Errorf("Commit returned error, details: %v.", err)
 	}
 
-	trans, err = in_red_fs.NewTransaction(to)
+	trans, err = in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
@@ -174,7 +174,7 @@ func Test_AddThenTripleUpdatesPerson(t *testing.T) {
 		t.Errorf("Commit returned error, details: %v.", err)
 	}
 
-	trans, err = in_red_fs.NewTransaction(to)
+	trans, err = in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
@@ -194,7 +194,7 @@ func Test_AddThenTripleUpdatesPerson(t *testing.T) {
 		t.Errorf("Commit returned error, details: %v.", err)
 	}
 
-	trans, err = in_red_fs.NewTransaction(to)
+	trans, err = in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
@@ -214,7 +214,7 @@ func Test_AddThenTripleUpdatesPerson(t *testing.T) {
 		t.Errorf("Commit returned error, details: %v.", err)
 	}
 
-	trans, err = in_red_fs.NewTransaction(to)
+	trans, err = in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
@@ -239,12 +239,12 @@ func Test_AddThenTripleUpdatesPerson(t *testing.T) {
 func Test_TwoTransactionsWithNoConflict(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
 
-	trans2, _ := in_red_fs.NewTransaction(to)
+	trans2, _ := in_red_fs.NewTransaction(ctx, to)
 
 	trans.Begin()
 	trans2.Begin()
@@ -281,7 +281,7 @@ func Test_TwoTransactionsWithNoConflict(t *testing.T) {
 func Test_AddAndSearchManyPersons(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
@@ -314,7 +314,7 @@ func Test_AddAndSearchManyPersons(t *testing.T) {
 	}
 
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	trans, err = in_red_fs.NewTransaction(to2)
+	trans, err = in_red_fs.NewTransaction(ctx, to2)
 	if err != nil {
 		t.Errorf("%s", err.Error())
 		t.FailNow()
@@ -350,7 +350,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 	end := 100000
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
@@ -370,7 +370,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 				t.Error(err)
 				t.FailNow()
 			}
-			t1, _ = in_red_fs.NewTransaction(to)
+			t1, _ = in_red_fs.NewTransaction(ctx, to)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, tableName1, t1, Compare)
 		}
@@ -399,7 +399,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 				t.Error(err)
 				t.FailNow()
 			}
-			t1, _ = in_red_fs.NewTransaction(to2)
+			t1, _ = in_red_fs.NewTransaction(ctx, to2)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, tableName1, t1, Compare)
 		}
@@ -414,7 +414,7 @@ func Test_VolumeDeletes(t *testing.T) {
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	//to.UseCacheForFileRegionLocks = true
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
@@ -436,7 +436,7 @@ func Test_VolumeDeletes(t *testing.T) {
 				t.Error(err)
 				t.FailNow()
 			}
-			t1, _ = in_red_fs.NewTransaction(to)
+			t1, _ = in_red_fs.NewTransaction(ctx, to)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, tableName1, t1, Compare)
 		}
@@ -451,7 +451,7 @@ func Test_MixedOperations(t *testing.T) {
 	end := 14000
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     tableName1,
@@ -488,7 +488,7 @@ func Test_MixedOperations(t *testing.T) {
 				t.Error(err)
 				t.FailNow()
 			}
-			t1, _ = in_red_fs.NewTransaction(to)
+			t1, _ = in_red_fs.NewTransaction(ctx, to)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, tableName1, t1, Compare)
 		}
@@ -524,7 +524,7 @@ func Test_MixedOperations(t *testing.T) {
 				t.Error(err)
 				t.FailNow()
 			}
-			t1, _ = in_red_fs.NewTransaction(to)
+			t1, _ = in_red_fs.NewTransaction(ctx, to)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, tableName1, t1, Compare)
 		}
@@ -534,7 +534,7 @@ func Test_MixedOperations(t *testing.T) {
 func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	ctx := context.Background()
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 
 	b3, _ := in_red_fs.NewBtree[int, string](ctx, sop.StoreOptions{
@@ -558,7 +558,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 			t.Errorf("Rollback error: %v", err)
 		}
 
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 
 		b3, _ = in_red_fs.OpenBtree[int, string](ctx, tableName2, t1, nil)

--- a/in_red_fs/integration_tests/value_data_segment/basic_test.go
+++ b/in_red_fs/integration_tests/value_data_segment/basic_test.go
@@ -27,7 +27,7 @@ const dataPath string = "/Users/grecinto/sop_data"
 
 func Test_TransactionStory_OpenVsNewBTree(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -59,7 +59,7 @@ func Test_TransactionStory_SingleBTree(t *testing.T) {
 	// 3. Do CRUD on BTree
 	// 4. Commit Transaction
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -103,7 +103,7 @@ func Test_TransactionStory_SingleBTree(t *testing.T) {
 func Test_ByteArrayValue(t *testing.T) {
 	in_red_fs.RemoveBtree(ctx, dataPath, "baStore")
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -145,7 +145,7 @@ func Test_ByteArrayValue(t *testing.T) {
 
 func Test_ByteArrayValueGet(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.NoCheck, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/in_red_fs/integration_tests/value_data_segment/transaction_edge_cases_test.go
+++ b/in_red_fs/integration_tests/value_data_segment/transaction_edge_cases_test.go
@@ -17,8 +17,8 @@ import (
 // Reader transaction succeeds.
 func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
-	t2, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
+	t2, _ := in_red_fs.NewTransaction(ctx, to)
 
 	t1.Begin()
 	t2.Begin()
@@ -44,7 +44,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 		b3.Add(ctx, pk, p)
 		b3.Add(ctx, pk2, p2)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 			Name:                     "personvdb7",
@@ -87,7 +87,7 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 	}
 
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t1, _ = in_red_fs.NewTransaction(to2)
+	t1, _ = in_red_fs.NewTransaction(ctx, to2)
 	t1.Begin()
 	b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "personvdb7", t1, Compare)
 	var person Person
@@ -112,8 +112,8 @@ func Test_TwoTransactionsUpdatesOnSameItem(t *testing.T) {
 // keys are sequential/contiguous between the two.
 func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
-	t2, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
+	t2, _ := in_red_fs.NewTransaction(ctx, to)
 
 	t1.Begin()
 	t2.Begin()
@@ -139,7 +139,7 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 		b3.Add(ctx, pk, p)
 		b3.Add(ctx, pk2, p2)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "personvdb7", t1, Compare)
 	}
@@ -169,10 +169,10 @@ func Test_TwoTransactionsUpdatesOnSameNodeDifferentItems(t *testing.T) {
 // Reader transaction fails commit when an item read was modified by another transaction in-flight.
 func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t2, _ := in_red_fs.NewTransaction(to2)
+	t2, _ := in_red_fs.NewTransaction(ctx, to2)
 
 	t1.Begin()
 	t2.Begin()
@@ -198,7 +198,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 		b3.Add(ctx, pk, p)
 		b3.Add(ctx, pk2, p2)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "personvdb7", t1, Compare)
 	}
@@ -229,9 +229,9 @@ func Test_TwoTransactionsOneReadsAnotherWritesSameItem(t *testing.T) {
 // Case: Reader transaction succeeds commit, while another item in same Node got updated by another transaction.
 func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t2, _ := in_red_fs.NewTransaction(to2)
+	t2, _ := in_red_fs.NewTransaction(ctx, to2)
 
 	t1.Begin()
 	t2.Begin()
@@ -259,7 +259,7 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 		b3.Add(ctx, pk2, p2)
 		b3.Add(ctx, pk3, p3)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "personvdb7", t1, Compare)
 	}
@@ -289,8 +289,8 @@ func Test_TwoTransactionsOneReadsAnotherWritesAnotherItemOnSameNode(t *testing.T
 // One transaction updates a colliding item in 1st and a 2nd trans.
 func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
-	t2, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
+	t2, _ := in_red_fs.NewTransaction(ctx, to)
 
 	t1.Begin()
 	t2.Begin()
@@ -322,7 +322,7 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		b3.Add(ctx, pk4, p4)
 		b3.Add(ctx, pk5, p5)
 		t1.Commit(ctx)
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 		b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "personvdb7", t1, Compare)
 	}
@@ -379,7 +379,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	in_red_fs.RemoveBtree(ctx, dataPath, "twophase2")
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[int, string](ctx, sop.StoreOptions{
 		Name:                     "twophase2",
@@ -396,7 +396,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	eg, ctx2 := errgroup.WithContext(ctx)
 
 	f1 := func() error {
-		t1, _ := in_red_fs.NewTransaction(to)
+		t1, _ := in_red_fs.NewTransaction(ctx2, to)
 		t1.Begin()
 		b3, _ := in_red_fs.OpenBtree[int, string](ctx2, "twophase2", t1, nil)
 		b3.Add(ctx2, 5000, "I am the value with 5000 key.")
@@ -406,7 +406,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	}
 
 	f2 := func() error {
-		t2, _ := in_red_fs.NewTransaction(to)
+		t2, _ := in_red_fs.NewTransaction(ctx2, to)
 		t2.Begin()
 		b32, _ := in_red_fs.OpenBtree[int, string](ctx2, "twophase2", t2, nil)
 		b32.Add(ctx2, 5500, "I am the value with 5000 key.")
@@ -424,7 +424,7 @@ func Test_Concurrent2CommitsOnNewBtree(t *testing.T) {
 	}
 
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	t1, _ = in_red_fs.NewTransaction(to2)
+	t1, _ = in_red_fs.NewTransaction(ctx, to2)
 	t1.Begin()
 
 	b3, _ = in_red_fs.OpenBtree[int, string](ctx, "twophase2", t1, nil)

--- a/in_red_fs/integration_tests/value_data_segment/transaction_test.go
+++ b/in_red_fs/integration_tests/value_data_segment/transaction_test.go
@@ -47,7 +47,7 @@ const batchSize = 200
 
 func Test_SimpleAddPerson(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -58,10 +58,6 @@ func Test_SimpleAddPerson(t *testing.T) {
 	b3, err := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
-		IsValueDataInNodeSegment: false,
-		LeafLoadBalancing:        false,
-		Description:              "",
 	}, trans, Compare)
 	if err != nil {
 		t.Errorf("Error instantiating Btree, details: %v.", err)
@@ -94,12 +90,12 @@ func Test_SimpleAddPerson(t *testing.T) {
 
 func Test_TwoTransactionsWithNoConflict(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	trans2, err := in_red_fs.NewTransaction(to)
+	trans2, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -138,7 +134,7 @@ func Test_TwoTransactionsWithNoConflict(t *testing.T) {
 
 func Test_AddAndSearchManyPersons(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	trans, err := in_red_fs.NewTransaction(to)
+	trans, err := in_red_fs.NewTransaction(ctx, to)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -147,10 +143,6 @@ func Test_AddAndSearchManyPersons(t *testing.T) {
 	b3, err := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
 		SlotLength:               nodeSlotLength,
-		IsUnique:                 false,
-		IsValueDataInNodeSegment: false,
-		LeafLoadBalancing:        false,
-		Description:              "",
 	}, trans, Compare)
 	if err != nil {
 		t.Errorf("Error instantiating Btree, details: %v.", err)
@@ -174,7 +166,7 @@ func Test_AddAndSearchManyPersons(t *testing.T) {
 	}
 
 	tor, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-	trans, err = in_red_fs.NewTransaction(tor)
+	trans, err = in_red_fs.NewTransaction(ctx, tor)
 	if err != nil {
 		t.Error(err.Error())
 		t.Fail()
@@ -209,7 +201,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 	end := 100000
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:       "persondb",
@@ -228,7 +220,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 				t.Error(err)
 				t.Fail()
 			}
-			t1, _ = in_red_fs.NewTransaction(to)
+			t1, _ = in_red_fs.NewTransaction(ctx, to)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "persondb", t1, Compare)
 		}
@@ -253,7 +245,7 @@ func Test_VolumeAddThenSearch(t *testing.T) {
 				t.Fail()
 			}
 			tor, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
-			t1, _ = in_red_fs.NewTransaction(tor)
+			t1, _ = in_red_fs.NewTransaction(ctx, tor)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "persondb", t1, Compare)
 		}
@@ -266,7 +258,7 @@ func VolumeDeletes(t *testing.T) {
 	end := 100000
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:       "persondb",
@@ -287,7 +279,7 @@ func VolumeDeletes(t *testing.T) {
 				t.Error(err)
 				t.Fail()
 			}
-			t1, _ = in_red_fs.NewTransaction(to)
+			t1, _ = in_red_fs.NewTransaction(ctx, to)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "persondb", t1, Compare)
 		}
@@ -301,7 +293,7 @@ func MixedOperations(t *testing.T) {
 	end := 14000
 
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 	b3, _ := in_red_fs.NewBtree[PersonKey, Person](ctx, sop.StoreOptions{
 		Name:                     "persondb",
@@ -341,7 +333,7 @@ func MixedOperations(t *testing.T) {
 				t.Error(err)
 				t.Fail()
 			}
-			t1, _ = in_red_fs.NewTransaction(to)
+			t1, _ = in_red_fs.NewTransaction(ctx, to)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "persondb", t1, Compare)
 		}
@@ -377,7 +369,7 @@ func MixedOperations(t *testing.T) {
 				t.Error(err)
 				t.Fail()
 			}
-			t1, _ = in_red_fs.NewTransaction(to)
+			t1, _ = in_red_fs.NewTransaction(ctx, to)
 			t1.Begin()
 			b3, _ = in_red_fs.OpenBtree[PersonKey, Person](ctx, "persondb", t1, Compare)
 		}
@@ -386,7 +378,7 @@ func MixedOperations(t *testing.T) {
 
 func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 
 	b3, _ := in_red_fs.NewBtree[int, string](ctx, sop.StoreOptions{
@@ -407,7 +399,7 @@ func Test_TwoPhaseCommitRolledback(t *testing.T) {
 	if err := twoPhase.Phase1Commit(ctx); err == nil {
 		twoPhase.Rollback(ctx, nil)
 
-		t1, _ = in_red_fs.NewTransaction(to)
+		t1, _ = in_red_fs.NewTransaction(ctx, to)
 		t1.Begin()
 
 		b3, _ = in_red_fs.OpenBtree[int, string](ctx, "twophase", t1, nil)
@@ -424,7 +416,7 @@ func Test_StrangeBtreeStoreName(t *testing.T) {
 
 	in_red_fs.RemoveBtree(ctx, dataPath, "2phase")
 
-	t1, _ := in_red_fs.NewTransaction(to)
+	t1, _ := in_red_fs.NewTransaction(ctx, to)
 	t1.Begin()
 
 	if _, err := in_red_fs.NewBtree[int, string](ctx, sop.StoreOptions{

--- a/in_red_fs/manage_btree.go
+++ b/in_red_fs/manage_btree.go
@@ -26,7 +26,7 @@ func RemoveBtree(ctx context.Context, storesBaseFolder string, name string) erro
 	log.Info(fmt.Sprintf("Btree %s%c%s is about to be deleted", storesBaseFolder, os.PathSeparator, name))
 
 	cache := redis.NewClient()
-	replicationTracker, err := fs.NewReplicationTracker([]string{storesBaseFolder}, false)
+	replicationTracker, err := fs.NewReplicationTracker(ctx, []string{storesBaseFolder}, false, cache)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
…s) for replication state caching.

Meaning, in the cluster, this code set should perform a lot more performance, being able to read realtime replication state from Redis.
* Transction API were modified to support passing context in the Transaction ctor, when the Replication tracker is being instantiated. (Redis IO needs context)