### PR TITLE
in_red_fs: registry update "all or nothing" on failure will attempt to restore any changes done and if that fails, will issue a "failover" error to cause a failover

### DIFF
--- a/cassandra/transaction_log.go
+++ b/cassandra/transaction_log.go
@@ -245,3 +245,12 @@ func (d dummy) Add(ctx context.Context, tid sop.UUID, payload []byte) error {
 func (d dummy) Remove(ctx context.Context, tid sop.UUID) error {
 	return nil
 }
+
+// Write a backup file for the priority log contents (payload).
+func (d dummy) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error {
+	return nil
+}
+
+func (d dummy) RemoveBackup(ctx context.Context, tid sop.UUID) error {
+	return nil
+}

--- a/common/node_repository_backend.go
+++ b/common/node_repository_backend.go
@@ -416,15 +416,12 @@ func (nr *nodeRepositoryBackend) areFetchedItemsIntact(ctx context.Context, node
 	return true, nil
 }
 
-func (nr *nodeRepositoryBackend) rollbackNewRootNodes(ctx context.Context, rollbackData interface{}) error {
-	if rollbackData == nil {
+func (nr *nodeRepositoryBackend) rollbackNewRootNodes(ctx context.Context, rollbackData sop.Tuple[[]sop.RegistryPayload[sop.UUID], []sop.BlobsPayload[sop.UUID]]) error {
+	if len(rollbackData.First) == 0 {
 		return nil
 	}
-	var bibs []sop.BlobsPayload[sop.UUID]
-	var vids []sop.RegistryPayload[sop.UUID]
-	tup := rollbackData.(sop.Tuple[[]sop.RegistryPayload[sop.UUID], []sop.BlobsPayload[sop.UUID]])
-	vids = tup.First
-	bibs = tup.Second
+	vids := rollbackData.First
+	bibs := rollbackData.Second
 	if len(vids) == 0 {
 		return nil
 	}
@@ -456,12 +453,9 @@ func (nr *nodeRepositoryBackend) rollbackNewRootNodes(ctx context.Context, rollb
 	return lastErr
 }
 
-func (nr *nodeRepositoryBackend) rollbackAddedNodes(ctx context.Context, rollbackData interface{}) error {
-	var bibs []sop.BlobsPayload[sop.UUID]
-	var vids []sop.RegistryPayload[sop.UUID]
-	tup := rollbackData.(sop.Tuple[[]sop.RegistryPayload[sop.UUID], []sop.BlobsPayload[sop.UUID]])
-	vids = tup.First
-	bibs = tup.Second
+func (nr *nodeRepositoryBackend) rollbackAddedNodes(ctx context.Context, rollbackData sop.Tuple[[]sop.RegistryPayload[sop.UUID], []sop.BlobsPayload[sop.UUID]]) error {
+	vids := rollbackData.First
+	bibs := rollbackData.Second
 	if len(vids) == 0 {
 		return nil
 	}

--- a/error.go
+++ b/error.go
@@ -12,26 +12,13 @@ const (
 	RestoreRegistryFileSectorFailure
 )
 
-type ErrorMetadata interface {
-	GetCode() ErrorCode
-	GetError() error
-}
-
 // SOP custom error.
-type Error[T any] struct {
-	ErrorMetadata
+type Error struct {
 	Code     ErrorCode
 	Err      error
-	UserData T
+	UserData any
 }
 
-func (e Error[T]) GetCode() ErrorCode {
-	return e.Code
-}
-func (e Error[T]) GetError() error {
-	return e.Err
-}
-
-func (e Error[T]) Error() string {
-	return fmt.Errorf("Error %d: %w, user data: %v", e.Code, e.Err, e.UserData).Error()
+func (e Error) Error() string {
+	return fmt.Errorf("error code: %d, user data: %v, details: %w", e.Code, e.UserData, e.Err).Error()
 }

--- a/fs/file_io.go
+++ b/fs/file_io.go
@@ -37,7 +37,7 @@ func (dio defaultFileIO) WriteFile(ctx context.Context, name string, data []byte
 				err := os.WriteFile(name, data, perm)
 				if err != nil {
 					return retry.RetryableError(
-						sop.Error[string]{
+						sop.Error{
 							Code: sop.FileIOError,
 							Err:  err,
 						})
@@ -56,7 +56,7 @@ func (dio defaultFileIO) ReadFile(ctx context.Context, name string) ([]byte, err
 		ba, err = os.ReadFile(name)
 		if err != nil {
 			return retry.RetryableError(
-				sop.Error[string]{
+				sop.Error{
 					Code: sop.FileIOError,
 					Err:  err,
 				})
@@ -70,7 +70,7 @@ func (dio defaultFileIO) Remove(ctx context.Context, name string) error {
 		err := os.Remove(name)
 		if err != nil {
 			return retry.RetryableError(
-				sop.Error[string]{
+				sop.Error{
 					Code: sop.FileIOError,
 					Err:  err,
 				})
@@ -84,7 +84,7 @@ func (dio defaultFileIO) MkdirAll(ctx context.Context, path string, perm os.File
 		err := os.MkdirAll(path, perm)
 		if err != nil {
 			return retry.RetryableError(
-				sop.Error[string]{
+				sop.Error{
 					Code: sop.FileIOError,
 					Err:  err,
 				})
@@ -97,7 +97,7 @@ func (dio defaultFileIO) RemoveAll(ctx context.Context, path string) error {
 		err := os.RemoveAll(path)
 		if err != nil {
 			return retry.RetryableError(
-				sop.Error[string]{
+				sop.Error{
 					Code: sop.FileIOError,
 					Err:  err,
 				})
@@ -117,7 +117,7 @@ func (dio defaultFileIO) ReadDir(ctx context.Context, sourceDir string) ([]os.Di
 		var err error
 		r, err = os.ReadDir(sourceDir)
 		if err != nil {
-			return retry.RetryableError(sop.Error[string]{
+			return retry.RetryableError(sop.Error{
 				Code: sop.FileIOError,
 				Err:  err,
 			})

--- a/fs/hashmap_file_region.go
+++ b/fs/hashmap_file_region.go
@@ -73,7 +73,7 @@ func (hm *hashmap) updateFileBlockRegion(ctx context.Context, dio *directIO, blo
 			err = fmt.Errorf("updateFileBlockRegion failed: %w", err)
 			log.Debug(err.Error())
 			lk.LockID = tid
-			return sop.Error[*sop.LockKey]{
+			return sop.Error{
 				Code:     sop.LockAcquisitionFailure,
 				Err:      err,
 				UserData: lk,

--- a/fs/registry_map.go
+++ b/fs/registry_map.go
@@ -19,11 +19,11 @@ func newRegistryMap(readWrite bool, hashModValue int, replicationTracker *replic
 }
 
 // Add a given set of Handle(s) record(s) on file(s) where they are supposed to get stored in.
-func (rm registryMap) add(ctx context.Context, items ...sop.Tuple[string, []sop.Handle]) error {
+func (rm registryMap) add(ctx context.Context, storesHandles []sop.RegistryPayload[sop.Handle]) error {
 	// Individually write to the file area occupied by the handle so we don't create "lock pressure".
-	for _, item := range items {
-		for _, h := range item.Second {
-			frd, err := rm.hashmap.findFileRegion(ctx, item.First, []sop.UUID{h.LogicalID})
+	for _, item := range storesHandles {
+		for _, h := range item.IDs {
+			frd, err := rm.hashmap.findFileRegion(ctx, item.RegistryTable, []sop.UUID{h.LogicalID})
 			if err != nil {
 				return err
 			}
@@ -46,22 +46,22 @@ func (rm registryMap) add(ctx context.Context, items ...sop.Tuple[string, []sop.
 }
 
 // Update a given set of Handle(s) record(s) on file(s) where they are stored in.
-func (rm registryMap) set(ctx context.Context, items ...sop.Tuple[string, []sop.Handle]) error {
-	for _, item := range items {
-		frds, err := rm.hashmap.findFileRegion(ctx, item.First, getIDs(item.Second))
+func (rm registryMap) set(ctx context.Context, storesHandles []sop.RegistryPayload[sop.Handle]) error {
+	for _, item := range storesHandles {
+		frds, err := rm.hashmap.findFileRegion(ctx, item.RegistryTable, getIDs(item.IDs))
 		if err != nil {
 			return err
 		}
 		// Update the Handles read w/ the items' values.
 		for i := range frds {
 			// Check if the record in the target file region is different.
-			if !frds[i].handle.IsEmpty() && frds[i].handle.LogicalID != item.Second[i].LogicalID {
+			if !frds[i].handle.IsEmpty() && frds[i].handle.LogicalID != item.IDs[i].LogicalID {
 				// Fail if the record on target is different.
 				return fmt.Errorf("registryMap.set failed, an item(target lid=%v) at offset=%v is different (source lid=%v)",
-					frds[i].handle.LogicalID, frds[i].getOffset(), item.Second[i].LogicalID)
+					frds[i].handle.LogicalID, frds[i].getOffset(), item.IDs[i].LogicalID)
 			}
 			// Update the handle with incoming.
-			frds[i].handle = item.Second[i]
+			frds[i].handle = item.IDs[i]
 		}
 
 		// Do actual file region update.
@@ -75,27 +75,27 @@ func (rm registryMap) set(ctx context.Context, items ...sop.Tuple[string, []sop.
 }
 
 // Fetch the Handle record(s) from a given set of file(s) & their UUID(s).
-func (rm registryMap) fetch(ctx context.Context, keys ...sop.Tuple[string, []sop.UUID]) ([]sop.Tuple[string, []sop.Handle], error) {
-	result := make([]sop.Tuple[string, []sop.Handle], 0, len(keys))
+func (rm registryMap) fetch(ctx context.Context, keys []sop.RegistryPayload[sop.UUID]) ([]sop.RegistryPayload[sop.Handle], error) {
+	result := make([]sop.RegistryPayload[sop.Handle], 0, len(keys))
 	for _, k := range keys {
-		handles, err := rm.hashmap.fetch(ctx, k.First, k.Second)
+		handles, err := rm.hashmap.fetch(ctx, k.RegistryTable, k.IDs)
 		if err != nil {
 			return nil, fmt.Errorf("registryMap.fetch failed, details: %w", err)
 		}
-		result = append(result, sop.Tuple[string, []sop.Handle]{
-			First:  k.First,
-			Second: handles,
+		result = append(result, sop.RegistryPayload[sop.Handle]{
+			RegistryTable: k.RegistryTable,
+			IDs:           handles,
 		})
 	}
 	return result, nil
 }
 
 // Mark the Handle record(s) on file to be deleted & reuse ready.
-func (rm registryMap) remove(ctx context.Context, keys ...sop.Tuple[string, []sop.UUID]) error {
+func (rm registryMap) remove(ctx context.Context, keys []sop.RegistryPayload[sop.UUID]) error {
 	// Individually delete the file area occupied by the handle so we don't create "lock pressure".
 	for _, key := range keys {
 
-		frds, err := rm.hashmap.findFileRegion(ctx, key.First, key.Second)
+		frds, err := rm.hashmap.findFileRegion(ctx, key.RegistryTable, key.IDs)
 		if err != nil {
 			return err
 		}
@@ -106,10 +106,10 @@ func (rm registryMap) remove(ctx context.Context, keys ...sop.Tuple[string, []so
 				return fmt.Errorf("registryMap.remove failed, an item at offset=%v was not found, can't delete a missing item", frds[i].getOffset())
 			}
 			// Check if the record in the target file region is different.
-			if frds[i].handle.LogicalID != key.Second[i] {
+			if frds[i].handle.LogicalID != key.IDs[i] {
 				// Fail if the found record on target is different.
 				return fmt.Errorf("registryMap.remove failed, an item(target lid=%v) at offset=%v is different (source lid=%v)",
-					frds[i].handle.LogicalID, frds[i].getOffset(), key.Second[i])
+					frds[i].handle.LogicalID, frds[i].getOffset(), key.IDs[i])
 			}
 		}
 

--- a/fs/registry_map_test.go
+++ b/fs/registry_map_test.go
@@ -14,10 +14,10 @@ func TestRegistryMapAdd(t *testing.T) {
 
 	h := sop.NewHandle(uuid)
 
-	if err := r.add(ctx, sop.Tuple[string, []sop.Handle]{
-		First:  "regtest",
-		Second: []sop.Handle{h},
-	}); err != nil {
+	if err := r.add(ctx, []sop.RegistryPayload[sop.Handle]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.Handle{h},
+	}}); err != nil {
 		t.Error(err.Error())
 	}
 
@@ -31,10 +31,10 @@ func TestRegistryMapSet(t *testing.T) {
 
 	h := sop.NewHandle(uuid)
 
-	if err := r.set(ctx, sop.Tuple[string, []sop.Handle]{
-		First:  "regtest",
-		Second: []sop.Handle{h},
-	}); err != nil {
+	if err := r.set(ctx, []sop.RegistryPayload[sop.Handle]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.Handle{h},
+	}}); err != nil {
 		t.Error(err.Error())
 	}
 
@@ -46,14 +46,14 @@ func TestRegistryMapGet(t *testing.T) {
 	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
 	r := newRegistryMap(true, hashMod, rt, redis.NewClient())
 
-	if res, err := r.fetch(ctx, sop.Tuple[string, []sop.UUID]{
-		First:  "regtest",
-		Second: []sop.UUID{uuid},
-	}); err != nil {
+	if res, err := r.fetch(ctx, []sop.RegistryPayload[sop.UUID]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.UUID{uuid},
+	}}); err != nil {
 		t.Error(err.Error())
 	} else {
-		if res[0].First != "regtest" || res[0].Second[0].LogicalID != uuid {
-			t.Errorf("Expected: First='regtest', Second='%v', got: First: %s, Second=%v", uuid, res[0].First, res[0].Second[0].LogicalID)
+		if res[0].RegistryTable != "regtest" || res[0].IDs[0].LogicalID != uuid {
+			t.Errorf("Expected: First='regtest', Second='%v', got: First: %s, Second=%v", uuid, res[0].RegistryTable, res[0].IDs[0].LogicalID)
 		}
 	}
 
@@ -65,10 +65,10 @@ func TestRegistryMapRemove(t *testing.T) {
 	rt, _ := NewReplicationTracker(ctx, []string{"/Users/grecinto/sop_data/"}, false, l2cache)
 	r := newRegistryMap(true, hashMod, rt, redis.NewClient())
 
-	if err := r.remove(ctx, sop.Tuple[string, []sop.UUID]{
-		First:  "regtest",
-		Second: []sop.UUID{uuid},
-	}); err != nil {
+	if err := r.remove(ctx, []sop.RegistryPayload[sop.UUID]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.UUID{uuid},
+	}}); err != nil {
 		t.Error(err.Error())
 	}
 
@@ -82,24 +82,24 @@ func TestRegistryMapFailedSet(t *testing.T) {
 
 	h := sop.NewHandle(uuid)
 
-	if err := r.add(ctx, sop.Tuple[string, []sop.Handle]{
-		First:  "regtest",
-		Second: []sop.Handle{h},
-	}); err != nil {
+	if err := r.add(ctx, []sop.RegistryPayload[sop.Handle]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.Handle{h},
+	}}); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := r.remove(ctx, sop.Tuple[string, []sop.UUID]{
-		First:  "regtest",
-		Second: []sop.UUID{uuid},
-	}); err != nil {
+	if err := r.remove(ctx, []sop.RegistryPayload[sop.UUID]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.UUID{uuid},
+	}}); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := r.set(ctx, sop.Tuple[string, []sop.Handle]{
-		First:  "regtest",
-		Second: []sop.Handle{h},
-	}); err == nil {
+	if err := r.set(ctx, []sop.RegistryPayload[sop.Handle]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.Handle{h},
+	}}); err == nil {
 		t.Errorf("r.set succeeded, expected to fail")
 	}
 
@@ -113,24 +113,24 @@ func TestRegistryMapRecyAddRemoveAdd(t *testing.T) {
 
 	h := sop.NewHandle(uuid)
 
-	if err := r.add(ctx, sop.Tuple[string, []sop.Handle]{
-		First:  "regtest",
-		Second: []sop.Handle{h},
-	}); err != nil {
+	if err := r.add(ctx, []sop.RegistryPayload[sop.Handle]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.Handle{h},
+	}}); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := r.remove(ctx, sop.Tuple[string, []sop.UUID]{
-		First:  "regtest",
-		Second: []sop.UUID{uuid},
-	}); err != nil {
+	if err := r.remove(ctx, []sop.RegistryPayload[sop.UUID]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.UUID{uuid},
+	}}); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := r.add(ctx, sop.Tuple[string, []sop.Handle]{
-		First:  "regtest",
-		Second: []sop.Handle{h},
-	}); err != nil {
+	if err := r.add(ctx, []sop.RegistryPayload[sop.Handle]{{
+		RegistryTable: "regtest",
+		IDs:           []sop.Handle{h},
+	}}); err != nil {
 		t.Error(err.Error())
 	}
 

--- a/fs/replication_tracker.go
+++ b/fs/replication_tracker.go
@@ -100,13 +100,13 @@ func (r *replicationTracker) HandleReplicationRelatedError(ctx context.Context, 
 		return
 	}
 	rootErr := errors.Unwrap(ioError)
-	err1, ok1 := rootErr.(sop.ErrorMetadata)
-	err2, ok2 := ioError.(sop.ErrorMetadata)
+	err1, ok1 := rootErr.(sop.Error)
+	err2, ok2 := ioError.(sop.Error)
 	if ok2 {
 		err1 = err2
 	}
 	if ok1 || ok2 {
-		log.Error(fmt.Sprintf("a replication related error detected (rollback: %v), details: %v", rollbackSucceeded, err1.GetError()))
+		log.Error(fmt.Sprintf("a replication related error detected (rollback: %v), details: %v", rollbackSucceeded, err1.Error))
 
 		// No need to failover if rollback succeeded. It means that the IO error itself is temporary.
 
@@ -117,7 +117,7 @@ func (r *replicationTracker) HandleReplicationRelatedError(ctx context.Context, 
 		if rollbackSucceeded {
 			return
 		}
-		if err1.GetCode() >= sop.FailoverQualifiedError || err2.GetCode() >= sop.FailoverQualifiedError {
+		if err1.Code >= sop.FailoverQualifiedError || err2.Code >= sop.FailoverQualifiedError {
 			// Cause a failover switch to passive destinations on succeeding transactions.
 			if err := r.failover(ctx); err != nil {
 				log.Error(fmt.Sprintf("failover to folder %s failed, details: %v", r.getPassiveBaseFolder(), err.Error()))

--- a/fs/transaction_log.go
+++ b/fs/transaction_log.go
@@ -17,11 +17,9 @@ import (
 
 const (
 	// DateHourLayout format mask string.
-	DateHourLayout           = "2006-01-02T15"
-	logFileExtension         = ".log"
-	logFolder                = "translogs"
-	priorityLogFileExtension = ".plg"
-	priorityLogMinAgeInMin   = 5
+	DateHourLayout   = "2006-01-02T15"
+	logFileExtension = ".log"
+	logFolder        = "translogs"
 )
 
 type TransactionLog struct {
@@ -46,111 +44,7 @@ func NewTransactionLog(cache sop.Cache, rt *replicationTracker) *TransactionLog 
 	}
 }
 
-type priorityLog struct {
-	replicationTracker *replicationTracker
-	tid                sop.UUID
-}
-
-func (l priorityLog) IsEnabled() bool {
-	return true
-}
-
-// Remove will delete transaction log(t_log) records given a transaction ID(tid).
-func (l priorityLog) Remove(ctx context.Context, tid sop.UUID) error {
-	fio := NewFileIO()
-	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogFileExtension))
-	if fio.Exists(ctx, filename) {
-		return fio.Remove(ctx, filename)
-	}
-	return nil
-}
-
-// Add transaction log w/ payload blob to the transaction log file.
-func (l priorityLog) Add(ctx context.Context, tid sop.UUID, payload []byte) error {
-	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogFileExtension))
-	fio := NewFileIO()
-	fio.WriteFile(ctx, filename, payload, permission)
-	return nil
-}
-
-// Log commit changes to its own log file separate than the rest of transaction logs.
-// This is a special log file only used during "reinstate" of drives back for replication.
-func (l priorityLog) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []sop.RegistryPayload[sop.Handle]) error {
-	return l.replicationTracker.logCommitChanges(ctx, l.tid, stores, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles)
-}
-
-// Fetch the transaction priority logs details given a tranasction ID.
-func (l priorityLog) Get(ctx context.Context, tid sop.UUID) ([]sop.RegistryPayload[sop.Handle], error) {
-	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogFileExtension))
-	fio := NewFileIO()
-	if !fio.Exists(ctx, filename) {
-		return nil, nil
-	}
-	if ba, err := fio.ReadFile(ctx, filename); err != nil {
-		return nil, err
-	} else {
-		var data []sop.RegistryPayload[sop.Handle]
-		encoding.DefaultMarshaler.Unmarshal(ba, &data)
-
-		return data, nil
-	}
-}
-
-func (l priorityLog) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValuePair[sop.UUID, []sop.RegistryPayload[sop.Handle]], error) {
-	mh, _ := time.Parse(DateHourLayout, sop.Now().Format(DateHourLayout))
-	cappedHour := mh.Add(-time.Duration(priorityLogMinAgeInMin * time.Minute))
-
-	f := func(de os.DirEntry) bool {
-		info, _ := de.Info()
-
-		fts := info.ModTime().Format(DateHourLayout)
-		ft, _ := time.Parse(DateHourLayout, fts)
-		filename := info.Name()
-		_, err := sop.ParseUUID(filename[0 : len(filename)-len(priorityLogFileExtension)])
-		if err != nil {
-			return false
-		}
-		return cappedHour.Compare(ft) >= 0
-	}
-
-	fn := l.replicationTracker.formatActiveFolderEntity(logFolder)
-	fio := NewFileIO()
-	if !fio.Exists(ctx, fn) {
-		if err := fio.MkdirAll(ctx, fn, permission); err != nil {
-			log.Warn(fmt.Sprintf("error creating %s, details: %v", fn, err))
-		}
-		return nil, nil
-	}
-	files, err := getFilesSortedDescByModifiedTime(ctx, fn, priorityLogFileExtension, f)
-	if err != nil || len(files) == 0 {
-		return nil, err
-	}
-
-	// 25 is defaut batch size.
-	if batchSize <= 0 {
-		batchSize = 25
-	}
-
-	// Get the oldest first & so on...
-	res := make([]sop.KeyValuePair[sop.UUID, []sop.RegistryPayload[sop.Handle]], 0, batchSize)
-	for i := range batchSize {
-		if i == len(files) {
-			break
-		}
-		filename := files[i].Name()
-		tid, _ := sop.ParseUUID(filename[0 : len(filename)-len(priorityLogFileExtension)])
-		r, e := l.Get(ctx, tid)
-		if e != nil {
-			return res, e
-		}
-		res = append(res, sop.KeyValuePair[sop.UUID, []sop.RegistryPayload[sop.Handle]]{
-			Key:   tid,
-			Value: r,
-		})
-	}
-	return res, nil
-}
-
+// Returns the priority log logger.
 func (tl *TransactionLog) PriorityLog() sop.TransactionPriorityLog {
 	return tl.priorityLog
 }

--- a/fs/transaction_priority_log.go
+++ b/fs/transaction_priority_log.go
@@ -1,0 +1,141 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	log "log/slog"
+	"os"
+	"time"
+
+	"github.com/SharedCode/sop"
+	"github.com/SharedCode/sop/encoding"
+)
+
+const (
+	priorityLogFileExtension       = ".plg"
+	priorityLogBackupFileExtension = ".plb"
+	priorityLogMinAgeInMin         = 5
+)
+
+type priorityLog struct {
+	replicationTracker *replicationTracker
+	tid                sop.UUID
+}
+
+func (l priorityLog) IsEnabled() bool {
+	return true
+}
+
+// Add transaction log w/ payload blob to the transaction log file.
+func (l priorityLog) Add(ctx context.Context, tid sop.UUID, payload []byte) error {
+	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogFileExtension))
+	fio := NewFileIO()
+	fio.WriteFile(ctx, filename, payload, permission)
+	return nil
+}
+
+// Log commit changes to its own log file separate than the rest of transaction logs.
+// This is a special log file only used during "reinstate" of drives back for replication.
+func (l priorityLog) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []sop.RegistryPayload[sop.Handle]) error {
+	return l.replicationTracker.logCommitChanges(ctx, l.tid, stores, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles)
+}
+
+// Fetch the transaction priority logs details given a tranasction ID.
+func (l priorityLog) Get(ctx context.Context, tid sop.UUID) ([]sop.RegistryPayload[sop.Handle], error) {
+	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogFileExtension))
+	fio := NewFileIO()
+	if !fio.Exists(ctx, filename) {
+		return nil, nil
+	}
+	if ba, err := fio.ReadFile(ctx, filename); err != nil {
+		return nil, err
+	} else {
+		var data []sop.RegistryPayload[sop.Handle]
+		encoding.DefaultMarshaler.Unmarshal(ba, &data)
+
+		return data, nil
+	}
+}
+
+func (l priorityLog) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValuePair[sop.UUID, []sop.RegistryPayload[sop.Handle]], error) {
+	mh, _ := time.Parse(DateHourLayout, sop.Now().Format(DateHourLayout))
+	cappedHour := mh.Add(-time.Duration(priorityLogMinAgeInMin * time.Minute))
+
+	f := func(de os.DirEntry) bool {
+		info, _ := de.Info()
+
+		fts := info.ModTime().Format(DateHourLayout)
+		ft, _ := time.Parse(DateHourLayout, fts)
+		filename := info.Name()
+		_, err := sop.ParseUUID(filename[0 : len(filename)-len(priorityLogFileExtension)])
+		if err != nil {
+			return false
+		}
+		return cappedHour.Compare(ft) >= 0
+	}
+
+	fn := l.replicationTracker.formatActiveFolderEntity(logFolder)
+	fio := NewFileIO()
+	if !fio.Exists(ctx, fn) {
+		if err := fio.MkdirAll(ctx, fn, permission); err != nil {
+			log.Warn(fmt.Sprintf("error creating %s, details: %v", fn, err))
+		}
+		return nil, nil
+	}
+	files, err := getFilesSortedDescByModifiedTime(ctx, fn, priorityLogFileExtension, f)
+	if err != nil || len(files) == 0 {
+		return nil, err
+	}
+
+	// 25 is defaut batch size.
+	if batchSize <= 0 {
+		batchSize = 25
+	}
+
+	// Get the oldest first & so on...
+	res := make([]sop.KeyValuePair[sop.UUID, []sop.RegistryPayload[sop.Handle]], 0, batchSize)
+	for i := range batchSize {
+		if i == len(files) {
+			break
+		}
+		filename := files[i].Name()
+		tid, te := sop.ParseUUID(filename[0 : len(filename)-len(priorityLogFileExtension)])
+		if te != nil {
+			log.Warn("file %s does not belong in this folder, details: %s", filename, te)
+			continue
+		}
+		r, e := l.Get(ctx, tid)
+		if e != nil {
+			return res, e
+		}
+		res = append(res, sop.KeyValuePair[sop.UUID, []sop.RegistryPayload[sop.Handle]]{
+			Key:   tid,
+			Value: r,
+		})
+	}
+	return res, nil
+}
+
+// Remove will delete transaction log(t_log) records given a transaction ID(tid).
+func (l priorityLog) Remove(ctx context.Context, tid sop.UUID) error {
+	fio := NewFileIO()
+	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogFileExtension))
+	if fio.Exists(ctx, filename) {
+		return fio.Remove(ctx, filename)
+	}
+	return nil
+}
+
+func (l priorityLog) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error {
+	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogBackupFileExtension))
+	fio := NewFileIO()
+	fio.WriteFile(ctx, filename, payload, permission)
+	return nil
+}
+
+func (l priorityLog) RemoveBackup(ctx context.Context, tid sop.UUID) error {
+	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogBackupFileExtension))
+	fio := NewFileIO()
+	fio.Remove(ctx, filename)
+	return nil
+}

--- a/handle.go
+++ b/handle.go
@@ -123,3 +123,17 @@ func (x *Handle) IsEqual(y *Handle) bool {
 		x.PhysicalIDA == y.PhysicalIDA &&
 		x.PhysicalIDB == y.PhysicalIDB
 }
+
+// Extract logical UUIDs of a given set of handles.
+func ExtractLogicalIDs(storeHandles []RegistryPayload[Handle]) []RegistryPayload[UUID] {
+	r := make([]RegistryPayload[UUID], len(storeHandles))
+	for i := range storeHandles {
+		r[i].RegistryTable = storeHandles[i].RegistryTable
+		r[i].CacheDuration = storeHandles[i].CacheDuration
+		r[i].IDs = make([]UUID, len(storeHandles[i].IDs))
+		for ii := range storeHandles[i].IDs {
+			r[i].IDs[ii] = storeHandles[i].IDs[ii].LogicalID
+		}
+	}
+	return r
+}

--- a/in_red_fs/integration_tests/replication/direct_io_sim.go
+++ b/in_red_fs/integration_tests/replication/direct_io_sim.go
@@ -16,7 +16,7 @@ func newDirectIOReplicationSim() fs.UnitTestInjectableIO {
 }
 
 func (dio *dioReplicationSim) Open(filename string, flag int, permission os.FileMode) error {
-	return sop.Error[sop.UUID]{
+	return sop.Error{
 		Code: sop.RestoreRegistryFileSectorFailure,
 		Err:  fmt.Errorf("simulated error on Open"),
 	}

--- a/in_red_fs/integration_tests/replication/replication_test.go
+++ b/in_red_fs/integration_tests/replication/replication_test.go
@@ -93,11 +93,6 @@ func Test_ReinstateDrive(t *testing.T) {
 	}
 }
 
-func Test(t *testing.T) {
-	fmt.Printf("Error: %d\n", sop.RestoreRegistryFileSectorFailure)
-	fmt.Printf("equal: %d", sop.FileIOError)
-}
-
 func TestDirectIOSetupNewFileFailure_WithReplication(t *testing.T) {
 	fs.DirectIOSim = newDirectIOReplicationSim()
 

--- a/repository.go
+++ b/repository.go
@@ -94,6 +94,11 @@ type TransactionPriorityLog interface {
 	// Log commit changes to its own log file separate than the rest of transaction logs.
 	// This is a special log file only used during "reinstate" of drives back for replication.
 	LogCommitChanges(ctx context.Context, stores []StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []RegistryPayload[Handle]) error
+
+	// Write a backup file for the priority log contents (payload).
+	WriteBackup(ctx context.Context, tid UUID, payload []byte) error
+	// Remove a backup file.
+	RemoveBackup(ctx context.Context, tid UUID) error
 }
 
 // Transaction Log specifies the API(methods) needed to implement logging for the transaction.


### PR DESCRIPTION
in_red_fs: registry update "all or nothing" on failure will attempt to restore any changes done and if that fails, will issue a "failover" error to cause a failover.
* Refactors to keep the File System registry to hashmap handover code simple and dandy.