### PR TITLE
in_red_fs: doPriorityRollbacks was fleshed out restore potential partial write OR raising failover as needed

### DIFF
--- a/common/two_phase_commit_transaction.go
+++ b/common/two_phase_commit_transaction.go
@@ -591,12 +591,11 @@ func (t *Transaction) updateVersionThenPopulateMru(ctx context.Context, handles 
 
 func (t *Transaction) handleRegistrySectorLockTimeout(ctx context.Context, err sop.Error) error {
 	const (
-		lockDuration = 5 * time.Minute
-		lockKey      = "DTrollbk"
+		lockKey = "DTrollbk"
 	)
 
 	lk := t.l2Cache.CreateLockKeys([]string{lockKey})
-	if ok, _, _ := t.l2Cache.Lock(ctx, lockDuration, lk); ok {
+	if ok, _, _ := t.l2Cache.Lock(ctx, defaultLockDuration, lk); ok {
 		if ok, _ = t.l2Cache.IsLocked(ctx, lk); ok {
 			ud, ok := err.UserData.(*sop.LockKey)
 			if !ok {

--- a/in_red_fs/transaction_options.go
+++ b/in_red_fs/transaction_options.go
@@ -87,7 +87,7 @@ func NewTransactionOptionsWithReplication(mode sop.TransactionMode, maxTime time
 	storesFolders []string, erasureConfig map[string]fs.ErasureCodingConfig) (TransationOptionsWithReplication, error) {
 	if erasureConfig == nil {
 		erasureConfig = fs.GetGlobalErasureConfig()
-	}	
+	}
 	storesFolders = pickStoresFoldersFromEC(storesFolders, erasureConfig)
 
 	if len(storesFolders) < 2 {

--- a/repository.go
+++ b/repository.go
@@ -186,7 +186,9 @@ type KeyValueStore[TK any, TV any] interface {
 // String key and interface{} value are the supported types. Also specifies methods useful for locking.
 type Cache interface {
 	Set(ctx context.Context, key string, value string, expiration time.Duration) error
-	// First return bool var signifies success or false if either item was not found or an error occurred during Get.
+	// First return bool var signifies success or false for one or these reasons: item(w/ key) was not found or an error occurred during Get.
+	// Second return is the item's value part.
+	// Third return is the error encountered calling Redis get API, if there is.
 	Get(ctx context.Context, key string) (bool, string, error)
 	// First return bool var signifies success or false if either item was not found or an error occurred during Get.
 	GetEx(ctx context.Context, key string, expiration time.Duration) (bool, string, error)


### PR DESCRIPTION
in_red_fs: doPriorityRollbacks (background processor of priority logs) was fleshed out to do a better job of restoring potential partial write OR raising failover as needed, when cases of high risk of data corruption.