### PR TITLE
in_red_fs: refactored the "streaming data store" ctors to use StoreOptions & added validations to enforce "recommended" B-tree configurations for streaming use-case.

### DIFF
--- a/fs/replication_tracker.go
+++ b/fs/replication_tracker.go
@@ -123,6 +123,7 @@ func (r *replicationTracker) handleFailedToReplicate(ctx context.Context) {
 
 	// L2 cache "knows" of failure, just return.
 	if globalReplicationDetails.replicationStatus.FailedToReplicate {
+		r.replicationStatus.FailedToReplicate = true
 		return
 	}
 
@@ -158,8 +159,7 @@ func (r *replicationTracker) failover(ctx context.Context) error {
 		log.Warn(fmt.Sprintf("error while updating global replication status & L2 cache, details: %v", err))
 	}
 
-	if globalReplicationDetails.IsFirstFolderActive == !r.IsFirstFolderActive ||
-		r.replicationStatus.FailedToReplicate {
+	if globalReplicationDetails.IsFirstFolderActive == !r.IsFirstFolderActive {
 		// Do nothing if global tracker already knows that a failover already occurred.
 		return nil
 	}

--- a/in_red_fs/integration_tests/replication/replication_test.go
+++ b/in_red_fs/integration_tests/replication/replication_test.go
@@ -140,6 +140,46 @@ func TestDirectIOSetupNewFileFailure_WithReplication(t *testing.T) {
 
 }
 
+func TestOpenBtree_TransWithRepl_failed(t *testing.T) {
+	fs.DirectIOSim = newDirectIOReplicationSim()
+
+	ctx := context.Background()
+	// Take from global EC config the data paths & EC config details.
+	to, _ := in_red_fs.NewTransactionOptionsWithReplication(nil, sop.ForWriting, -1, fs.MinimumModValue, nil)
+
+	trans, err := in_red_fs.NewTransactionWithReplication(ctx, to)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	trans.Begin()
+	_, err = in_red_fs.OpenBtree[int, string](ctx, "repltable", trans, nil)
+	if err == nil {
+		t.Error("expected to fail but succeeded")
+		t.FailNow()
+	}
+}
+
+func TestOpenBtreeWithRepl_succeeded(t *testing.T) {
+	fs.DirectIOSim = newDirectIOReplicationSim()
+
+	ctx := context.Background()
+	// Take from global EC config the data paths & EC config details.
+	to, _ := in_red_fs.NewTransactionOptionsWithReplication(nil, sop.ForWriting, -1, fs.MinimumModValue, nil)
+
+	trans, err := in_red_fs.NewTransactionWithReplication(ctx, to)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	trans.Begin()
+	_, err = in_red_fs.OpenBtreeWithReplication[int, string](ctx, "repltable", trans, nil)
+	if err != nil {
+		t.Errorf("expected to succeed but failed, details: %v", err)
+		t.FailNow()
+	}
+}
+
 func TestDirectIOReadFromFileFailure(t *testing.T) {
 }
 func TestDirectIOWriteToFileFailure(t *testing.T) {

--- a/in_red_fs/integration_tests/streaming_data_store_test.go
+++ b/in_red_fs/integration_tests/streaming_data_store_test.go
@@ -19,7 +19,8 @@ func Test_StreamingDataStoreInvalidCases(t *testing.T) {
 	trans.Begin()
 
 	// Empty Store get/update methods test cases.
-	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "xyz", trans, nil)
+	so := sop.ConfigureStore("xyz", true, 100, "", sop.BigData, "")
+	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	if _, err := sds.GetCurrentValue(ctx); err == nil {
 		t.Errorf("GetCurrentValue on empty btree failed, got nil want err")
 	}
@@ -36,7 +37,8 @@ func Test_StreamingDataStoreBasicUse(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore", trans, nil)
+	so := sop.ConfigureStore("videoStore", true, 100, "", sop.BigData, "")
+	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo")
 	for i := 0; i < 10; i++ {
 		encoder.Encode(fmt.Sprintf("%d. a huge chunk, about 10MB.", i))
@@ -46,7 +48,7 @@ func Test_StreamingDataStoreBasicUse(t *testing.T) {
 	// Read back the data. Pass false on 2nd argument will toggle to a "reader" transaction.
 	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStore", trans, nil)
+	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 
 	ok, _ := sds.FindOne(ctx, "fooVideo")
 	if !ok {
@@ -81,7 +83,8 @@ func Test_StreamingDataStoreMultipleItems(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreM", trans, nil)
+	so := sop.ConfigureStore("videoStoreM", true, 100, "", sop.BigData, "")
+	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo")
 	for i := 0; i < 10; i++ {
 		encoder.Encode(fmt.Sprintf("%d. a huge chunk, about 12MB.", i))
@@ -96,7 +99,7 @@ func Test_StreamingDataStoreMultipleItems(t *testing.T) {
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
 	trans, _ = in_red_fs.NewTransaction(ctx, to2)
 	trans.Begin()
-	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreM", trans, nil)
+	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 
 	ok, _ := sds.FindOne(ctx, "fooVideo")
 	if !ok {
@@ -131,7 +134,8 @@ func Test_StreamingDataStoreDeleteAnItem(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreD", trans, nil)
+	so := sop.ConfigureStore("videoStoreD", true, 100, "", sop.BigData, "")
+	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo")
 	for i := 0; i < 10; i++ {
 		encoder.Encode(fmt.Sprintf("%d. a huge chunk, about 12MB.", i))
@@ -185,7 +189,8 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreU", trans, nil)
+	so := sop.ConfigureStore("videoStoreU", true, 100, "", sop.BigData, "")
+	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo2")
 	for i := 0; i < 10; i++ {
 		encoder.Encode(fmt.Sprintf("%d. a huge chunk, about 10MB.", i))
@@ -195,7 +200,7 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 	// Update the video.
 	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreU", trans, nil)
+	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ = sds.Update(ctx, "fooVideo2")
 	chunkCount := 9
 	for i := 0; i < chunkCount; i++ {
@@ -209,7 +214,7 @@ func Test_StreamingDataStoreBigDataUpdate(t *testing.T) {
 	to2, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForReading, -1, fs.MinimumModValue)
 	trans, _ = in_red_fs.NewTransaction(ctx, to2)
 	trans.Begin()
-	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStoreU", trans, nil)
+	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 
 	ok, _ := sds.FindOne(ctx, "fooVideo2")
 	if !ok {
@@ -245,7 +250,8 @@ func Test_StreamingDataStoreUpdateWithCountCheck(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore2", trans, nil)
+	so := sop.ConfigureStore("videoStore2", true, 100, "", sop.BigData, "")
+	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo1")
 	encodeVideo(encoder, 50)
 	trans.Commit(ctx)
@@ -253,7 +259,7 @@ func Test_StreamingDataStoreUpdateWithCountCheck(t *testing.T) {
 	// Update the video.
 	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStore2", trans, nil)
+	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ = sds.Update(ctx, "fooVideo1")
 	encodeVideo(encoder, 5)
 	// Important to close the encoder, otherwise, cleanup will not happen.
@@ -271,7 +277,8 @@ func Test_StreamingDataStoreUpdateExtend(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore4", trans, nil)
+	so := sop.ConfigureStore("videoStore4", true, 100, "", sop.BigData, "")
+	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo3")
 	encodeVideo(encoder, 5)
 	trans.Commit(ctx)
@@ -279,7 +286,7 @@ func Test_StreamingDataStoreUpdateExtend(t *testing.T) {
 	// Update the video.
 	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStore4", trans, nil)
+	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ = sds.Update(ctx, "fooVideo3")
 	encodeVideo(encoder, 7)
 	// Since we updated with 7 chunks, 2 longer than existing, Close will not do anything.
@@ -298,7 +305,8 @@ func Test_StreamingDataStoreUpdate(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore5", trans, nil)
+	so := sop.ConfigureStore("videoStore5", true, 100, "", sop.BigData, "")
+	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ := sds.Add(ctx, "fooVideo")
 	encodeVideo(encoder, 5)
 	trans.Commit(ctx)
@@ -306,7 +314,7 @@ func Test_StreamingDataStoreUpdate(t *testing.T) {
 	// Update the video.
 	trans, _ = in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, "videoStore5", trans, nil)
+	sds, _ = in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 	encoder, _ = sds.Update(ctx, "fooVideo")
 	encodeVideo(encoder, 5)
 	encoder.Close()
@@ -323,7 +331,8 @@ func Test_StreamingDataStoreDelete(t *testing.T) {
 	to, _ := in_red_fs.NewTransactionOptions(dataPath, sop.ForWriting, -1, fs.MinimumModValue)
 	trans, _ := in_red_fs.NewTransaction(ctx, to)
 	trans.Begin()
-	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, "videoStore3", trans, nil)
+	so := sop.ConfigureStore("videoStore3", true, 100, "", sop.BigData, "")
+	sds, _ := in_red_fs.NewStreamingDataStore[string](ctx, so, trans, nil)
 
 	encoder, _ := sds.Add(ctx, "fooVideo1")
 	encodeVideo(encoder, 50)

--- a/in_red_fs/manage_btree.go
+++ b/in_red_fs/manage_btree.go
@@ -15,7 +15,7 @@ import (
 	sd "github.com/SharedCode/sop/streaming_data"
 )
 
-const(
+const (
 	minimumStreamingStoreSlotLength = 50
 )
 
@@ -56,17 +56,17 @@ func OpenBtree[TK btree.Ordered, TV any](ctx context.Context, name string, t sop
 // If B-Tree(name) is not found in the backend, a new one will be created. Otherwise, the existing one will be opened
 // and the parameters checked if matching. If you know that it exists, then it is more convenient and more readable to call
 // the OpenBtree function.
-func NewBtree[TK btree.Ordered, TV any](ctx context.Context, si sop.StoreOptions, t sop.Transaction, comparer btree.ComparerFunc[TK]) (btree.BtreeInterface[TK, TV], error) {
+func NewBtree[TK btree.Ordered, TV any](ctx context.Context, so sop.StoreOptions, t sop.Transaction, comparer btree.ComparerFunc[TK]) (btree.BtreeInterface[TK, TV], error) {
 	if ct, ok := t.GetPhasedTransaction().(*common.Transaction); ok {
 		if ct.HandleReplicationRelatedError != nil {
 			return nil, fmt.Errorf("failed in NewBtree as transaction has replication enabled, use NewBtreeWithReplication instead")
 		}
 	}
-	si.DisableRegistryStoreFormatting = true
+	so.DisableRegistryStoreFormatting = true
 	trans, _ := t.GetPhasedTransaction().(*common.Transaction)
 	sr := trans.GetStoreRepository().(*fs.StoreRepository)
-	si.BlobStoreBaseFolderPath = sr.GetStoresBaseFolder()
-	return common.NewBtree[TK, TV](ctx, si, t, comparer)
+	so.BlobStoreBaseFolderPath = sr.GetStoresBaseFolder()
+	return common.NewBtree[TK, TV](ctx, so, t, comparer)
 }
 
 // OpenBtreeWithReplication will (open &) instantiate a B-tree that has SOP's file system based replication feature.
@@ -80,15 +80,15 @@ func OpenBtreeWithReplication[TK btree.Ordered, TV any](ctx context.Context, nam
 }
 
 // NewBtreeWithReplication will (create! &) instantiate a B-tree that has SOP's file system based replication feature.
-func NewBtreeWithReplication[TK btree.Ordered, TV any](ctx context.Context, si sop.StoreOptions, t sop.Transaction, comparer btree.ComparerFunc[TK]) (btree.BtreeInterface[TK, TV], error) {
+func NewBtreeWithReplication[TK btree.Ordered, TV any](ctx context.Context, so sop.StoreOptions, t sop.Transaction, comparer btree.ComparerFunc[TK]) (btree.BtreeInterface[TK, TV], error) {
 	if ct, ok := t.GetPhasedTransaction().(*common.Transaction); ok {
 		if ct.HandleReplicationRelatedError == nil {
 			return nil, fmt.Errorf("failed in NewBtreeWithReplication as transaction has no replication, use NewBtree instead")
 		}
 	}
-	si.DisableRegistryStoreFormatting = true
-	si.DisableBlobStoreFormatting = true
-	return common.NewBtree[TK, TV](ctx, si, t, comparer)
+	so.DisableRegistryStoreFormatting = true
+	so.DisableBlobStoreFormatting = true
+	return common.NewBtree[TK, TV](ctx, so, t, comparer)
 }
 
 // Streaming Data Store related.


### PR DESCRIPTION
in_red_fs: refactored the "streaming data store" ctors to use StoreOptions instead of parameters (cleaner) & added validations to enforce "recommended" B-tree configurations for "big/medium data" streaming use-case.