### PR TITLE
in_red_fs: refactored the Registry interface & structs for good separation of concerns.

### DIFF
--- a/cassandra/registry.go
+++ b/cassandra/registry.go
@@ -110,37 +110,65 @@ func (v *registry) Update(ctx context.Context, storesHandles []sop.RegistryPaylo
 	return nil
 }
 
-func (v *registry) UpdateNoLocks(ctx context.Context, storesHandles []sop.RegistryPayload[sop.Handle]) error {
-
-	// Do the actual batch logged transaction update in Cassandra.
-	batch := connection.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
-	if connection.Config.ConsistencyBook.RegistryUpdate > gocql.Any {
-		batch.SetConsistency(connection.Config.ConsistencyBook.RegistryUpdate)
+func (v *registry) UpdateNoLocks(ctx context.Context, allOrNothing bool, storesHandles []sop.RegistryPayload[sop.Handle]) error {
+	if connection == nil {
+		return fmt.Errorf("Cassandra connection is closed, 'call OpenConnection(config) to open it")
 	}
 
-	for _, sh := range storesHandles {
-		updateStatement := fmt.Sprintf("UPDATE %s.%s SET is_idb = ?, p_ida = ?, p_idb = ?, ver = ?, wip_ts = ?, is_del = ? WHERE lid = ?;",
-			connection.Config.Keyspace, sh.RegistryTable)
-		for _, h := range sh.IDs {
-			// Enqueue update registry record cmd.
-			batch.Query(updateStatement, h.IsActiveIDB, gocql.UUID(h.PhysicalIDA), gocql.UUID(h.PhysicalIDB),
-				h.Version, h.WorkInProgressTimestamp, h.IsDeleted, gocql.UUID(h.LogicalID))
+	if allOrNothing {
+		// Do the actual batch logged transaction update in Cassandra.
+		batch := connection.Session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+		if connection.Config.ConsistencyBook.RegistryUpdate > gocql.Any {
+			batch.SetConsistency(connection.Config.ConsistencyBook.RegistryUpdate)
 		}
-	}
 
-	// Execute the batch query, all or nothing.
-	if err := connection.Session.ExecuteBatch(batch); err != nil {
-		// Failed update all, thus, return err to cause rollback.
-		return err
-	}
-
-	// Update redis cache.
-	for _, sh := range storesHandles {
-		for _, h := range sh.IDs {
-			if err := v.l2Cache.SetStruct(ctx, h.LogicalID.String(), &h, sh.CacheDuration); err != nil {
-				log.Warn(fmt.Sprintf("Registry Update (redis setstruct) failed, details: %v", err))
+		for _, sh := range storesHandles {
+			updateStatement := fmt.Sprintf("UPDATE %s.%s SET is_idb = ?, p_ida = ?, p_idb = ?, ver = ?, wip_ts = ?, is_del = ? WHERE lid = ?;",
+				connection.Config.Keyspace, sh.RegistryTable)
+			for _, h := range sh.IDs {
+				// Enqueue update registry record cmd.
+				batch.Query(updateStatement, h.IsActiveIDB, gocql.UUID(h.PhysicalIDA), gocql.UUID(h.PhysicalIDB),
+					h.Version, h.WorkInProgressTimestamp, h.IsDeleted, gocql.UUID(h.LogicalID))
 			}
-			v.l1Cache.Handles.Set(convertToKvp([]sop.Handle{h}))
+		}
+
+		// Execute the batch query, all or nothing.
+		if err := connection.Session.ExecuteBatch(batch); err != nil {
+			// Failed update all, thus, return err to cause rollback.
+			return err
+		}
+
+		// Update redis cache.
+		for _, sh := range storesHandles {
+			for _, h := range sh.IDs {
+				if err := v.l2Cache.SetStruct(ctx, h.LogicalID.String(), &h, sh.CacheDuration); err != nil {
+					log.Warn(fmt.Sprintf("Registry Update (redis setstruct) failed, details: %v", err))
+				}
+				v.l1Cache.Handles.Set(convertToKvp([]sop.Handle{h}))
+			}
+		}
+	} else {
+		for _, sh := range storesHandles {
+			updateStatement := fmt.Sprintf("UPDATE %s.%s SET is_idb = ?, p_ida = ?, p_idb = ?, ver = ?, wip_ts = ?, is_del = ? WHERE lid = ?;",
+				connection.Config.Keyspace, sh.RegistryTable)
+			// Fail on 1st encountered error. It is non-critical operation, SOP can "heal" those got left.
+			for _, h := range sh.IDs {
+				qry := connection.Session.Query(updateStatement, h.IsActiveIDB, gocql.UUID(h.PhysicalIDA), gocql.UUID(h.PhysicalIDB),
+					h.Version, h.WorkInProgressTimestamp, h.IsDeleted, gocql.UUID(h.LogicalID)).WithContext(ctx)
+				if connection.Config.ConsistencyBook.RegistryUpdate > gocql.Any {
+					qry.Consistency(connection.Config.ConsistencyBook.RegistryUpdate)
+				}
+
+				// Update registry record.
+				if err := qry.Exec(); err != nil {
+					return err
+				}
+
+				if err := v.l2Cache.SetStruct(ctx, h.LogicalID.String(), &h, sh.CacheDuration); err != nil {
+					log.Warn(fmt.Sprintf("Registry Update (redis setstruct) failed, details: %v", err))
+				}
+				v.l1Cache.Handles.Set(convertToKvp([]sop.Handle{h}))
+			}
 		}
 	}
 

--- a/common/actively_persisted_item_test.go
+++ b/common/actively_persisted_item_test.go
@@ -27,7 +27,7 @@ func Test_StreamingDataStoreRollbackShouldEraseTIDLogs(t *testing.T) {
 	sds.Add(ctx, "fooVideo2", "video content")
 
 	tidLogs := trans.GetPhasedTransaction().(*Transaction).
-		logger.logger.(*mocks.MockTransactionLog).GetTIDLogs(
+		logger.TransactionLog.(*mocks.MockTransactionLog).GetTIDLogs(
 		trans.GetPhasedTransaction().(*Transaction).logger.transactionID)
 
 	if tidLogs == nil {
@@ -37,7 +37,7 @@ func Test_StreamingDataStoreRollbackShouldEraseTIDLogs(t *testing.T) {
 	trans.Rollback(ctx)
 
 	gotTidLogs := trans.GetPhasedTransaction().(*Transaction).
-		logger.logger.(*mocks.MockTransactionLog).GetTIDLogs(
+		logger.TransactionLog.(*mocks.MockTransactionLog).GetTIDLogs(
 		trans.GetPhasedTransaction().(*Transaction).logger.transactionID)
 
 	if gotTidLogs != nil {
@@ -74,7 +74,7 @@ func Test_StreamingDataStoreAbandonedTransactionLogsGetCleaned(t *testing.T) {
 	twoPhaseTrans := pt.(*Transaction)
 
 	// GetOne should not get anything as uncommitted transaction is still ongoing or not expired.
-	tid, _, _, _ := twoPhaseTrans.logger.logger.GetOne(ctx)
+	tid, _, _, _ := twoPhaseTrans.logger.GetOne(ctx)
 	if !tid.IsNil() {
 		t.Errorf("Failed, got %v, want nil.", tid)
 	}
@@ -85,7 +85,7 @@ func Test_StreamingDataStoreAbandonedTransactionLogsGetCleaned(t *testing.T) {
 	sop.Now = func() time.Time { return today }
 	//Now = func() time.Time { return today }
 
-	tid, _, _, _ = twoPhaseTrans.logger.logger.GetOne(ctx)
+	tid, _, _, _ = twoPhaseTrans.logger.GetOne(ctx)
 	if tid.IsNil() {
 		t.Errorf("Failed, got nil, want valid Tid.")
 	}
@@ -94,7 +94,7 @@ func Test_StreamingDataStoreAbandonedTransactionLogsGetCleaned(t *testing.T) {
 		t.Errorf("processExpiredTransactionLogs failed, got %v want nil.", err)
 	}
 
-	tid, _, _, _ = twoPhaseTrans.logger.logger.GetOne(ctx)
+	tid, _, _, _ = twoPhaseTrans.logger.GetOne(ctx)
 	if !tid.IsNil() {
 		t.Errorf("Failed, got %v, want nil.", tid)
 	}

--- a/common/mocks/mock_registry.go
+++ b/common/mocks/mock_registry.go
@@ -37,7 +37,7 @@ func (v *Mock_vid_registry) Update(ctx context.Context, storesHandles []sop.Regi
 	}
 	return nil
 }
-func (v *Mock_vid_registry) UpdateNoLocks(ctx context.Context, storesHandles []sop.RegistryPayload[sop.Handle]) error {
+func (v *Mock_vid_registry) UpdateNoLocks(ctx context.Context, allOrNothing bool, storesHandles []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
 

--- a/common/node_repository_backend.go
+++ b/common/node_repository_backend.go
@@ -295,7 +295,7 @@ func (nr *nodeRepositoryBackend) commitUpdatedNodes(ctx context.Context, nodes [
 	}
 	log.Debug("outside commitUpdatedNodes forloop trying to AllocateID")
 
-	if err := nr.transaction.registry.UpdateNoLocks(ctx, handles); err != nil {
+	if err := nr.transaction.registry.UpdateNoLocks(ctx, false, handles); err != nil {
 		log.Debug(fmt.Sprintf("commitUpdatedNodes failed registry.Update, details: %v", err))
 		return false, nil, err
 	}
@@ -340,7 +340,7 @@ func (nr *nodeRepositoryBackend) commitRemovedNodes(ctx context.Context, nodes [
 		}
 	}
 	// Persist the handles changes.
-	if err := nr.transaction.registry.UpdateNoLocks(ctx, handles); err != nil {
+	if err := nr.transaction.registry.UpdateNoLocks(ctx, false, handles); err != nil {
 		return false, nil, err
 	}
 	return true, handles, nil
@@ -520,7 +520,7 @@ func (nr *nodeRepositoryBackend) rollbackUpdatedNodes(ctx context.Context, nodes
 	}
 	// Undo changes in virtual ID registry.
 	if nodesAreLocked {
-		if err = nr.transaction.registry.UpdateNoLocks(ctx, handles); err != nil {
+		if err = nr.transaction.registry.UpdateNoLocks(ctx, false, handles); err != nil {
 			lastErr = fmt.Errorf("unable to undo updated nodes registration, %v, error: %v", handles, err)
 			log.Error(lastErr.Error())
 		}
@@ -599,7 +599,7 @@ func (nr *nodeRepositoryBackend) rollbackRemovedNodes(ctx context.Context, nodes
 
 	// Persist the handles changes.
 	if nodesAreLocked {
-		if err := nr.transaction.registry.UpdateNoLocks(ctx, handlesForRollback); err != nil {
+		if err := nr.transaction.registry.UpdateNoLocks(ctx, false, handlesForRollback); err != nil {
 			err = fmt.Errorf("unable to undo removed nodes in registry, %v, error: %v", handlesForRollback, err)
 			log.Error(err.Error())
 			return err

--- a/common/transaction_logging_test.go
+++ b/common/transaction_logging_test.go
@@ -85,7 +85,7 @@ func Test_TLog_FailOnFinalizeCommit(t *testing.T) {
 	twoPhaseTrans.phase1Commit(ctx)
 
 	// GetOne should not get anything as uncommitted transaction is still ongoing or not expired.
-	tid, _, _, _ := twoPhaseTrans.logger.logger.GetOne(ctx)
+	tid, _, _, _ := twoPhaseTrans.logger.GetOne(ctx)
 	if !tid.IsNil() {
 		t.Errorf("Failed, got %v, want nil.", tid)
 	}
@@ -96,7 +96,7 @@ func Test_TLog_FailOnFinalizeCommit(t *testing.T) {
 	sop.Now = func() time.Time { return today }
 	//Now = func() time.Time { return today }
 
-	tid, _, _, _ = twoPhaseTrans.logger.logger.GetOne(ctx)
+	tid, _, _, _ = twoPhaseTrans.logger.GetOne(ctx)
 	if tid.IsNil() {
 		t.Errorf("Failed, got nil Tid, want valid Tid.")
 	}

--- a/fs/registry.go
+++ b/fs/registry.go
@@ -92,7 +92,7 @@ func (r *registryOnDisk) Update(ctx context.Context, storesHandles []sop.Registr
 	return nil
 }
 
-func (r *registryOnDisk) UpdateNoLocks(ctx context.Context, storesHandles []sop.RegistryPayload[sop.Handle]) error {
+func (r *registryOnDisk) UpdateNoLocks(ctx context.Context, allOrNothing bool, storesHandles []sop.RegistryPayload[sop.Handle]) error {
 	for _, sh := range storesHandles {
 		if err := r.hashmap.set(ctx, sop.Tuple[string, []sop.Handle]{First: sh.RegistryTable, Second: sh.IDs}); err != nil {
 			for _, h := range sh.IDs {

--- a/repository.go
+++ b/repository.go
@@ -93,10 +93,6 @@ type FileSystemSpecificLog interface {
 // Transaction Log specifies the API(methods) needed to implement logging for the transaction.
 type TransactionLog interface {
 	FileSystemSpecificLog
-	// Add a transaction log.
-	Add(ctx context.Context, tid UUID, commitFunction int, payload []byte) error
-	// Remove all logs of a given transaciton.
-	Remove(ctx context.Context, tid UUID) error
 
 	// GetOne will fetch the oldest transaction logs from the backend, older than 1 hour ago, mark it so succeeding call
 	// will return the next hour and so on, until no more, upon reaching the current hour.

--- a/repository.go
+++ b/repository.go
@@ -36,7 +36,7 @@ type Registry interface {
 	Update(ctx context.Context, handles []RegistryPayload[Handle]) error
 	// Update for use in an active transaction where the registry handles for update were
 	// all pre-locked (& post call unlocked) by the transaction manager.
-	UpdateNoLocks(ctx context.Context, storesHandles []RegistryPayload[Handle]) error
+	UpdateNoLocks(ctx context.Context, allOrNothing bool, storesHandles []RegistryPayload[Handle]) error
 	// Remove will delete handles(given their IDs) from registry table(s).
 	Remove(context.Context, []RegistryPayload[UUID]) error
 
@@ -77,8 +77,22 @@ type BlobsPayload[T UUID | KeyValuePair[UUID, []byte]] struct {
 	Blobs []T
 }
 
+// File system specific log.
+type FileSystemSpecificLog interface {
+	// Add a transaction log.
+	Add(ctx context.Context, tid UUID, commitFunction int, payload []byte) error
+	// Remove all logs of a given transaciton.
+	Remove(ctx context.Context, tid UUID) error
+	// Fetch the transaction priority logs details given a transaction ID.
+	Get(ctx context.Context, tid UUID) ([]RegistryPayload[Handle], error)
+	// Log commit changes to its own log file separate than the rest of transaction logs.
+	// This is a special log file only used during "reinstate" of drives back for replication.
+	LogCommitChanges(ctx context.Context, stores []StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []RegistryPayload[Handle]) error
+}
+
 // Transaction Log specifies the API(methods) needed to implement logging for the transaction.
 type TransactionLog interface {
+	FileSystemSpecificLog
 	// Add a transaction log.
 	Add(ctx context.Context, tid UUID, commitFunction int, payload []byte) error
 	// Remove all logs of a given transaciton.
@@ -98,16 +112,9 @@ type TransactionLog interface {
 	// Or nils if there is no more needing cleanup for this date hour.
 	GetOneOfHour(ctx context.Context, hour string) (UUID, []KeyValuePair[int, []byte], error)
 
-	// Fetch the transaction priority logs details given a transaction ID.
-	Get(ctx context.Context, tid UUID) ([]RegistryPayload[Handle], error)
-
 	// Implement to generate a new UUID. Cassandra transaction logging uses gocql.UUIDFromTime, SOP in file system
 	// should just use the general sop.NewUUID function which currently uses google's uuid package.
 	NewUUID() UUID
-
-	// Log commit changes to its own log file separate than the rest of transaction logs.
-	// This is a special log file only used during "reinstate" of drives back for replication.
-	LogCommitChanges(ctx context.Context, stores []StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []RegistryPayload[Handle]) error
 }
 
 // StoreRepository specifies CRUD methods for StoreInfo (storage &) management.


### PR DESCRIPTION
in_red_fs: refactored the Registry interface & structs for good separation of concerns.
Cassandra registry brings back the "all or nothing" feature that takes advantage of Cassandra cluster's
batch logged (all or nothing) feature.
File System registry uses SOP replication & registry resilience via SOP tranasaction logging