### PR TITLE
Race fix part 1

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -124,6 +124,17 @@
 				"mydi-nocov"
 			],
 			"group": "test"
+		},
+		{
+			"label": "Docker: Run Integration (No Coverage)",
+			"type": "shell",
+			"command": "docker",
+			"args": [
+				"run",
+				"--rm",
+				"mydi-nocov"
+			],
+			"group": "test"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -135,6 +135,19 @@
 				"mydi-nocov"
 			],
 			"group": "test"
+		},
+		{
+			"label": "Go: Test (Unit)",
+			"type": "shell",
+			"command": "go",
+			"args": [
+				"test",
+				"./..."
+			],
+			"problemMatcher": [
+				"$go"
+			],
+			"group": "test"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -113,6 +113,17 @@
 				"Go: Test (Integration)"
 			],
 			"problemMatcher": []
+		},
+		{
+			"label": "Docker: Run Integration (No Coverage)",
+			"type": "shell",
+			"command": "docker",
+			"args": [
+				"run",
+				"--rm",
+				"mydi-nocov"
+			],
+			"group": "test"
 		}
 	]
 }

--- a/Dockerfile.nocov
+++ b/Dockerfile.nocov
@@ -26,5 +26,5 @@ CMD ["docker-entrypoint-nocov.sh"]
 
 # Sample commands to build then run docker image:
 # docker build -f Dockerfile.nocov -t mydi-nocov .
-# docker run mydi-nocov
+# docker run --rm mydi-nocov
 #   This will run the integration tests in inredfs package that requires Redis which is provided in docker image.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ See details here: https://github.com/sharedcode/sop/blob/master/README2.md#simpl
 # SOP for Python (sop4py)
 See details here: https://github.com/sharedcode/sop/tree/master/jsondb/python#readme
 
+## Timeouts and deadlines
+SOP commits are governed by two bounds:
+- The caller context (deadline/cancellation)
+- The transaction maxTime (commit max duration)
+
+The commit ends when the earlier of these two is reached. Internal lock TTLs use maxTime to ensure locks are bounded even if the caller cancels early.
+
+Recommendation: If you want replication/log cleanup to complete under the same budget, set your context deadline to at least maxTime plus a small grace period.
+
 ## Community & support
 - Issues: https://github.com/SharedCode/sop/issues
 - Discussions: https://github.com/SharedCode/sop/discussions (design/usage topics)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ SOP is designed to keep your app online through common storage failures.
 
 See the detailed lifecycle guide (failures, observability, reinstate/fast‑forward, and drive replacement) in README2.md: https://github.com/SharedCode/sop/blob/master/README2.md#lifecycle-failures-failover-reinstate-and-ec-auto-repair
 
+Also see Operational caveats: https://github.com/SharedCode/sop/blob/master/README2.md#operational-caveats
+
 For planned maintenance, see Cluster reboot procedure: [Cluster reboot procedure](#cluster-reboot-procedure).
 
 ## Prerequisites

--- a/README2.md
+++ b/README2.md
@@ -231,6 +231,15 @@ What to look for
 - For EC beyond parity, the test asserts rollback and the absence of a failover event.
 
 
+## Operational caveats
+
+- Replication disabled (Active/Passive off): Metadata I/O errors will not trigger a failover. Commits to the single active path may fail depending on the error; recovery is manual. Prefer enabling replication to benefit from automatic failover and reinstate/fast‑forward.
+
+- Passive replication failures: When writes to the passive side fail, SOP sets FailedToReplicate. Active-side commits typically continue because the active write succeeded. Plan to run ReinstateFailedDrives to resync the passive, then fast‑forward recent deltas; monitor the FailedToReplicate flag until it clears.
+
+- After a flip: Immediately after an Active/Passive flip, some in‑flight or lingering operations aimed at the old active can encounter errors. Design clients for idempotent retry: start a fresh transaction and retry the operation.
+
+
 # Store Caching Config Guide
 Below examples illustrate how to configure the Store caching config feature. This feature provides automatic Redis based caching of data store's different data sets, both internal, for use to accelerate IO on internal needs of the B-trees and external, the enduser large data.
 

--- a/README2.md
+++ b/README2.md
@@ -19,6 +19,7 @@ Code coverage: https://app.codecov.io/github/sharedcode/sop
 - Transaction batching and ACID
 - Fine tuning
 - Transaction logging, serialization, two-phase commit
+- Coordination model (OOA) and safety
 - Optimistic Orchestration Algorithm (OOA)
 - Concurrent/parallel commits
 - ACID vs Big Data
@@ -611,6 +612,44 @@ On successful commit on Phase 1, SOP will then commit Phase 2, which is, to tell
 Phase 2 commit is a very fast, quick action as changes and Nodes are already resident on the Btree storage, it is just a matter of finalizing the Virtual ID registry with the new Nodes' physical addresses to swap the old with the new ones.
 
 See [transaction.go](./transaction.go) for more details on two phase commit & how to access it for your application transaction integration.
+
+## Coordination model (OOA) and safety
+
+### Coordination model: Redis-assisted, storage-anchored
+
+SOP uses Redis for fast, ephemeral coordination and the filesystem for durable sector claims. Redis locks provide low-latency contention detection; per-sector claim markers on storage enforce exclusive access for CUD operations. This hybrid keeps coordination responsive without coupling correctness to Redis durability.
+
+### Why this is safe (despite Redis tail loss/failover)
+
+- Locks are advisory; correctness is anchored in storage-sector claims and idempotent commit/rollback.
+- On Redis restart, SOP detects it and performs cleanup sweeps (clearing stale sector claims) before resuming.
+- Time-bounded lock TTLs, takeover checks, and rollback paths ensure progress without split-brain.
+- Priority logs and deterministic rollback let workers resume or repair safely after interruptions.
+
+### Operational properties
+
+- Decentralized: no leader or quorum; any node can coordinate on a sector independently.
+- Horizontally scalable: sharded by registry sectors; no global hot spots.
+- No single point of failure: loss of Redis state slows coordination briefly but doesn’t corrupt data.
+- Low latency: lock checks and claim writes are O(1) on hot path; no multi-round consensus.
+
+### When Redis is unavailable
+
+- Writes that need exclusivity will wait/fail fast; storage remains consistent.
+- On recovery, restart sweeps clear stale sector claims; workers resume.
+
+### Comparison to Paxos-style consensus
+
+- SOP avoids global consensus, leader election, and replicated logs—lower coordination latency and cost.
+- Better horizontal scaling for partitioned workloads (per-sector independence).
+- No SPOF in the coordination layer; failover is trivial and stateless.
+- If you need a globally ordered, cross-region commit log, consensus is still the right tool; SOP targets high-throughput, partition-aligned coordination. But then again, SOP is not a coordination engine, it is a storage engine. Its internal piece for coordination is what was described here.
+
+### TL;DR
+
+SOP builds a fast, decentralized coordination layer using Redis only for ephemeral locks and relies on storage-anchored sector claims for correctness. It scales out naturally and avoids consensus overhead while remaining safe under failover.
+
+See also: README.md section “Coordination model (OOA) and safety”.
 
 ## Optimistic Orchestration Algorithm (OOA)
 SOP uses a new, proprietary & open sourced, thus MIT licensed, unique algorithm using Redis I/O for orchestration, which aids in decentralized, highly parallelized operations. It uses simple Redis I/O ```fetch-set-fetch``` (not the Redis lock API!) for conflict detection/resolution and data merging across transactions whether in same machine or across different machines.

--- a/btree/test_helpers_test.go
+++ b/btree/test_helpers_test.go
@@ -3,6 +3,7 @@ package btree
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sharedcode/sop"
 )
@@ -51,6 +52,7 @@ func (m *mockTx) GetMode() sop.TransactionMode                    { return m.mod
 func (m *mockTx) GetStores(ctx context.Context) ([]string, error) { return nil, nil }
 func (m *mockTx) Close() error                                    { return nil }
 func (m *mockTx) GetID() sop.UUID                                 { return sop.NewUUID() }
+func (m *mockTx) CommitMaxDuration() time.Duration                 { return time.Minute }
 
 // iatErr induces an error on Add to exercise rollback path in the wrapper.
 type iatErr[TK Ordered, TV any] struct{}

--- a/common/coverage_boost_10_test.go
+++ b/common/coverage_boost_10_test.go
@@ -66,6 +66,10 @@ func Test_CommitTrackedItemsValues_NoItems_NoOp(t *testing.T) {
 // secondGetMissCache stubs GetStruct to miss both before and after SetStruct to force the race/error branch in lock.
 type secondGetMissCache struct{ sop.Cache }
 
+func (c secondGetMissCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (c secondGetMissCache) GetStruct(ctx context.Context, key string, target interface{}) (bool, error) {
 	return false, nil
 }
@@ -97,6 +101,10 @@ func Test_ItemActionTracker_Lock_SecondGet_NotFound_ReturnsError(t *testing.T) {
 // lockBackendErrCache simulates a backend error during Lock (false, Nil owner, non-nil err).
 type lockBackendErrCache struct{ sop.Cache }
 
+func (c lockBackendErrCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (c lockBackendErrCache) Lock(ctx context.Context, duration time.Duration, lockKeys []*sop.LockKey) (bool, sop.UUID, error) {
 	return false, sop.NilUUID, fmt.Errorf("lock backend error")
 }
@@ -118,6 +126,10 @@ func Test_TransactionLogger_AcquireLocks_Lock_Backend_Error_Propagates(t *testin
 
 // getStructErrCache returns an error from GetStruct to exercise checkTrackedItems error path.
 type getStructErrCache2 struct{ sop.Cache }
+
+func (c getStructErrCache2) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
 
 func (c getStructErrCache2) GetStruct(ctx context.Context, key string, target interface{}) (bool, error) {
 	return false, fmt.Errorf("cache get error")
@@ -236,6 +248,10 @@ func Test_Phase1Commit_RefetchAndMerge_Retry_Succeeds(t *testing.T) {
 
 // takeoverCacheOK simulates a dead-owner takeover success.
 type takeoverCacheOK struct{ sop.Cache }
+
+func (c takeoverCacheOK) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
 
 var takeoverTID = sop.NewUUID()
 
@@ -433,6 +449,10 @@ func Test_TransactionLogger_Rollback_FinalizeCommit_DeletesObsoleteAndTracked(t 
 // errDeleteCache wraps a Cache and forces Delete to return an error to cover error branch.
 type errDeleteCache struct{ sop.Cache }
 
+func (c errDeleteCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (e errDeleteCache) Delete(ctx context.Context, keys []string) (bool, error) {
 	return false, fmt.Errorf("forced delete error")
 }
@@ -550,6 +570,10 @@ func Test_ReaderTxn_AreFetchedItemsIntact_Error(t *testing.T) {
 // cacheIsLockedErr wraps the mock cache to return an error from IsLocked after a successful Lock.
 type cacheIsLockedErr struct{ sop.Cache }
 
+func (c cacheIsLockedErr) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (c cacheIsLockedErr) Lock(ctx context.Context, duration time.Duration, lockKeys []*sop.LockKey) (bool, sop.UUID, error) {
 	// Delegate to base cache to mark keys as locked by this owner
 	return c.Cache.Lock(ctx, duration, lockKeys)
@@ -560,6 +584,10 @@ func (c cacheIsLockedErr) IsLocked(ctx context.Context, lockKeys []*sop.LockKey)
 
 // cacheLockFailNoOwner makes Lock fail with no owner and returns an error.
 type cacheLockFailNoOwner struct{ sop.Cache }
+
+func (c cacheLockFailNoOwner) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
 
 func (c cacheLockFailNoOwner) Lock(ctx context.Context, duration time.Duration, lockKeys []*sop.LockKey) (bool, sop.UUID, error) {
 	return false, sop.NilUUID, fmt.Errorf("lock err")

--- a/common/coverage_boost_11_test.go
+++ b/common/coverage_boost_11_test.go
@@ -123,6 +123,9 @@ type getErrCache struct{ sop.Cache }
 func (g getErrCache) GetStruct(ctx context.Context, key string, target interface{}) (bool, error) {
 	return false, fmt.Errorf("getstruct err")
 }
+func (g getErrCache) IsRestarted(ctx context.Context) (bool, error) {
+	return g.Cache.IsRestarted(ctx)
+}
 
 func Test_ItemActionTracker_CheckTrackedItems_Error_And_GetCompat(t *testing.T) {
 	ctx := context.Background()
@@ -495,6 +498,9 @@ func (c errIsLockedCache13) Unlock(ctx context.Context, lockKeys []*sop.LockKey)
 	return c.inner.Unlock(ctx, lockKeys)
 }
 func (c errIsLockedCache13) Clear(ctx context.Context) error { return c.inner.Clear(ctx) }
+func (c errIsLockedCache13) IsRestarted(ctx context.Context) (bool, error) {
+	return c.inner.IsRestarted(ctx)
+}
 
 // errGetExCache13 wraps a cache and forces GetEx to error to hit acquireLocks' takeover GetEx error path.
 type errGetExCache13 struct {
@@ -547,6 +553,9 @@ func (c errGetExCache13) Unlock(ctx context.Context, lockKeys []*sop.LockKey) er
 	return c.inner.Unlock(ctx, lockKeys)
 }
 func (c errGetExCache13) Clear(ctx context.Context) error { return c.inner.Clear(ctx) }
+func (c errGetExCache13) IsRestarted(ctx context.Context) (bool, error) {
+	return c.inner.IsRestarted(ctx)
+}
 
 func Test_TransactionLogger_AcquireLocks_IsLocked_Error_UnlocksAndReturns(t *testing.T) {
 	ctx := context.Background()

--- a/common/coverage_boost_11_test.go
+++ b/common/coverage_boost_11_test.go
@@ -598,8 +598,6 @@ func (p plGetErr) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValuePa
 func (p plGetErr) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (p plGetErr) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error { return nil }
-func (p plGetErr) RemoveBackup(ctx context.Context, tid sop.UUID) error                { return nil }
 
 // plRemoveErr returns payload but Remove returns error to propagate.
 type plRemoveErr struct {
@@ -619,8 +617,6 @@ func (p plRemoveErr) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValu
 func (p plRemoveErr) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (p plRemoveErr) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error { return nil }
-func (p plRemoveErr) RemoveBackup(ctx context.Context, tid sop.UUID) error                { return nil }
 
 func Test_TransactionLogger_PriorityRollback_Get_Error_Propagated(t *testing.T) {
 	ctx := context.Background()

--- a/common/coverage_boost_11_test.go
+++ b/common/coverage_boost_11_test.go
@@ -607,6 +607,7 @@ func (p plGetErr) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValuePa
 func (p plGetErr) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (p plGetErr) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // plRemoveErr returns payload but Remove returns error to propagate.
 type plRemoveErr struct {
@@ -626,6 +627,7 @@ func (p plRemoveErr) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValu
 func (p plRemoveErr) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (p plRemoveErr) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 func Test_TransactionLogger_PriorityRollback_Get_Error_Propagated(t *testing.T) {
 	ctx := context.Background()

--- a/common/coverage_boost_12_test.go
+++ b/common/coverage_boost_12_test.go
@@ -37,10 +37,6 @@ func (s stubPriorityLogRemoveErr) GetBatch(ctx context.Context, batchSize int) (
 func (s stubPriorityLogRemoveErr) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (s stubPriorityLogRemoveErr) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error {
-	return nil
-}
-func (s stubPriorityLogRemoveErr) RemoveBackup(ctx context.Context, tid sop.UUID) error { return nil }
 
 type tlogWithPrioRemoveErr struct{ pl stubPriorityLogRemoveErr }
 

--- a/common/coverage_boost_12_test.go
+++ b/common/coverage_boost_12_test.go
@@ -37,6 +37,7 @@ func (s stubPriorityLogRemoveErr) GetBatch(ctx context.Context, batchSize int) (
 func (s stubPriorityLogRemoveErr) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (s stubPriorityLogRemoveErr) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 type tlogWithPrioRemoveErr struct{ pl stubPriorityLogRemoveErr }
 

--- a/common/coverage_boost_1_test.go
+++ b/common/coverage_boost_1_test.go
@@ -637,6 +637,9 @@ func (c lockThenIsLockedFalseCache) Unlock(ctx context.Context, lockKeys []*sop.
 	return c.inner.Unlock(ctx, lockKeys)
 }
 func (c lockThenIsLockedFalseCache) Clear(ctx context.Context) error { return c.inner.Clear(ctx) }
+func (c lockThenIsLockedFalseCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.inner.IsRestarted(ctx)
+}
 
 // lockErrorCache forces Lock to return an error to trigger error propagation path in acquireLocks.
 type lockErrorCache struct{ inner sop.Cache }
@@ -686,6 +689,9 @@ func (c lockErrorCache) Unlock(ctx context.Context, lockKeys []*sop.LockKey) err
 	return c.inner.Unlock(ctx, lockKeys)
 }
 func (c lockErrorCache) Clear(ctx context.Context) error { return c.inner.Clear(ctx) }
+func (c lockErrorCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.inner.IsRestarted(ctx)
+}
 
 func Test_AcquireLocks_PartialAfterOk_ReturnsFailover(t *testing.T) {
 	ctx := context.Background()

--- a/common/coverage_boost_1_test.go
+++ b/common/coverage_boost_1_test.go
@@ -425,6 +425,7 @@ func (prioRemoveWarn) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyVal
 func (prioRemoveWarn) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (prioRemoveWarn) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // wrapTLAddErr implements sop.TransactionLog with Add error and PriorityLog warn-on-remove.
 type wrapTLAddErr struct{ tlAddErr }

--- a/common/coverage_boost_2_test.go
+++ b/common/coverage_boost_2_test.go
@@ -70,6 +70,7 @@ func (p prioLogRemoveErr) GetBatch(ctx context.Context, batchSize int) ([]sop.Ke
 func (p prioLogRemoveErr) LogCommitChanges(ctx context.Context, _ []sop.StoreInfo, _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (p prioLogRemoveErr) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // wrapTLPrioRemoveErr delegates to inner TransactionLog but returns prioLogRemoveErr for PriorityLog.
 type wrapTLPrioRemoveErr struct{ inner *mocks.MockTransactionLog }

--- a/common/coverage_boost_2_test.go
+++ b/common/coverage_boost_2_test.go
@@ -589,8 +589,8 @@ func Test_TransactionLogger_DoPriorityRollbacks_RemoveError_ReturnsError(t *test
 	tx := &Transaction{l2Cache: l2, registry: reg}
 
 	// Seed lock ownership for the batch processing loop to enter.
-	_ = l2.Set(ctx, l2.FormatLockKey("Prbs"), sop.NewUUID().String(), time.Minute)
-	_, _ = l2.Delete(ctx, []string{l2.FormatLockKey("Prbs")})
+	_ = l2.Set(ctx, l2.FormatLockKey(coordinatorLockName), sop.NewUUID().String(), time.Minute)
+	_, _ = l2.Delete(ctx, []string{l2.FormatLockKey(coordinatorLockName)})
 
 	tid := sop.NewUUID()
 	lid := sop.NewUUID()
@@ -620,8 +620,8 @@ func Test_TransactionLogger_DoPriorityRollbacks_VersionAdvance_TriggersFailover(
 	tx := &Transaction{l2Cache: l2, registry: reg}
 
 	// Unlockable processing lock.
-	_ = l2.Set(ctx, l2.FormatLockKey("Prbs"), sop.NewUUID().String(), time.Minute)
-	_, _ = l2.Delete(ctx, []string{l2.FormatLockKey("Prbs")})
+	_ = l2.Set(ctx, l2.FormatLockKey(coordinatorLockName), sop.NewUUID().String(), time.Minute)
+	_, _ = l2.Delete(ctx, []string{l2.FormatLockKey(coordinatorLockName)})
 
 	tid := sop.NewUUID()
 	lid := sop.NewUUID()

--- a/common/coverage_boost_3_test.go
+++ b/common/coverage_boost_3_test.go
@@ -232,25 +232,28 @@ func (p *prioLogRemoveFail) Remove(ctx context.Context, tid sop.UUID) error {
 	return fmt.Errorf("remove fail")
 }
 
-func Test_TransactionLogger_DoPriorityRollbacks_RemoveError_BackupRemoved(t *testing.T) {
+func Test_TransactionLogger_DoPriorityRollbacks_RemoveError_Propagates(t *testing.T) {
 	ctx := context.Background()
 	l2 := mocks.NewMockClient()
 	tid := sop.NewUUID()
-	// Prepare batch with one entry; Remove will fail, so RemoveBackup should still be called
+	// Prepare batch with one entry; Remove will fail and error should be returned.
+	lid := sop.NewUUID()
 	base := &prioLogRemoveFail{prioLogBatch{tid: tid, batch: [][]sop.RegistryPayload[sop.Handle]{
-		{{RegistryTable: "rt", IDs: []sop.Handle{sop.NewHandle(sop.NewUUID())}}},
+		{{RegistryTable: "rt", IDs: []sop.Handle{sop.NewHandle(lid)}}},
 	}}}
 	tl := newTransactionLogger(mocks.NewMockTransactionLog(), true)
 	// Wrap TransactionLog to return our prio log behavior
 	tl.TransactionLog = tlWithPL{inner: tl.TransactionLog.(*mocks.MockTransactionLog), pl: base}
-	// Registry not used due to early remove error; just provide transaction with cache
-	txn := &Transaction{l2Cache: l2, registry: mocks.NewMockRegistry(false)}
+	// Seed registry so version checks don't panic; provide transaction with cache
+	reg := mocks.NewMockRegistry(false)
+	_ = reg.Add(ctx, []sop.RegistryPayload[sop.Handle]{{RegistryTable: "rt", IDs: []sop.Handle{sop.NewHandle(lid)}}})
+	txn := &Transaction{l2Cache: l2, registry: reg}
 	ok, err := tl.doPriorityRollbacks(ctx, txn)
-	if err != nil || !ok {
-		t.Fatalf("expected ok=true err=nil; got ok=%v err=%v", ok, err)
+	if err == nil {
+		t.Fatalf("expected error from Remove to be returned")
 	}
-	if base.wrote == 0 || base.removedBk == 0 {
-		t.Fatalf("expected backup write and backup remove on remove error")
+	if ok {
+		t.Fatalf("expected ok=false when Remove returns error")
 	}
 }
 
@@ -492,10 +495,6 @@ func (t timeoutPriorityLog) GetBatch(ctx context.Context, batchSize int) ([]sop.
 func (t timeoutPriorityLog) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (t timeoutPriorityLog) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error {
-	return nil
-}
-func (t timeoutPriorityLog) RemoveBackup(ctx context.Context, tid sop.UUID) error { return nil }
 
 // stubTLogTimeout wraps stubPriorityLog inside a TransactionLog implementation.
 type stubTLogTimeout struct{ pl timeoutPriorityLog }
@@ -796,8 +795,6 @@ func (p prioNoop) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValuePa
 func (p prioNoop) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (p prioNoop) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error { return nil }
-func (p prioNoop) RemoveBackup(ctx context.Context, tid sop.UUID) error                { return nil }
 
 func Test_ItemActionTracker_Add_ActivelyPersisted_LogError_Propagates(t *testing.T) {
 	ctx := context.Background()

--- a/common/coverage_boost_3_test.go
+++ b/common/coverage_boost_3_test.go
@@ -495,6 +495,7 @@ func (t timeoutPriorityLog) GetBatch(ctx context.Context, batchSize int) ([]sop.
 func (t timeoutPriorityLog) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (t timeoutPriorityLog) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // stubTLogTimeout wraps stubPriorityLog inside a TransactionLog implementation.
 type stubTLogTimeout struct{ pl timeoutPriorityLog }
@@ -795,6 +796,7 @@ func (p prioNoop) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValuePa
 func (p prioNoop) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (p prioNoop) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 func Test_ItemActionTracker_Add_ActivelyPersisted_LogError_Propagates(t *testing.T) {
 	ctx := context.Background()

--- a/common/coverage_boost_4_test.go
+++ b/common/coverage_boost_4_test.go
@@ -173,6 +173,10 @@ func Test_RollbackRemovedNodes_RegistryGetError(t *testing.T) {
 // getStructErrCache forces GetStruct to return an error while indicating not found.
 type getStructErrCache struct{ sop.Cache }
 
+func (c getStructErrCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (g getStructErrCache) GetStruct(ctx context.Context, key string, target interface{}) (bool, error) {
 	return false, fmt.Errorf("getstruct err")
 }
@@ -237,6 +241,8 @@ func Test_ItemActionTracker_CheckTrackedItems_Conflict(t *testing.T) {
 
 // zeroSetCache stores a zero LockID in SetStruct to trigger the "can't attain a lock" path after re-get.
 type zeroSetCache struct{ sop.Cache }
+
+func (c zeroSetCache) IsRestarted(ctx context.Context) (bool, error) { return c.Cache.IsRestarted(ctx) }
 
 func (z zeroSetCache) SetStruct(ctx context.Context, key string, value interface{}, expiration time.Duration) error {
 	if lr, ok := value.(*lockRecord); ok {
@@ -761,6 +767,10 @@ func Test_Phase1Commit_CommitUpdatedNodes_SectorTimeout_Retry_Succeeds(t *testin
 
 // cacheWarnOnSetStruct returns error on SetStruct to exercise warning paths in commitAddedNodes/commitNewRootNodes.
 type cacheWarnOnSetStruct struct{ sop.Cache }
+
+func (c cacheWarnOnSetStruct) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
 
 func (c cacheWarnOnSetStruct) SetStruct(ctx context.Context, key string, value interface{}, d time.Duration) error {
 	return fmt.Errorf("setstruct err")

--- a/common/coverage_boost_5_test.go
+++ b/common/coverage_boost_5_test.go
@@ -474,9 +474,9 @@ func Test_TransactionLogger_DoPriorityRollbacks_MultiEntry_MixedOutcomes(t *test
 	tl := newTransactionLogger(stubTLog{pl: pl}, true)
 
 	// Let locks be acquirable and stable
-	_ = l2.Set(ctx, l2.FormatLockKey("Prbs"), sop.NewUUID().String(), time.Minute)
+	_ = l2.Set(ctx, l2.FormatLockKey(coordinatorLockName), sop.NewUUID().String(), time.Minute)
 	// Clear to allow our lock to be acquired by doPriorityRollbacks
-	_, _ = l2.Delete(ctx, []string{l2.FormatLockKey("Prbs")})
+	_, _ = l2.Delete(ctx, []string{l2.FormatLockKey(coordinatorLockName)})
 
 	consumed, err := tl.doPriorityRollbacks(ctx, tx)
 	if err == nil {
@@ -803,6 +803,9 @@ func (m *failSecondGetAfterSetCache) Unlock(ctx context.Context, ks []*sop.LockK
 	return m.inner.Unlock(ctx, ks)
 }
 func (m *failSecondGetAfterSetCache) Clear(ctx context.Context) error { return m.inner.Clear(ctx) }
+func (m *failSecondGetAfterSetCache) IsRestarted(ctx context.Context) (bool, error) {
+	return m.inner.IsRestarted(ctx)
+}
 
 func Test_ItemActionTracker_Add_ActivelyPersisted_NilValue_NoBlobNoCache(t *testing.T) {
 	ctx := context.Background()

--- a/common/coverage_boost_5_test.go
+++ b/common/coverage_boost_5_test.go
@@ -225,6 +225,7 @@ func (r *recPrioLog2) GetBatch(context.Context, int) ([]sop.KeyValuePair[sop.UUI
 func (r *recPrioLog2) LogCommitChanges(context.Context, []sop.StoreInfo, []sop.RegistryPayload[sop.Handle], []sop.RegistryPayload[sop.Handle], []sop.RegistryPayload[sop.Handle], []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (r *recPrioLog2) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // TransactionLog wrapper that returns our recPrioLog2.
 type tlWithPL2 struct{ pl sop.TransactionPriorityLog }

--- a/common/coverage_boost_5_test.go
+++ b/common/coverage_boost_5_test.go
@@ -225,8 +225,6 @@ func (r *recPrioLog2) GetBatch(context.Context, int) ([]sop.KeyValuePair[sop.UUI
 func (r *recPrioLog2) LogCommitChanges(context.Context, []sop.StoreInfo, []sop.RegistryPayload[sop.Handle], []sop.RegistryPayload[sop.Handle], []sop.RegistryPayload[sop.Handle], []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (r *recPrioLog2) WriteBackup(context.Context, sop.UUID, []byte) error { return nil }
-func (r *recPrioLog2) RemoveBackup(context.Context, sop.UUID) error        { return nil }
 
 // TransactionLog wrapper that returns our recPrioLog2.
 type tlWithPL2 struct{ pl sop.TransactionPriorityLog }
@@ -450,9 +448,7 @@ func Test_HandleRegistrySectorLockTimeout_PriorityRollbackError_ReturnsOriginal(
 	}
 }
 
-// Covers doPriorityRollbacks iterating over a multi-entry batch where the first succeeds
-// and the second hits WriteBackup error and is skipped. Ensures per-entry handling, not
-// just single-element behavior.
+// Covers doPriorityRollbacks iterating over a multi-entry batch where both entries are processed.
 func Test_TransactionLogger_DoPriorityRollbacks_MultiEntry_MixedOutcomes(t *testing.T) {
 	ctx := context.Background()
 	l2 := mocks.NewMockClient()
@@ -469,11 +465,11 @@ func Test_TransactionLogger_DoPriorityRollbacks_MultiEntry_MixedOutcomes(t *test
 	_ = reg.Add(ctx, []sop.RegistryPayload[sop.Handle]{{RegistryTable: "rt", IDs: []sop.Handle{sop.NewHandle(lid1)}}})
 	_ = reg.Add(ctx, []sop.RegistryPayload[sop.Handle]{{RegistryTable: "rt", IDs: []sop.Handle{sop.NewHandle(lid2)}}})
 
-	// Batch: first will succeed; second will fail at WriteBackup
+	// Batch: two entries
 	pl := &stubPriorityLog{batch: []sop.KeyValuePair[sop.UUID, []sop.RegistryPayload[sop.Handle]]{
 		{Key: tid1, Value: []sop.RegistryPayload[sop.Handle]{{RegistryTable: "rt", BlobTable: "bt", IDs: []sop.Handle{sop.NewHandle(lid1)}}}},
 		{Key: tid2, Value: []sop.RegistryPayload[sop.Handle]{{RegistryTable: "rt", BlobTable: "bt", IDs: []sop.Handle{sop.NewHandle(lid2)}}}},
-	}, writeBackupErr: map[string]error{tid2.String(): context.DeadlineExceeded}}
+	}, removeErr: map[string]error{tid2.String(): errors.New("rm fail")}}
 
 	tl := newTransactionLogger(stubTLog{pl: pl}, true)
 
@@ -483,19 +479,16 @@ func Test_TransactionLogger_DoPriorityRollbacks_MultiEntry_MixedOutcomes(t *test
 	_, _ = l2.Delete(ctx, []string{l2.FormatLockKey("Prbs")})
 
 	consumed, err := tl.doPriorityRollbacks(ctx, tx)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
+	if err == nil {
+		t.Fatalf("expected error from Remove to be returned")
 	}
-	if !consumed {
-		t.Fatalf("expected consumed=true with non-empty batch")
+	if consumed {
+		t.Fatalf("expected consumed=false when Remove errors")
 	}
 
-	// RemoveBackup should be called for tid1 (success path), not for tid2 (write backup error)
-	if pl.removeBackupHit[tid1.String()] == 0 {
-		t.Fatalf("expected RemoveBackup called for tid1")
-	}
-	if pl.removeBackupHit[tid2.String()] != 0 {
-		t.Fatalf("expected no RemoveBackup for tid2 with write-backup error")
+	// Remove should be attempted for both tids
+	if pl.removedHit[tid1.String()] == 0 || pl.removedHit[tid2.String()] == 0 {
+		t.Fatalf("expected Remove attempted for both tids")
 	}
 }
 

--- a/common/coverage_boost_6_test.go
+++ b/common/coverage_boost_6_test.go
@@ -631,6 +631,10 @@ func Test_RefetchAndMerge_Add_InNode_DuplicateKey_ReturnsError(t *testing.T) {
 // unlockErrCache wraps a cache to force Unlock errors.
 type unlockErrCache struct{ sop.Cache }
 
+func (c unlockErrCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (c unlockErrCache) Unlock(ctx context.Context, lockKeys []*sop.LockKey) error {
 	return fmt.Errorf("unlock error")
 }
@@ -707,7 +711,7 @@ func Test_TransactionLogger_DoPriorityRollbacks_PrbsLockHeld_ReturnsFalse(t *tes
 	ctx := context.Background()
 	l2 := mocks.NewMockClient()
 	// Pre-lock the exact key used internally: FormatLockKey applied twice (matching implementation).
-	prbsKey := l2.FormatLockKey(l2.FormatLockKey("Prbs"))
+	prbsKey := l2.FormatLockKey(l2.FormatLockKey(coordinatorLockName))
 	_ = l2.Set(ctx, prbsKey, sop.NewUUID().String(), time.Minute)
 
 	tl := newTransactionLogger(stubTLog{pl: &stubPriorityLog{}}, true)

--- a/common/coverage_boost_7_test.go
+++ b/common/coverage_boost_7_test.go
@@ -569,10 +569,6 @@ func (p *prioLogAddCounter) GetBatch(ctx context.Context, batchSize int) ([]sop.
 func (p *prioLogAddCounter) LogCommitChanges(ctx context.Context, _ []sop.StoreInfo, _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (p *prioLogAddCounter) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error {
-	return nil
-}
-func (p *prioLogAddCounter) RemoveBackup(ctx context.Context, tid sop.UUID) error { return nil }
 
 // tlWithCustomPL injects a custom PriorityLog while delegating to the mock transaction log.
 type tlWithCustomPL struct {

--- a/common/coverage_boost_7_test.go
+++ b/common/coverage_boost_7_test.go
@@ -569,6 +569,7 @@ func (p *prioLogAddCounter) GetBatch(ctx context.Context, batchSize int) ([]sop.
 func (p *prioLogAddCounter) LogCommitChanges(ctx context.Context, _ []sop.StoreInfo, _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (p *prioLogAddCounter) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // tlWithCustomPL injects a custom PriorityLog while delegating to the mock transaction log.
 type tlWithCustomPL struct {

--- a/common/coverage_boost_8_test.go
+++ b/common/coverage_boost_8_test.go
@@ -627,6 +627,10 @@ func Test_TransactionLogger_Rollback_Finalize_WithDeleteTrackedItemsValues_Propa
 // to exercise acquireLocks partial-lock failover branch.
 type partialLockCache struct{ sop.Cache }
 
+func (c partialLockCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (p *partialLockCache) Lock(ctx context.Context, duration time.Duration, lockKeys []*sop.LockKey) (bool, sop.UUID, error) {
 	return true, sop.NilUUID, nil
 }

--- a/common/coverage_boost_test.go
+++ b/common/coverage_boost_test.go
@@ -47,6 +47,7 @@ func (r *recPrioLog) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValu
 func (r *recPrioLog) LogCommitChanges(ctx context.Context, _ []sop.StoreInfo, _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (r *recPrioLog) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // wrapCache lets us override IsLocked once to simulate transient lock verification failure.
 type wrapCache struct {
@@ -371,6 +372,7 @@ func (w warnPL) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValuePair
 func (w warnPL) LogCommitChanges(ctx context.Context, _ []sop.StoreInfo, _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle]) error {
 	return fmt.Errorf("warn: log commit changes")
 }
+func (w warnPL) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // wrapTL delegates to the mock transaction log but returns a warnPL for PriorityLog.
 type wrapTL struct{ inner *mocks.MockTransactionLog }
@@ -612,6 +614,7 @@ func (p *prioLogBatch) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyVa
 func (p *prioLogBatch) LogCommitChanges(ctx context.Context, _ []sop.StoreInfo, _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle], _ []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (p *prioLogBatch) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // Backup APIs removed; count Add/Remove via existing methods.
 

--- a/common/coverage_boost_test.go
+++ b/common/coverage_boost_test.go
@@ -200,7 +200,7 @@ func Test_TransactionLogger_DoPriorityRollbacks_LockNotAcquired(t *testing.T) {
 	txn := &Transaction{l2Cache: mocks.NewMockClient()}
 	// Pre-acquire the priority lock with another owner so doPriorityRollbacks cannot enter.
 	// Note: doPriorityRollbacks formats the key twice, so mirror that here.
-	k := txn.l2Cache.FormatLockKey(txn.l2Cache.FormatLockKey("Prbs"))
+	k := txn.l2Cache.FormatLockKey(txn.l2Cache.FormatLockKey(coordinatorLockName))
 	_ = txn.l2Cache.Set(ctx, k, sop.NewUUID().String(), time.Minute)
 	tl := newTransactionLogger(mocks.NewMockTransactionLog(), true)
 	ok, err := tl.doPriorityRollbacks(ctx, txn)
@@ -718,6 +718,9 @@ func (m missAfterSetCache) Unlock(ctx context.Context, lk []*sop.LockKey) error 
 	return m.base.Unlock(ctx, lk)
 }
 func (m missAfterSetCache) Clear(ctx context.Context) error { return m.base.Clear(ctx) }
+func (m missAfterSetCache) IsRestarted(ctx context.Context) (bool, error) {
+	return m.base.IsRestarted(ctx)
+}
 
 func Test_ItemActionTracker_Lock_CantAttain_AfterSet_ReturnsError(t *testing.T) {
 	ctx := context.Background()

--- a/common/instantiatemocktransaction.go
+++ b/common/instantiatemocktransaction.go
@@ -22,7 +22,7 @@ func newMockTransaction(t *testing.T, mode sop.TransactionMode, maxTime time.Dur
 	// Ensure global L1 cache uses the mock Redis client to avoid real Redis dependency in tests.
 	cache.NewGlobalCache(mockRedisCache, cache.DefaultMinCapacity, cache.DefaultMaxCapacity)
 	twoPhase, _ := newMockTwoPhaseCommitTransaction(t, mode, maxTime, false)
-	return sop.NewTransaction(mode, twoPhase, maxTime, false)
+	return sop.NewTransaction(mode, twoPhase, false)
 }
 
 // NewMockTransaction with logging turned on.
@@ -31,7 +31,7 @@ func newMockTransactionWithLogging(t *testing.T, mode sop.TransactionMode, maxTi
 	// Ensure global L1 cache uses the mock Redis client to avoid real Redis dependency in tests.
 	cache.NewGlobalCache(mockRedisCache, cache.DefaultMinCapacity, cache.DefaultMaxCapacity)
 	twoPhase, _ := newMockTwoPhaseCommitTransaction(t, mode, maxTime, true)
-	return sop.NewTransaction(mode, twoPhase, maxTime, true)
+	return sop.NewTransaction(mode, twoPhase, true)
 }
 
 func newMockTwoPhaseCommitTransaction(t *testing.T, mode sop.TransactionMode, maxTime time.Duration, logging bool) (sop.TwoPhaseCommitTransaction, error) {

--- a/common/itemactiontracker_scenarios2_test.go
+++ b/common/itemactiontracker_scenarios2_test.go
@@ -78,6 +78,9 @@ func (f *flakyCache) Unlock(ctx context.Context, lockKeys []*sop.LockKey) error 
 	return f.base.Unlock(ctx, lockKeys)
 }
 func (f *flakyCache) Clear(ctx context.Context) error { return f.base.Clear(ctx) }
+func (f *flakyCache) IsRestarted(ctx context.Context) (bool, error) {
+	return f.base.IsRestarted(ctx)
+}
 
 func Test_ItemActionTracker_Lock_PostSetReadMiss_ReturnsError(t *testing.T) {
 	ctx := context.Background()
@@ -163,6 +166,9 @@ func (e *errLockCache) Unlock(ctx context.Context, lockKeys []*sop.LockKey) erro
 	return e.base.Unlock(ctx, lockKeys)
 }
 func (e *errLockCache) Clear(ctx context.Context) error { return e.base.Clear(ctx) }
+func (e *errLockCache) IsRestarted(ctx context.Context) (bool, error) {
+	return e.base.IsRestarted(ctx)
+}
 
 func Test_ItemActionTracker_Lock_EarlyGetStructError(t *testing.T) {
 	ctx := context.Background()
@@ -294,6 +300,9 @@ func (e *errCache) Unlock(ctx context.Context, lockKeys []*sop.LockKey) error {
 	return e.base.Unlock(ctx, lockKeys)
 }
 func (e *errCache) Clear(ctx context.Context) error { return e.base.Clear(ctx) }
+func (e *errCache) IsRestarted(ctx context.Context) (bool, error) {
+	return e.base.IsRestarted(ctx)
+}
 
 func Test_ItemActionTracker_Get_RedisErrors_UsesBlob_StillSucceeds(t *testing.T) {
 	ctx := context.Background()

--- a/common/locks_and_registry_test.go
+++ b/common/locks_and_registry_test.go
@@ -41,6 +41,7 @@ func (s *stubPriorityLog2) GetBatch(ctx context.Context, batchSize int) ([]sop.K
 func (s *stubPriorityLog2) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (s *stubPriorityLog2) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // Backup methods removed from interface; no-op methods deleted.
 // Removed backup methods

--- a/common/locks_and_registry_test.go
+++ b/common/locks_and_registry_test.go
@@ -41,10 +41,9 @@ func (s *stubPriorityLog2) GetBatch(ctx context.Context, batchSize int) ([]sop.K
 func (s *stubPriorityLog2) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, a, b, c, d []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (s *stubPriorityLog2) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error {
-	return nil
-}
-func (s *stubPriorityLog2) RemoveBackup(ctx context.Context, tid sop.UUID) error { return nil }
+
+// Backup methods removed from interface; no-op methods deleted.
+// Removed backup methods
 
 // stubTLog2 returns our stubPriorityLog2
 type stubTLog2 struct{ pl *stubPriorityLog2 }

--- a/common/mocks/mock_redis.go
+++ b/common/mocks/mock_redis.go
@@ -11,6 +11,7 @@ import (
 type mockRedis struct {
 	lookup      map[string][]byte // for SetStruct/GetStruct
 	stringStore map[string]string // for Set/Get and locking values
+	restarted   bool              // toggled to simulate a restart event once
 }
 
 // Returns a new Redis mock client.
@@ -38,6 +39,15 @@ func (m *mockRedis) GetEx(ctx context.Context, key string, expiration time.Durat
 	return m.Get(ctx, key)
 }
 func (m *mockRedis) Ping(ctx context.Context) error { return nil }
+
+// IsRestarted returns the internal flag once and then resets it to false.
+func (m *mockRedis) IsRestarted(ctx context.Context) (bool, error) {
+	if m.restarted {
+		m.restarted = false
+		return true, nil
+	}
+	return false, nil
+}
 
 // Struct operations used by value caching and item locks.
 func (m *mockRedis) SetStruct(ctx context.Context, key string, value interface{}, expiration time.Duration) error {

--- a/common/mocks/mock_transaction_log.go
+++ b/common/mocks/mock_transaction_log.go
@@ -150,6 +150,7 @@ func (d dummyPriorityLog) GetBatch(ctx context.Context, batchSize int) ([]sop.Ke
 func (d dummyPriorityLog) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (d dummyPriorityLog) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // Fetch the transaction logs details given a tranasction ID.
 func (tl *MockTransactionLog) Get(ctx context.Context, tid sop.UUID) ([]sop.RegistryPayload[sop.Handle], error) {

--- a/common/mocks/mock_transaction_log.go
+++ b/common/mocks/mock_transaction_log.go
@@ -150,10 +150,6 @@ func (d dummyPriorityLog) GetBatch(ctx context.Context, batchSize int) ([]sop.Ke
 func (d dummyPriorityLog) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (d dummyPriorityLog) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error {
-	return nil
-}
-func (d dummyPriorityLog) RemoveBackup(ctx context.Context, tid sop.UUID) error { return nil }
 
 // Fetch the transaction logs details given a tranasction ID.
 func (tl *MockTransactionLog) Get(ctx context.Context, tid sop.UUID) ([]sop.RegistryPayload[sop.Handle], error) {

--- a/common/transactionlogger_scenarios_test.go
+++ b/common/transactionlogger_scenarios_test.go
@@ -48,7 +48,8 @@ func (noOpPrioLog) GetBatch(context.Context, int) ([]sop.KeyValuePair[sop.UUID, 
 func (noOpPrioLog) LogCommitChanges(context.Context, []sop.StoreInfo, []sop.RegistryPayload[sop.Handle], []sop.RegistryPayload[sop.Handle], []sop.RegistryPayload[sop.Handle], []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
-func (t *tlRecorder) PriorityLog() sop.TransactionPriorityLog { return noOpPrioLog{} }
+func (noOpPrioLog) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
+func (t *tlRecorder) PriorityLog() sop.TransactionPriorityLog        { return noOpPrioLog{} }
 func (t *tlRecorder) Add(ctx context.Context, tid sop.UUID, commitFunction int, payload []byte) error {
 	t.added = append(t.added, sop.KeyValuePair[int, []byte]{Key: commitFunction, Value: payload})
 	return nil
@@ -107,6 +108,7 @@ func (s *stubPriorityLog) GetBatch(ctx context.Context, batchSize int) ([]sop.Ke
 func (s *stubPriorityLog) LogCommitChanges(ctx context.Context, stores []sop.StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []sop.RegistryPayload[sop.Handle]) error {
 	return nil
 }
+func (s *stubPriorityLog) ClearRegistrySectorClaims(ctx context.Context) error { return nil }
 
 // stubTLog implements sop.TransactionLog and returns our stubPriorityLog.
 type stubTLog struct{ pl *stubPriorityLog }

--- a/common/twopc_phase2_paths_scenarios_test.go
+++ b/common/twopc_phase2_paths_scenarios_test.go
@@ -170,12 +170,8 @@ func Test_Rollback_Error_From_PreCommitTrackedValues_Delete(t *testing.T) {
 func Test_OnIdle_Runs_Priority_And_Expired_Paths(t *testing.T) {
 	ctx := context.Background()
 	pl := &stubPriorityLog{
-		batch: []sop.KeyValuePair[sop.UUID, []sop.RegistryPayload[sop.Handle]]{
-			{Key: sop.NewUUID(), Value: []sop.RegistryPayload[sop.Handle]{{RegistryTable: "rt", IDs: []sop.Handle{sop.NewHandle(sop.NewUUID())}}}},
-		},
-		writeBackupErr:  map[string]error{},
-		removeErr:       map[string]error{},
-		removeBackupHit: map[string]int{},
+		batch:     []sop.KeyValuePair[sop.UUID, []sop.RegistryPayload[sop.Handle]]{{Key: sop.NewUUID(), Value: []sop.RegistryPayload[sop.Handle]{{RegistryTable: "rt", IDs: []sop.Handle{sop.NewHandle(sop.NewUUID())}}}}},
+		removeErr: map[string]error{},
 	}
 	tl := newTransactionLogger(stubTLog{pl: pl}, true)
 	reg := mocks.NewMockRegistry(false)
@@ -206,8 +202,9 @@ func Test_OnIdle_Runs_Priority_And_Expired_Paths(t *testing.T) {
 	if hourBeingProcessed != "" {
 		t.Fatalf("expected hourBeingProcessed reset, got %q", hourBeingProcessed)
 	}
-	if len(pl.removeBackupHit) == 0 {
-		t.Fatalf("expected RemoveBackup to be called at least once")
+	// Ensure some progress occurred by checking priority batch was consumed or Remove attempted.
+	if len(pl.removedHit) == 0 {
+		t.Fatalf("expected priority Remove to be attempted at least once")
 	}
 }
 

--- a/common/twophasecommittransaction.go
+++ b/common/twophasecommittransaction.go
@@ -474,7 +474,9 @@ func (t *Transaction) phase1Commit(ctx context.Context) error {
 	if len(updatedNodesHandles) > 0 || len(removedNodesHandles) > 0 {
 		// Log the updated nodes & removed nodes handles for use in their rollback in File System Registry implementation.
 		// Cassandra tlogger will ignore this as it has its own "all or nothing" feature handled inside Cassandra cluster.
-		t.logger.PriorityLog().Add(ctx, t.GetID(), toByteArray(append(updatedNodesHandles, removedNodesHandles...)))
+		if err := t.logger.PriorityLog().Add(ctx, t.GetID(), toByteArray(append(updatedNodesHandles, removedNodesHandles...))); err != nil {
+			return err
+		}
 	}
 
 	// Prepare to switch to active "state" the (inactive) updated Nodes, in phase2Commit.

--- a/common/twophasecommittransaction.go
+++ b/common/twophasecommittransaction.go
@@ -348,7 +348,10 @@ func (t *Transaction) phase1Commit(ctx context.Context) error {
 		}
 		//* End: Try to lock all updated & removed nodes before moving forward.
 
-		if err := t.commitTrackedValuesWithLogging(ctx); err != nil {
+		if err := t.logger.log(ctx, commitTrackedItemsValues, toByteArray(t.getForRollbackTrackedItemsValues())); err != nil {
+			return err
+		}
+		if err := t.commitTrackedItemsValues(ctx); err != nil {
 			return err
 		}
 
@@ -364,47 +367,78 @@ func (t *Transaction) phase1Commit(ctx context.Context) error {
 		bibs := convertToBlobRequestPayload(rootNodes)
 		vids := convertToRegistryRequestPayload(rootNodes)
 
-		if s, err := t.commitRootNodesWithLogging(ctx, vids, bibs, rootNodes); err != nil {
+		if err := t.logger.log(ctx, commitNewRootNodes, toByteArray(sop.Tuple[[]sop.RegistryPayload[sop.UUID], []sop.BlobsPayload[sop.UUID]]{
+			First: vids, Second: bibs,
+		})); err != nil {
 			return err
-		} else {
-			successful = s
+		}
+		if successful, t.newRootNodeHandles, err = t.btreesBackend[0].nodeRepository.commitNewRootNodes(ctx, rootNodes); err != nil {
+			var se sop.Error
+			if errors.As(err, &se) {
+				if err := t.handleRegistrySectorLockTimeout(ctx, se); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
 		}
 
 		if successful {
 			// Check for conflict on fetched items.
-			if s, err := t.checkFetchedItemsIntactWithLogging(ctx, fetchedNodes); err != nil {
+			if err := t.logger.log(ctx, areFetchedItemsIntact, nil); err != nil {
 				return err
-			} else {
-				successful = s
+			}
+			if successful, err = t.btreesBackend[0].nodeRepository.areFetchedItemsIntact(ctx, fetchedNodes); err != nil {
+				return err
 			}
 		}
 		if successful {
 			// Commit updated nodes.
-			if uhs, s, err := t.commitUpdatedNodesWithLogging(ctx, updatedNodes); err != nil {
+			if successful, updatedNodesHandles, err = t.btreesBackend[0].nodeRepository.commitUpdatedNodes(ctx, updatedNodes); err != nil {
+				var se sop.Error
+				if errors.As(err, &se) {
+					if err := t.handleRegistrySectorLockTimeout(ctx, se); err != nil {
+						return err
+					}
+				} else {
+					return err
+				}
+			}
+			// Log the inactive Blobs' IDs of newly written so we can just easily remove them when cleaning up "dead" transaction logs.
+			if err := t.logger.log(ctx, commitUpdatedNodes, toByteArray(extractInactiveBlobsIDs(updatedNodesHandles))); err != nil {
 				return err
-			} else {
-				updatedNodesHandles = uhs
-				successful = s
 			}
 		}
 		// Only do commit removed nodes if successful so far.
 		if successful {
 			// Commit removed nodes.
-			if rhs, s, err := t.commitRemovedNodesWithLogging(ctx, removedNodes); err != nil {
+			if err := t.logger.log(ctx, commitRemovedNodes, toByteArray(convertToRegistryRequestPayload(removedNodes))); err != nil {
 				return err
-			} else {
-				removedNodesHandles = rhs
-				successful = s
+			}
+			if successful, removedNodesHandles, err = t.btreesBackend[0].nodeRepository.commitRemovedNodes(ctx, removedNodes); err != nil {
+				return err
 			}
 		}
 
 		// Only do commit added nodes if successful so far.
 		if successful {
 			// Commit added nodes.
-			if s, err := t.commitAddedNodesWithLogging(ctx, addedNodes); err != nil {
+			if err := t.logger.log(ctx, commitAddedNodes, toByteArray(sop.Tuple[[]sop.RegistryPayload[sop.UUID], []sop.BlobsPayload[sop.UUID]]{
+				First:  convertToRegistryRequestPayload(addedNodes),
+				Second: convertToBlobRequestPayload(addedNodes),
+			})); err != nil {
 				return err
-			} else if !s {
-				successful = false
+			}
+			if t.addedNodeHandles, err = t.btreesBackend[0].nodeRepository.commitAddedNodes(ctx, addedNodes); err != nil {
+				var se sop.Error
+				if errors.As(err, &se) {
+					if err := t.handleRegistrySectorLockTimeout(ctx, se); err != nil {
+						return err
+					}
+					successful = false
+				} else {
+					return err
+				}
 			}
 		}
 
@@ -473,99 +507,6 @@ func (t *Transaction) phase1Commit(ctx context.Context) error {
 	t.updatedNodes = updatedNodes
 
 	return nil
-}
-
-// commitTrackedValuesWithLogging logs and persists tracked item values segment.
-func (t *Transaction) commitTrackedValuesWithLogging(ctx context.Context) error {
-	if err := t.logger.log(ctx, commitTrackedItemsValues, toByteArray(t.getForRollbackTrackedItemsValues())); err != nil {
-		return err
-	}
-	return t.commitTrackedItemsValues(ctx)
-}
-
-// commitRootNodesWithLogging logs and commits new root nodes, handling registry sector lock timeout semantics.
-func (t *Transaction) commitRootNodesWithLogging(ctx context.Context, vids []sop.RegistryPayload[sop.UUID], bibs []sop.BlobsPayload[sop.UUID], rootNodes []sop.Tuple[*sop.StoreInfo, []interface{}]) (bool, error) {
-	if err := t.logger.log(ctx, commitNewRootNodes, toByteArray(sop.Tuple[[]sop.RegistryPayload[sop.UUID], []sop.BlobsPayload[sop.UUID]]{First: vids, Second: bibs})); err != nil {
-		return false, err
-	}
-	successful, handles, err := t.btreesBackend[0].nodeRepository.commitNewRootNodes(ctx, rootNodes)
-	if err != nil {
-		var se sop.Error
-		if errors.As(err, &se) {
-			if err := t.handleRegistrySectorLockTimeout(ctx, se); err != nil {
-				return false, err
-			}
-			// treat as handled; keep successful as-is from repo
-		} else {
-			return false, err
-		}
-	}
-	t.newRootNodeHandles = handles
-	return successful, nil
-}
-
-// checkFetchedItemsIntactWithLogging logs and checks fetched item conflicts.
-func (t *Transaction) checkFetchedItemsIntactWithLogging(ctx context.Context, fetchedNodes []sop.Tuple[*sop.StoreInfo, []interface{}]) (bool, error) {
-	if err := t.logger.log(ctx, areFetchedItemsIntact, nil); err != nil {
-		return false, err
-	}
-	return t.btreesBackend[0].nodeRepository.areFetchedItemsIntact(ctx, fetchedNodes)
-}
-
-// commitUpdatedNodesWithLogging commits updated nodes and logs inactive blob IDs for cleanup.
-func (t *Transaction) commitUpdatedNodesWithLogging(ctx context.Context, updatedNodes []sop.Tuple[*sop.StoreInfo, []interface{}]) ([]sop.RegistryPayload[sop.Handle], bool, error) {
-	successful, updatedNodesHandles, err := t.btreesBackend[0].nodeRepository.commitUpdatedNodes(ctx, updatedNodes)
-	if err != nil {
-		var se sop.Error
-		if errors.As(err, &se) {
-			if err := t.handleRegistrySectorLockTimeout(ctx, se); err != nil {
-				return nil, false, err
-			}
-		} else {
-			return nil, false, err
-		}
-	}
-	// Log inactive blobs from updated nodes for later cleanup of dead transactions.
-	if err := t.logger.log(ctx, commitUpdatedNodes, toByteArray(extractInactiveBlobsIDs(updatedNodesHandles))); err != nil {
-		return nil, false, err
-	}
-	return updatedNodesHandles, successful, nil
-}
-
-// commitRemovedNodesWithLogging logs and commits removed nodes.
-func (t *Transaction) commitRemovedNodesWithLogging(ctx context.Context, removedNodes []sop.Tuple[*sop.StoreInfo, []interface{}]) ([]sop.RegistryPayload[sop.Handle], bool, error) {
-	if err := t.logger.log(ctx, commitRemovedNodes, toByteArray(convertToRegistryRequestPayload(removedNodes))); err != nil {
-		return nil, false, err
-	}
-	successful, removedNodesHandles, err := t.btreesBackend[0].nodeRepository.commitRemovedNodes(ctx, removedNodes)
-	if err != nil {
-		return nil, false, err
-	}
-	return removedNodesHandles, successful, nil
-}
-
-// commitAddedNodesWithLogging logs and commits added nodes; on handled registry sector lock timeout, signals retry needed via false.
-func (t *Transaction) commitAddedNodesWithLogging(ctx context.Context, addedNodes []sop.Tuple[*sop.StoreInfo, []interface{}]) (bool, error) {
-	if err := t.logger.log(ctx, commitAddedNodes, toByteArray(sop.Tuple[[]sop.RegistryPayload[sop.UUID], []sop.BlobsPayload[sop.UUID]]{
-		First:  convertToRegistryRequestPayload(addedNodes),
-		Second: convertToBlobRequestPayload(addedNodes),
-	})); err != nil {
-		return false, err
-	}
-	handles, err := t.btreesBackend[0].nodeRepository.commitAddedNodes(ctx, addedNodes)
-	if err != nil {
-		var se sop.Error
-		if errors.As(err, &se) {
-			if err := t.handleRegistrySectorLockTimeout(ctx, se); err != nil {
-				return false, err
-			}
-			// handled; signal caller to retry path by returning false
-			return false, nil
-		}
-		return false, err
-	}
-	t.addedNodeHandles = handles
-	return true, nil
 }
 
 // phase2Commit finalizes the commit process and does cleanup afterwards.

--- a/common/twophasecommittransaction2.go
+++ b/common/twophasecommittransaction2.go
@@ -495,9 +495,24 @@ func (t *Transaction) onIdle(ctx context.Context) {
 		return
 	}
 
+	// If cache backend restarted, attempt a one-time priority rollback sweep immediately.
+	if t.l2Cache != nil && t.logger != nil && t.logger.PriorityLog().IsEnabled() {
+		if restarted, err := t.l2Cache.IsRestarted(ctx); err == nil && restarted {
+			// On restart, sweep all priority logs (ignore age) once.
+			ctxAll := context.WithValue(ctx, sop.ContextPriorityLogIgnoreAge, true)
+			if _, err := t.logger.doPriorityRollbacks(ctxAll, t); err != nil {
+				if t.HandleReplicationRelatedError != nil {
+					t.HandleReplicationRelatedError(ctx, err, nil, true)
+				}
+			}
+			// Reset the priority log found flag so interval will be at decent time (default).
+			priorityLogFound = false
+		}
+	}
+
 	// Allow only one priority rollback processor.
-	// Check every 2.5 minutes if there are any pending rollbacks that "aged" (5min or older).
-	interval := 150
+	// Check every 5 minutes if there are any pending rollbacks that "aged" (5min or older).
+	interval := 300
 	if priorityLogFound {
 		interval = 5
 	}

--- a/common/twophasecommittransaction2.go
+++ b/common/twophasecommittransaction2.go
@@ -516,7 +516,7 @@ func (t *Transaction) onIdle(ctx context.Context) {
 				if t.HandleReplicationRelatedError != nil {
 					t.HandleReplicationRelatedError(ctx, err, nil, true)
 				}
-				priorityLogFound = false
+				priorityLogFound = found
 			} else {
 				priorityLogFound = found
 			}

--- a/fs/additional_coverage_new_branches_test.go
+++ b/fs/additional_coverage_new_branches_test.go
@@ -107,6 +107,10 @@ func TestRegistry_Replicate_rmCloseOverrideError(t *testing.T) {
 // Cache wrapper that forces SetStruct to return an error to exercise log.Warn paths in Add & Update.
 type setStructErrCache struct{ sop.Cache }
 
+func (c setStructErrCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (c setStructErrCache) SetStruct(ctx context.Context, key string, value interface{}, exp time.Duration) error {
 	return errors.New("induced setstruct error")
 }

--- a/fs/additional_fs_coverage_test.go
+++ b/fs/additional_fs_coverage_test.go
@@ -197,6 +197,9 @@ func (m *lockFailingCache) IsLockedByOthers(ctx context.Context, ks []string) (b
 }
 func (m *lockFailingCache) Unlock(ctx context.Context, lks []*sop.LockKey) error { return nil }
 func (m *lockFailingCache) Clear(ctx context.Context) error                      { return m.base.Clear(ctx) }
+func (m *lockFailingCache) IsRestarted(ctx context.Context) (bool, error) {
+	return m.base.IsRestarted(ctx)
+}
 func Test_updateFileBlockRegion_LockTimeout(t *testing.T) {
 	// Short-deadline context forces the timeout branch on lock acquisition loop.
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)

--- a/fs/hashmap.fileregion.go
+++ b/fs/hashmap.fileregion.go
@@ -66,14 +66,7 @@ func (hm *hashmap) updateFileBlockRegion(ctx context.Context, dio *fileDirectIO,
 			return err
 		}
 		if ok {
-			// Double check to ensure we have no race condition and 100% acquired a lock on the sector.
-			if ok, err := hm.cache.IsLocked(ctx, []*sop.LockKey{lk}); ok {
-				break
-			} else if err != nil {
-				// Unlock the sector just in case it can "get through", before return.
-				hm.unlockFileBlockRegion(ctx, lk)
-				return err
-			}
+			break
 		}
 		if err := sop.TimedOut(ctx, "lockFileBlockRegion", startTime, time.Duration(lockSectorRetryTimeoutInSecs*time.Second)); err != nil {
 			// If the context is canceled or the operation's context deadline was exceeded, return the raw error
@@ -120,7 +113,6 @@ func (hm *hashmap) updateFileBlockRegion(ctx context.Context, dio *fileDirectIO,
 	return hm.unlockFileBlockRegion(ctx, lk)
 
 }
-
 
 func (hm *hashmap) lockFileBlockRegion(ctx context.Context, dio *fileDirectIO, offset int64) (bool, sop.UUID, *sop.LockKey, error) {
 	tid := hm.replicationTracker.tid

--- a/fs/hashmap.fileregion.go
+++ b/fs/hashmap.fileregion.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	lockSectorRetryTimeoutInSecs = 30
+	lockSectorRetryTimeoutInSecs = 3 * 60
 )
 
 var zeroSector = bytes.Repeat([]byte{0}, sop.HandleSizeInBytes)

--- a/fs/hashmap_scenarios2_test.go
+++ b/fs/hashmap_scenarios2_test.go
@@ -19,6 +19,9 @@ type lockFailOkFalse struct{ sop.Cache }
 func (m lockFailOkFalse) Lock(ctx context.Context, d time.Duration, lk []*sop.LockKey) (bool, sop.UUID, error) {
 	return false, sop.NilUUID, nil
 }
+func (m lockFailOkFalse) IsRestarted(ctx context.Context) (bool, error) {
+	return m.Cache.IsRestarted(ctx)
+}
 
 // Ensures setupNewFile surfaces lock-acquisition failure and does not create/truncate the segment.
 func TestHashmap_setupNewFile_LockFailure_NoCreate(t *testing.T) {

--- a/fs/hashmap_scenarios_test.go
+++ b/fs/hashmap_scenarios_test.go
@@ -116,6 +116,9 @@ func (m *mockCacheHashmap) Unlock(ctx context.Context, lk []*sop.LockKey) error 
 	return m.base.Unlock(ctx, lk)
 }
 func (m *mockCacheHashmap) Clear(ctx context.Context) error { return m.base.Clear(ctx) }
+func (m *mockCacheHashmap) IsRestarted(ctx context.Context) (bool, error) {
+	return m.base.IsRestarted(ctx)
+}
 
 func contains(s, sub string) bool {
 	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
@@ -148,7 +151,6 @@ func TestHashmap_AllScenarios(t *testing.T) {
 
 	cache := mocks.NewMockClient()
 	hm := newHashmap(true, 32, rt, cache)
-
 	// --- Scenario: write + read + delete lifecycle ---
 	table := "regcase"
 	if err := os.MkdirAll(filepath.Join(rt.getActiveBaseFolder(), table), 0o755); err != nil {
@@ -586,6 +588,9 @@ func (m *mockCacheIsLockedErr) IsLocked(ctx context.Context, lk []*sop.LockKey) 
 		return false, e
 	}
 	return m.mockCacheHashmap.IsLocked(ctx, lk)
+}
+func (m *mockCacheIsLockedErr) IsRestarted(ctx context.Context) (bool, error) {
+	return m.mockCacheHashmap.IsRestarted(ctx)
 }
 
 func Test_updateFileBlockRegion_ErrorPaths_Table(t *testing.T) {

--- a/fs/replicationtracker_scenarios3_test.go
+++ b/fs/replicationtracker_scenarios3_test.go
@@ -15,6 +15,10 @@ import (
 
 type getStructExErrCache struct{ sop.Cache }
 
+func (c getStructExErrCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (c getStructExErrCache) GetStructEx(ctx context.Context, key string, v interface{}, ttl time.Duration) (bool, error) {
 	return false, errors.New("l2 boom")
 }
@@ -557,11 +561,19 @@ func Test_ReadStatus_ActivePresent_InvalidJSON_ReturnsError(t *testing.T) {
 
 type getStructExErrCache2 struct{ sop.Cache }
 
+func (c getStructExErrCache2) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (c getStructExErrCache2) GetStructEx(ctx context.Context, key string, v interface{}, ttl time.Duration) (bool, error) {
 	return false, errors.New("getstructex err2")
 }
 
 type getStructExNotFoundCache struct{ sop.Cache }
+
+func (c getStructExNotFoundCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
 
 func (c getStructExNotFoundCache) GetStructEx(ctx context.Context, key string, v interface{}, ttl time.Duration) (bool, error) {
 	return false, nil
@@ -582,12 +594,20 @@ func (c getStructExFoundCache) GetStructEx(ctx context.Context, key string, v in
 
 type setStructErrCache2 struct{ sop.Cache }
 
+func (c setStructErrCache2) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
+
 func (c setStructErrCache2) SetStruct(ctx context.Context, key string, value interface{}, exp time.Duration) error {
 	return errors.New("setstruct err2")
 }
 
 // combined wrapper: GetStructEx returns not found, SetStruct returns error
 type notFoundSetErrCache struct{ sop.Cache }
+
+func (c notFoundSetErrCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.Cache.IsRestarted(ctx)
+}
 
 func (c notFoundSetErrCache) GetStructEx(ctx context.Context, key string, v interface{}, ttl time.Duration) (bool, error) {
 	return false, nil

--- a/fs/storerepository_scenarios3_test.go
+++ b/fs/storerepository_scenarios3_test.go
@@ -64,17 +64,26 @@ func (m mockCacheWarn) Unlock(ctx context.Context, ks []*sop.LockKey) error {
 	return m.inner.Unlock(ctx, ks)
 }
 func (m mockCacheWarn) Clear(ctx context.Context) error { return m.inner.Clear(ctx) }
+func (m mockCacheWarn) IsRestarted(ctx context.Context) (bool, error) {
+	return m.inner.IsRestarted(ctx)
+}
 
 type mockCacheDeleteWarn struct{ sop.Cache }
 
 func (m mockCacheDeleteWarn) Delete(context.Context, []string) (bool, error) {
 	return false, errors.New("fail delete")
 }
+func (m mockCacheDeleteWarn) IsRestarted(ctx context.Context) (bool, error) {
+	return m.Cache.IsRestarted(ctx)
+}
 
 type mockCacheSetStructWarn struct{ sop.Cache }
 
 func (m mockCacheSetStructWarn) SetStruct(context.Context, string, interface{}, time.Duration) error {
 	return errors.New("fail setstruct")
+}
+func (m mockCacheSetStructWarn) IsRestarted(ctx context.Context) (bool, error) {
+	return m.Cache.IsRestarted(ctx)
 }
 
 // mockCacheAlwaysLocked forces Lock to report the key(s) are already locked, so Update's
@@ -83,6 +92,9 @@ type mockCacheAlwaysLocked struct{ sop.Cache }
 
 func (m mockCacheAlwaysLocked) Lock(ctx context.Context, d time.Duration, ks []*sop.LockKey) (bool, sop.UUID, error) {
 	return false, sop.NewUUID(), nil
+}
+func (m mockCacheAlwaysLocked) IsRestarted(ctx context.Context) (bool, error) {
+	return m.Cache.IsRestarted(ctx)
 }
 
 // failingRemoveAll triggers RemoveAll failure for passive replicated path ending with /x1.

--- a/fs/storerepository_scenarios3_test.go
+++ b/fs/storerepository_scenarios3_test.go
@@ -676,6 +676,10 @@ func Test_StoreRepository_Replicate_Marshal_Error(t *testing.T) {
 
 	a := t.TempDir()
 	b := t.TempDir()
+	// Ensure global replication state doesn't short-circuit Replicate due to prior tests.
+	prevGlob := GlobalReplicationDetails
+	GlobalReplicationDetails = &ReplicationTrackedDetails{}
+	t.Cleanup(func() { GlobalReplicationDetails = prevGlob })
 	rt, _ := NewReplicationTracker(ctx, []string{a, b}, true, cache)
 
 	sr, err := NewStoreRepository(ctx, rt, nil, cache, 0)

--- a/fs/transactionlog_scenarios_test.go
+++ b/fs/transactionlog_scenarios_test.go
@@ -263,6 +263,9 @@ func (c *cacheIsLockedFalse) Unlock(ctx context.Context, lk []*sop.LockKey) erro
 	return c.base.Unlock(ctx, lk)
 }
 func (c *cacheIsLockedFalse) Clear(ctx context.Context) error { return c.base.Clear(ctx) }
+func (c *cacheIsLockedFalse) IsRestarted(ctx context.Context) (bool, error) {
+	return c.base.IsRestarted(ctx)
+}
 
 // Exercises the final IsLocked check inside GetOne returning nils.
 func Test_TransactionLog_GetOne_FinalIsLockedFalse(t *testing.T) {

--- a/fs/transactionprioritylog.go
+++ b/fs/transactionprioritylog.go
@@ -30,13 +30,10 @@ func (l priorityLog) IsEnabled() bool {
 }
 
 // Add writes the priority log payload for a transaction.
-// Note: errors from WriteFile are currently ignored (fire-and-forget), as the system can
-// proceed without strict durability here; callers rely on batching and backups instead.
 func (l priorityLog) Add(ctx context.Context, tid sop.UUID, payload []byte) error {
 	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogFileExtension))
 	fio := NewFileIO()
-	fio.WriteFile(ctx, filename, payload, permission)
-	return nil
+	return fio.WriteFile(ctx, filename, payload, permission)
 }
 
 // LogCommitChanges persists commit-change metadata used when reinstating failed drives.

--- a/fs/transactionprioritylog.go
+++ b/fs/transactionprioritylog.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	priorityLogFileExtension       = ".plg"
-	priorityLogBackupFileExtension = ".plb"
 	priorityLogMinAgeInMin         = 5
 )
 
@@ -121,27 +120,10 @@ func (l priorityLog) GetBatch(ctx context.Context, batchSize int) ([]sop.KeyValu
 
 // Remove deletes the priority log for a transaction, if present.
 func (l priorityLog) Remove(ctx context.Context, tid sop.UUID) error {
-	fio := newFileIO(sop.FileIOErrorFailoverQualified)
+	fio := NewFileIO()
 	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogFileExtension))
 	if fio.Exists(ctx, filename) {
 		return fio.Remove(ctx, filename)
 	}
-	return nil
-}
-
-// WriteBackup writes a backup copy of the priority log payload.
-// Similar to Add, this ignores errors (best-effort) and returns nil.
-func (l priorityLog) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error {
-	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogBackupFileExtension))
-	fio := NewFileIO()
-	fio.WriteFile(ctx, filename, payload, permission)
-	return nil
-}
-
-// RemoveBackup deletes the backup copy of the priority log payload.
-func (l priorityLog) RemoveBackup(ctx context.Context, tid sop.UUID) error {
-	filename := l.replicationTracker.formatActiveFolderEntity(fmt.Sprintf("%s%c%s%s", logFolder, os.PathSeparator, tid.String(), priorityLogBackupFileExtension))
-	fio := NewFileIO()
-	fio.Remove(ctx, filename)
 	return nil
 }

--- a/fs/transactionprioritylog_scenarios_test.go
+++ b/fs/transactionprioritylog_scenarios_test.go
@@ -63,14 +63,6 @@ func TestTransactionAndPriorityLog_Scenarios(t *testing.T) {
 		t.Fatalf("Priority Get mismatch: %+v err=%v", got, err)
 	}
 
-	// WriteBackup / RemoveBackup
-	if err := pl.WriteBackup(ctx, tid1, ba1); err != nil {
-		t.Fatalf("Priority WriteBackup: %v", err)
-	}
-	if err := pl.RemoveBackup(ctx, tid1); err != nil {
-		t.Fatalf("Priority RemoveBackup: %v", err)
-	}
-
 	// Remove existing then again (graceful)
 	if err := pl.Remove(ctx, tid1); err != nil {
 		t.Fatalf("Priority Remove: %v", err)
@@ -511,17 +503,7 @@ func TestPriorityLog_BasicGetRemovePaths_Merged(t *testing.T) {
 	if err := pl.Remove(ctx, tid); err != nil {
 		t.Fatalf("remove absent: %v", err)
 	}
-	payload := []byte(`[{}]`)
-	if err := pl.WriteBackup(ctx, tid, payload); err != nil {
-		t.Fatalf("write backup: %v", err)
-	}
-	backupFile := rt.formatActiveFolderEntity(filepath.Join(logFolder, tid.String()+priorityLogBackupFileExtension))
-	if _, err := os.Stat(backupFile); err != nil {
-		t.Fatalf("expected backup file: %v", err)
-	}
-	if err := pl.RemoveBackup(ctx, tid); err != nil {
-		t.Fatalf("remove backup: %v", err)
-	}
+	// Removed unused variable payload
 }
 
 func TestTransactionLog_RemoveClosesFile_Merged(t *testing.T) {

--- a/fs/transactionprioritylog_scenarios_test.go
+++ b/fs/transactionprioritylog_scenarios_test.go
@@ -357,6 +357,9 @@ func (c *alwaysLockFailCache) IsLockedByOthers(ctx context.Context, ks []string)
 }
 func (c *alwaysLockFailCache) Unlock(ctx context.Context, lks []*sop.LockKey) error { return nil }
 func (c *alwaysLockFailCache) Clear(ctx context.Context) error                      { return c.mocksCache.Clear(ctx) }
+func (c *alwaysLockFailCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.mocksCache.IsRestarted(ctx)
+}
 
 // lostLockCache acquires locks but reports them lost on IsLocked check.
 type lostLockCache struct{ *alwaysLockFailCache }
@@ -367,6 +370,9 @@ func (c *lostLockCache) Lock(ctx context.Context, d time.Duration, lks []*sop.Lo
 }
 func (c *lostLockCache) IsLocked(ctx context.Context, lks []*sop.LockKey) (bool, error) {
 	return false, nil
+}
+func (c *lostLockCache) IsRestarted(ctx context.Context) (bool, error) {
+	return c.mocksCache.IsRestarted(ctx)
 }
 
 // Covers the successful GetOneOfHour path (eligible file within TTL window returning records).

--- a/inredfs/integrationtests/blobstore_ec_rollback_no_failover_test.go
+++ b/inredfs/integrationtests/blobstore_ec_rollback_no_failover_test.go
@@ -4,182 +4,204 @@
 package integrationtests
 
 import (
-    "context"
-    "fmt"
-    "os"
-    "path/filepath"
-    "strings"
-    "testing"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 
-    "github.com/sharedcode/sop"
-    "github.com/sharedcode/sop/common"
-    "github.com/sharedcode/sop/fs"
-    "github.com/sharedcode/sop/redis"
+	"github.com/sharedcode/sop"
+	"github.com/sharedcode/sop/common"
+	"github.com/sharedcode/sop/fs"
+	"github.com/sharedcode/sop/redis"
 )
 
 // ecFailFileIO simulates shard write failures for BlobStoreWithEC by failing WriteFile
 // for configured shard indices and path prefix. It returns a non-failover sop.Error code.
 type ecFailFileIO struct {
-    base       fs.FileIO
-    pathPrefix string
-    failIdx    map[int]struct{}
+	base       fs.FileIO
+	pathPrefix string
+	failIdx    map[int]struct{}
 }
 
 func (e ecFailFileIO) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
-    if strings.Contains(name, e.pathPrefix) {
-        // file names end with _<shardIndex>
-        idx := -1
-        for i := len(name) - 1; i >= 0; i-- {
-            if name[i] == '_' {
-                // parse suffix as int; if parsing fails, ignore
-                var n int
-                _, _ = fmt.Sscanf(name[i+1:], "%d", &n)
-                idx = n
-                break
-            }
-        }
-        if idx >= 0 {
-            if _, ok := e.failIdx[idx]; ok {
-                // Return a non-failover-qualified SOP error to ensure no failover.
-                return sop.Error{Code: sop.FileIOError, Err: fmt.Errorf("simulated shard write failure idx=%d", idx)}
-            }
-        }
-    }
-    return e.base.WriteFile(ctx, name, data, perm)
+	if strings.Contains(name, e.pathPrefix) {
+		// file names end with _<shardIndex>
+		idx := -1
+		for i := len(name) - 1; i >= 0; i-- {
+			if name[i] == '_' {
+				// parse suffix as int; if parsing fails, ignore
+				var n int
+				_, _ = fmt.Sscanf(name[i+1:], "%d", &n)
+				idx = n
+				break
+			}
+		}
+		if idx >= 0 {
+			if _, ok := e.failIdx[idx]; ok {
+				// Return a non-failover-qualified SOP error to ensure no failover.
+				return sop.Error{Code: sop.FileIOError, Err: fmt.Errorf("simulated shard write failure idx=%d", idx)}
+			}
+		}
+	}
+	return e.base.WriteFile(ctx, name, data, perm)
 }
-func (e ecFailFileIO) ReadFile(ctx context.Context, name string) ([]byte, error) { return e.base.ReadFile(ctx, name) }
+func (e ecFailFileIO) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	return e.base.ReadFile(ctx, name)
+}
 func (e ecFailFileIO) Remove(ctx context.Context, name string) error { return e.base.Remove(ctx, name) }
-func (e ecFailFileIO) Exists(ctx context.Context, p string) bool { return e.base.Exists(ctx, p) }
+func (e ecFailFileIO) Exists(ctx context.Context, p string) bool     { return e.base.Exists(ctx, p) }
 func (e ecFailFileIO) RemoveAll(ctx context.Context, p string) error { return e.base.RemoveAll(ctx, p) }
 func (e ecFailFileIO) MkdirAll(ctx context.Context, p string, perm os.FileMode) error {
-    return e.base.MkdirAll(ctx, p, perm)
+	return e.base.MkdirAll(ctx, p, perm)
 }
-func (e ecFailFileIO) ReadDir(ctx context.Context, d string) ([]os.DirEntry, error) { return e.base.ReadDir(ctx, d) }
+func (e ecFailFileIO) ReadDir(ctx context.Context, d string) ([]os.DirEntry, error) {
+	return e.base.ReadDir(ctx, d)
+}
 
 // Test_EC_BlobStore_ShardsExceedParity_Rollback_NoFailover ensures that when EC shard writes fail
 // beyond parity tolerance, the transaction rolls back and no failover event is generated (since
 // only Registry/StoreRepository IO can trigger failover).
 func Test_EC_BlobStore_ShardsExceedParity_Rollback_NoFailover(t *testing.T) {
-    ctx := context.Background()
+	ctx := context.Background()
 
-    // Isolated replication base folders for this test (same as other isolated tests):
-    isolatedStores := []string{
-        fmt.Sprintf("%s%cdisk8", dataPath, os.PathSeparator),
-        fmt.Sprintf("%s%cdisk9", dataPath, os.PathSeparator),
-    }
-    // EC config: 2 data + 2 parity across disk10..disk13
-    ecCfg := map[string]fs.ErasureCodingConfig{
-        "": {
-            DataShardsCount:   2,
-            ParityShardsCount: 2,
-            BaseFolderPathsAcrossDrives: []string{
-                fmt.Sprintf("%s%cdisk10", dataPath, os.PathSeparator),
-                fmt.Sprintf("%s%cdisk11", dataPath, os.PathSeparator),
-                fmt.Sprintf("%s%cdisk12", dataPath, os.PathSeparator),
-                fmt.Sprintf("%s%cdisk13", dataPath, os.PathSeparator),
-            },
-            RepairCorruptedShards: true,
-        },
-    }
+	// Isolated replication base folders for this test (same as other isolated tests):
+	isolatedStores := []string{
+		fmt.Sprintf("%s%cdisk8", dataPath, os.PathSeparator),
+		fmt.Sprintf("%s%cdisk9", dataPath, os.PathSeparator),
+	}
+	// EC config: 2 data + 2 parity across disk10..disk13
+	ecCfg := map[string]fs.ErasureCodingConfig{
+		"": {
+			DataShardsCount:   2,
+			ParityShardsCount: 2,
+			BaseFolderPathsAcrossDrives: []string{
+				fmt.Sprintf("%s%cdisk10", dataPath, os.PathSeparator),
+				fmt.Sprintf("%s%cdisk11", dataPath, os.PathSeparator),
+				fmt.Sprintf("%s%cdisk12", dataPath, os.PathSeparator),
+				fmt.Sprintf("%s%cdisk13", dataPath, os.PathSeparator),
+			},
+			RepairCorruptedShards: true,
+		},
+	}
 
-    // Table unique to this test; ensure isolation.
-    table := "ec_blob_failoverfree_it"
+	// Table unique to this test; ensure isolation.
+	table := "ec_blob_failoverfree_it"
 
-    // Clean environment for isolated disks.
-    sanitizeIsolatedReplicationBases(t)
-    cleanupStoreEverywhere(table)
-    cleanupECShards(table)
-    cleanupStoreRepository(table, isolatedStores)
+	// Clean environment for isolated disks.
+	sanitizeIsolatedReplicationBases(t)
+	cleanupStoreEverywhere(table)
+	cleanupECShards(table)
+	cleanupStoreRepository(table, isolatedStores)
 
-    // Build components mirroring NewTwoPhaseCommitTransactionWithReplication but with a custom BlobStore fileIO.
-    cache := redis.NewClient()
-    rt, err := fs.NewReplicationTracker(ctx, isolatedStores, true, cache)
-    if err != nil { t.Fatalf("NewReplicationTracker: %v", err) }
+	// Build components mirroring NewTwoPhaseCommitTransactionWithReplication but with a custom BlobStore fileIO.
+	cache := redis.NewClient()
+	rt, err := fs.NewReplicationTracker(ctx, isolatedStores, true, cache)
+	if err != nil {
+		t.Fatalf("NewReplicationTracker: %v", err)
+	}
 
-    // ManageStore + StoreRepository
-    mbsf := fs.NewManageStoreFolder(fs.NewFileIO())
-    sr, err := fs.NewStoreRepository(ctx, rt, mbsf, cache, fs.MinimumModValue)
-    if err != nil { t.Fatalf("NewStoreRepository: %v", err) }
+	// ManageStore + StoreRepository
+	mbsf := fs.NewManageStoreFolder(fs.NewFileIO())
+	sr, err := fs.NewStoreRepository(ctx, rt, mbsf, cache, fs.MinimumModValue)
+	if err != nil {
+		t.Fatalf("NewStoreRepository: %v", err)
+	}
 
-    // Registry (readWrite=true)
-    reg := fs.NewRegistry(true, fs.MinimumModValue, rt, cache)
+	// Registry (readWrite=true)
+	reg := fs.NewRegistry(true, fs.MinimumModValue, rt, cache)
 
-    // BlobStoreWithEC with failing FileIO: fail 3 shards (indices 0,1,2) to exceed parity (2)
-    baseFileIO := fs.NewFileIO()
-    // prefix where blob shards for this table will be written; matches DefaultToFilePath layout
-    // baseFolderPath + os.PathSeparator + table
-    // We'll target all EC drive roots by checking for table name in path for simplicity.
-    failPrefix := string(os.PathSeparator) + table + string(os.PathSeparator)
-    injected := ecFailFileIO{base: baseFileIO, pathPrefix: failPrefix, failIdx: map[int]struct{}{0:{},1:{},2:{}}}
-    bs, err := fs.NewBlobStoreWithEC(fs.DefaultToFilePath, injected, ecCfg)
-    if err != nil { t.Fatalf("NewBlobStoreWithEC: %v", err) }
+	// BlobStoreWithEC with failing FileIO: fail 3 shards (indices 0,1,2) to exceed parity (2)
+	baseFileIO := fs.NewFileIO()
+	// prefix where blob shards for this table will be written; matches DefaultToFilePath layout
+	// baseFolderPath + os.PathSeparator + table
+	// We'll target all EC drive roots by checking for table name in path for simplicity.
+	failPrefix := string(os.PathSeparator) + table + string(os.PathSeparator)
+	injected := ecFailFileIO{base: baseFileIO, pathPrefix: failPrefix, failIdx: map[int]struct{}{0: {}, 1: {}, 2: {}}}
+	bs, err := fs.NewBlobStoreWithEC(fs.DefaultToFilePath, injected, ecCfg)
+	if err != nil {
+		t.Fatalf("NewBlobStoreWithEC: %v", err)
+	}
 
-    // Transaction log and 2PC transaction
-    tl := fs.NewTransactionLog(cache, rt)
-    twoPT, err := common.NewTwoPhaseCommitTransaction(sop.ForWriting, -1, true, bs, sr, reg, cache, tl)
-    if err != nil { t.Fatalf("NewTwoPhaseCommitTransaction: %v", err) }
-    // Wire failover handler and set TID for sector locks
-    twoPT.HandleReplicationRelatedError = rt.HandleReplicationRelatedError
-    rt.SetTransactionID(twoPT.GetID())
+	// Transaction log and 2PC transaction
+	tl := fs.NewTransactionLog(cache, rt)
+	twoPT, err := common.NewTwoPhaseCommitTransaction(sop.ForWriting, -1, true, bs, sr, reg, cache, tl)
+	if err != nil {
+		t.Fatalf("NewTwoPhaseCommitTransaction: %v", err)
+	}
+	// Wire failover handler and set TID for sector locks
+	twoPT.HandleReplicationRelatedError = rt.HandleReplicationRelatedError
+	rt.SetTransactionID(twoPT.GetID())
 
-    // Wrap into sop.Transaction to use higher-level helpers
-    tx, err := sop.NewTransaction(sop.ForWriting, twoPT, true)
-    if err != nil { t.Fatalf("sop.NewTransaction: %v", err) }
+	// Wrap into sop.Transaction to use higher-level helpers
+	tx, err := sop.NewTransaction(sop.ForWriting, twoPT, true)
+	if err != nil {
+		t.Fatalf("sop.NewTransaction: %v", err)
+	}
 
-    // Ensure store exists via StoreRepository to avoid dependency on helper options.
-    // Use DisableBlobStoreFormatting so blob table equals store name (matches failPrefix).
-    si := sop.NewStoreInfo(sop.StoreOptions{
-        Name:                           table,
-        SlotLength:                     8,
-        IsValueDataInNodeSegment:       false,
-        IsValueDataActivelyPersisted:   true,
-        DisableRegistryStoreFormatting: true,
-        DisableBlobStoreFormatting:     true,
-    })
-    // Add is idempotent for unique names; ignore error if already present.
-    _ = sr.Add(ctx, *si)
+	// Ensure store exists via StoreRepository to avoid dependency on helper options.
+	// Use DisableBlobStoreFormatting so blob table equals store name (matches failPrefix).
+	si := sop.NewStoreInfo(sop.StoreOptions{
+		Name:                           table,
+		SlotLength:                     8,
+		IsValueDataInNodeSegment:       false,
+		IsValueDataActivelyPersisted:   true,
+		DisableRegistryStoreFormatting: true,
+		DisableBlobStoreFormatting:     true,
+	})
+	// Add is idempotent for unique names; ignore error if already present.
+	_ = sr.Add(ctx, *si)
 
-    initialActive := false
-    if fs.GlobalReplicationDetails != nil { initialActive = fs.GlobalReplicationDetails.ActiveFolderToggler }
+	initialActive := false
+	if fs.GlobalReplicationDetails != nil {
+		initialActive = fs.GlobalReplicationDetails.ActiveFolderToggler
+	}
 
-    // Perform a write that will cause EC Add to fail > parity and trigger rollback.
-    if err := tx.Begin(); err != nil { t.Fatalf("Begin: %v", err) }
-    // Open the store; it should exist now.
-    btr, err := common.OpenBtree[int, string](ctx, table, tx, nil)
-    if err != nil { t.Fatalf("OpenBtree: %v", err) }
-    _, upErr := btr.Upsert(ctx, 100, "blob-data-100")
-    // If active persistence fails during Upsert (BlobStore.Add error), roll back to clean staged blobs.
-    if upErr != nil {
-        _ = tx.Rollback(ctx)
-    } else {
-        // Otherwise, commit should fail due to EC write failures exceeding parity.
-        if err := tx.Commit(ctx); err == nil {
-            t.Fatalf("expected commit error due to EC shard write failures exceeding parity")
-        }
-    }
+	// Perform a write that will cause EC Add to fail > parity and trigger rollback.
+	if err := tx.Begin(); err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	// Open the store; it should exist now.
+	btr, err := common.OpenBtree[int, string](ctx, table, tx, nil)
+	if err != nil {
+		t.Fatalf("OpenBtree: %v", err)
+	}
+	_, upErr := btr.Upsert(ctx, 100, "blob-data-100")
+	// If active persistence fails during Upsert (BlobStore.Add error), roll back to clean staged blobs.
+	if upErr != nil {
+		_ = tx.Rollback(ctx)
+	} else {
+		// Otherwise, commit should fail due to EC write failures exceeding parity.
+		if err := tx.Commit(ctx); err == nil {
+			t.Fatalf("expected commit error due to EC shard write failures exceeding parity")
+		}
+	}
 
-    // Assert no failover occurred and FailedToReplicate did not flip.
-    if fs.GlobalReplicationDetails != nil {
-        if fs.GlobalReplicationDetails.ActiveFolderToggler != initialActive {
-            t.Fatalf("unexpected failover toggler flip for blob IO error; got %+v", *fs.GlobalReplicationDetails)
-        }
-        if fs.GlobalReplicationDetails.FailedToReplicate {
-            t.Fatalf("unexpected FailedToReplicate=true for blob IO error; got %+v", *fs.GlobalReplicationDetails)
-        }
-    }
+	// Assert no failover occurred and FailedToReplicate did not flip.
+	if fs.GlobalReplicationDetails != nil {
+		if fs.GlobalReplicationDetails.ActiveFolderToggler != initialActive {
+			t.Fatalf("unexpected failover toggler flip for blob IO error; got %+v", *fs.GlobalReplicationDetails)
+		}
+		if fs.GlobalReplicationDetails.FailedToReplicate {
+			t.Fatalf("unexpected FailedToReplicate=true for blob IO error; got %+v", *fs.GlobalReplicationDetails)
+		}
+	}
 
-    // Ensure no shard files were written for the blob (clean rollback) under any EC drive.
-    // Quick scan for files with the table folder containing the blob UUID as prefix.
-    for i := 10; i <= 13; i++ {
-        base := fmt.Sprintf("%s%cdisk%d", dataPath, os.PathSeparator, i)
-        dir := filepath.Join(base, table)
-        if _, err := os.Stat(dir); os.IsNotExist(err) { continue }
-        // Directory may exist due to attempted writes; ensure there are no files for this blob key.
-        des, _ := os.ReadDir(dir)
-        for _, de := range des {
-            if strings.Contains(de.Name(), "_") { // shard naming format
-                t.Fatalf("unexpected shard file present after rollback: %s", filepath.Join(dir, de.Name()))
-            }
-        }
-    }
+	// Ensure no shard files were written for the blob (clean rollback) under any EC drive.
+	// Quick scan for files with the table folder containing the blob UUID as prefix.
+	for i := 10; i <= 13; i++ {
+		base := fmt.Sprintf("%s%cdisk%d", dataPath, os.PathSeparator, i)
+		dir := filepath.Join(base, table)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			continue
+		}
+		// Directory may exist due to attempted writes; ensure there are no files for this blob key.
+		des, _ := os.ReadDir(dir)
+		for _, de := range des {
+			if strings.Contains(de.Name(), "_") { // shard naming format
+				t.Fatalf("unexpected shard file present after rollback: %s", filepath.Join(dir, de.Name()))
+			}
+		}
+	}
 }

--- a/inredfs/integrationtests/blobstore_ec_rollback_no_failover_test.go
+++ b/inredfs/integrationtests/blobstore_ec_rollback_no_failover_test.go
@@ -123,7 +123,7 @@ func Test_EC_BlobStore_ShardsExceedParity_Rollback_NoFailover(t *testing.T) {
     rt.SetTransactionID(twoPT.GetID())
 
     // Wrap into sop.Transaction to use higher-level helpers
-    tx, err := sop.NewTransaction(sop.ForWriting, twoPT, -1, true)
+    tx, err := sop.NewTransaction(sop.ForWriting, twoPT, true)
     if err != nil { t.Fatalf("sop.NewTransaction: %v", err) }
 
     // Ensure store exists via StoreRepository to avoid dependency on helper options.

--- a/inredfs/integrationtests/replication_failover_reinstate_test.go
+++ b/inredfs/integrationtests/replication_failover_reinstate_test.go
@@ -39,6 +39,11 @@ func makePassiveRegistryReadOnly(t *testing.T, table string) {
     base := passiveBaseFolder()
     ensureTableDir(t, base, table)
     seg := registrySegmentPath(base, table)
+    // Ensure the segment file exists so chmod will take effect across platforms/umasks.
+    if _, err := os.Stat(seg); os.IsNotExist(err) {
+        // Best-effort create an empty segment file; permissions will be tightened next.
+        _ = os.WriteFile(seg, []byte{}, 0o644)
+    }
     // Make only the segment file read-only to fail replication writes without affecting other tables/dirs.
     _ = os.Chmod(seg, 0o444)
 }

--- a/inredfs/integrationtests/replication_failover_reinstate_test.go
+++ b/inredfs/integrationtests/replication_failover_reinstate_test.go
@@ -4,18 +4,18 @@
 package integrationtests
 
 import (
-    "context"
-    "fmt"
-    "os"
-    "path/filepath"
-    "strings"
-    "testing"
-    "time"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
 
-    "github.com/sharedcode/sop"
-    "github.com/sharedcode/sop/fs"
-    "github.com/sharedcode/sop/inredfs"
-    "github.com/sharedcode/sop/redis"
+	"github.com/sharedcode/sop"
+	"github.com/sharedcode/sop/fs"
+	"github.com/sharedcode/sop/inredfs"
+	"github.com/sharedcode/sop/redis"
 )
 
 // Helpers to simulate IO failures by toggling permissions on registry segment files.
@@ -23,62 +23,88 @@ import (
 // without relying on sop.Error code classification, we deny writes on the PASSIVE folder so the
 // registry's replicate-to-passive path calls handleFailedToReplicate.
 func registrySegmentPath(base, table string) string {
-    rt := sop.FormatRegistryTable(table)
-    return filepath.Join(base, rt, fmt.Sprintf("%s-1.reg", rt))
+	rt := sop.FormatRegistryTable(table)
+	return filepath.Join(base, rt, fmt.Sprintf("%s-1.reg", rt))
 }
 
 func ensureTableDir(t *testing.T, base, table string) string {
-    t.Helper()
-    dir := filepath.Join(base, table)
-    _ = os.MkdirAll(dir, 0o755)
-    return dir
+	t.Helper()
+	dir := filepath.Join(base, table)
+	_ = os.MkdirAll(dir, 0o755)
+	return dir
 }
 
 // makePassiveRegistryReadOnly denies writes on the passive folder's registry path so replication fails.
 func makePassiveRegistryReadOnly(t *testing.T, table string) {
-    t.Helper()
-    base := passiveBaseFolder()
-    dir := ensureTableDir(t, base, sop.FormatRegistryTable(table))
-    // Make the directory read-only to block creation/truncation of any segment files.
-    _ = os.Chmod(dir, 0o555)
-    seg := registrySegmentPath(base, table)
-    // Ensure the segment file exists so chmod will take effect across platforms/umasks.
-    if _, err := os.Stat(seg); os.IsNotExist(err) {
-        // Best-effort create an empty segment file; permissions will be tightened next.
-        _ = os.WriteFile(seg, []byte{}, 0o644)
-    }
-    // Make only the segment file read-only to fail replication writes without affecting other tables/dirs.
-    _ = os.Chmod(seg, 0o444)
+	t.Helper()
+	base := passiveBaseFolder()
+	dir := ensureTableDir(t, base, sop.FormatRegistryTable(table))
+	// Make the directory read-only to block creation/truncation of any segment files.
+	_ = os.Chmod(dir, 0o555)
+	seg := registrySegmentPath(base, table)
+	// Ensure the segment file exists so chmod will take effect across platforms/umasks.
+	if _, err := os.Stat(seg); os.IsNotExist(err) {
+		// Best-effort create an empty segment file; permissions will be tightened next.
+		_ = os.WriteFile(seg, []byte{}, 0o644)
+	}
+	// Make only the segment file read-only to fail replication writes without affecting other tables/dirs.
+	_ = os.Chmod(seg, 0o444)
+}
+
+// makePassiveStoreInfoReadOnly denies writes on the passive folder's storeinfo.txt so store replication fails.
+func makePassiveStoreInfoReadOnly(t *testing.T, store string) {
+	t.Helper()
+	base := passiveBaseFolder()
+	dir := filepath.Join(base, store)
+	_ = os.MkdirAll(dir, 0o755)
+	fn := filepath.Join(dir, "storeinfo.txt")
+	if _, err := os.Stat(fn); os.IsNotExist(err) {
+		_ = os.WriteFile(fn, []byte("{}"), 0o644)
+	}
+	_ = os.Chmod(fn, 0o444)
 }
 
 func restoreRegistryPermissions(t *testing.T, table string) {
-    t.Helper()
-    for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
-        dir := ensureTableDir(t, base, sop.FormatRegistryTable(table))
-        _ = os.Chmod(dir, 0o755)
-        seg := registrySegmentPath(base, table)
-        _ = os.Chmod(seg, 0o644)
-    }
+	t.Helper()
+	for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
+		dir := ensureTableDir(t, base, sop.FormatRegistryTable(table))
+		_ = os.Chmod(dir, 0o755)
+		seg := registrySegmentPath(base, table)
+		_ = os.Chmod(seg, 0o644)
+	}
+}
+
+func restoreStoreInfoPermissions(t *testing.T, store string) {
+	t.Helper()
+	for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
+		dir := filepath.Join(base, store)
+		_ = os.MkdirAll(dir, 0o755)
+		fn := filepath.Join(dir, "storeinfo.txt")
+		// If file exists, make it writable again.
+		if _, err := os.Stat(fn); err == nil {
+			_ = os.Chmod(fn, 0o644)
+		}
+	}
 }
 
 // sanitizeIsolatedReplicationBases ensures base dirs are writable and clears stray stores that
 // could interfere (e.g., previously left read-only artifacts from other tests).
 func sanitizeIsolatedReplicationBases(t *testing.T) {
-    t.Helper()
-    bases := []string{activeBaseFolder(), passiveBaseFolder()}
-    for _, base := range bases {
-        _ = os.MkdirAll(base, 0o755)
-        _ = os.Chmod(base, 0o755)
-        // Remove any stores other than our status/commit log artifacts.
-        entries, _ := os.ReadDir(base)
-        for _, e := range entries {
-            name := e.Name()
-            if name == "commitlogs" || name == "replstat.txt" {
-                continue
-            }
-            _ = os.RemoveAll(filepath.Join(base, name))
-        }
-    }
+	t.Helper()
+	bases := []string{activeBaseFolder(), passiveBaseFolder()}
+	for _, base := range bases {
+		_ = os.MkdirAll(base, 0o755)
+		_ = os.Chmod(base, 0o755)
+		// Remove any stores other than our status/commit log artifacts.
+		entries, _ := os.ReadDir(base)
+		for _, e := range entries {
+			name := e.Name()
+			if name == "commitlogs" || name == "replstat.txt" {
+				continue
+			}
+			_ = os.RemoveAll(filepath.Join(base, name))
+		}
+	}
 }
 
 // Test_EC_Failover_Reinstate_FastForward_Short exercises:
@@ -87,371 +113,480 @@ func sanitizeIsolatedReplicationBases(t *testing.T) {
 // 3) start ReinstateFailedDrives and perform delta writes while reinstate is running (commit-change logs on)
 // 4) verify data integrity after reinstate; then trigger another failover and verify data still intact
 func Test_EC_Failover_Reinstate_FastForward_Short(t *testing.T) {
-    ctx := context.Background()
+	ctx := context.Background()
 
-    // Ensure clean L2 and status files to avoid cross-test influence.
-    cache := redis.NewClient()
-    _ = cache.Clear(ctx)
-    cleanupReplicationStatusFiles()
+	// Ensure clean L2 and status files to avoid cross-test influence.
+	cache := redis.NewClient()
+	_ = cache.Clear(ctx)
+	cleanupReplicationStatusFiles()
 
-    // Use dedicated replication base folders and EC disks for this test to avoid cross-test contamination.
-    isolatedStores := []string{
-        fmt.Sprintf("%s%cdisk8", dataPath, os.PathSeparator),
-        fmt.Sprintf("%s%cdisk9", dataPath, os.PathSeparator),
-    }
-    isolatedEC := map[string]fs.ErasureCodingConfig{
-        "": {
-            DataShardsCount:   2,
-            ParityShardsCount: 2,
-            BaseFolderPathsAcrossDrives: []string{
-                fmt.Sprintf("%s%cdisk10", dataPath, os.PathSeparator),
-                fmt.Sprintf("%s%cdisk11", dataPath, os.PathSeparator),
-                fmt.Sprintf("%s%cdisk12", dataPath, os.PathSeparator),
-                fmt.Sprintf("%s%cdisk13", dataPath, os.PathSeparator),
-            },
-            RepairCorruptedShards: true,
-        },
-    }
-    to, _ := inredfs.NewTransactionOptionsWithReplication(sop.ForWriting, -1, fs.MinimumModValue, isolatedStores, isolatedEC)
+	// Use dedicated replication base folders and EC disks for this test to avoid cross-test contamination.
+	isolatedStores := []string{
+		fmt.Sprintf("%s%cdisk8", dataPath, os.PathSeparator),
+		fmt.Sprintf("%s%cdisk9", dataPath, os.PathSeparator),
+	}
+	isolatedEC := map[string]fs.ErasureCodingConfig{
+		"": {
+			DataShardsCount:   2,
+			ParityShardsCount: 2,
+			BaseFolderPathsAcrossDrives: []string{
+				fmt.Sprintf("%s%cdisk10", dataPath, os.PathSeparator),
+				fmt.Sprintf("%s%cdisk11", dataPath, os.PathSeparator),
+				fmt.Sprintf("%s%cdisk12", dataPath, os.PathSeparator),
+				fmt.Sprintf("%s%cdisk13", dataPath, os.PathSeparator),
+			},
+			RepairCorruptedShards: true,
+		},
+	}
+	to, _ := inredfs.NewTransactionOptionsWithReplication(sop.ForWriting, -1, fs.MinimumModValue, isolatedStores, isolatedEC)
 
-    // Use a unique table name for isolated tests to avoid cross-suite collisions.
-    table := "ec_failover_ff_isolated_it"
+	// Use a unique table name for isolated tests to avoid cross-suite collisions.
+	table := "ec_failover_ff_isolated_it"
 
-    // Ensure no prior store artifacts remain across replication and EC disks, including store repository metadata.
-    sanitizeIsolatedReplicationBases(t)
-    cleanupStoreEverywhere(table)
-    cleanupECShards(table)
-    cleanupStoreRepository(table, isolatedStores)
+	// Ensure no prior store artifacts remain across replication and EC disks, including store repository metadata.
+	sanitizeIsolatedReplicationBases(t)
+	cleanupStoreEverywhere(table)
+	cleanupECShards(table)
+	cleanupStoreRepository(table, isolatedStores)
 
-    // Ensure directories/segments start with writable permissions to avoid leftover read-only from prior runs.
-    restoreRegistryPermissions(t, table)
+	// Ensure directories/segments start with writable permissions to avoid leftover read-only from prior runs.
+	restoreRegistryPermissions(t, table)
 
-    // Baseline: ensure the store exists (open-or-create) using short transactions.
-    if err := ensureStoreExists(ctx, to, table); err != nil { t.Fatalf("ensure store exists: %v", err) }
+	// Baseline: ensure the store exists (open-or-create) using short transactions.
+	if err := ensureStoreExists(ctx, to, table); err != nil {
+		t.Fatalf("ensure store exists: %v", err)
+	}
 
-    // Seed a couple of items in a fresh transaction.
-    trans, err := inredfs.NewTransactionWithReplication(ctx, to)
-    if err != nil { t.Fatal(err) }
-    if err = trans.Begin(); err != nil { t.Fatal(err) }
-    b, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, trans, nil)
-    if err != nil { t.Fatal(err) }
-    if ok, err := b.Upsert(ctx, 1, "alpha"); !ok || err != nil { t.Fatalf("seed upsert: %v", err) }
-    if ok, err := b.Upsert(ctx, 2, "bravo"); !ok || err != nil { t.Fatalf("seed upsert: %v", err) }
-    // Pre-seed more items to make copyStores take a measurable time during reinstate.
-    for i := 10; i <= 30; i++ {
-        if ok, err := b.Upsert(ctx, i, fmt.Sprintf("preseed-%d", i)); !ok || err != nil { t.Fatalf("preseed upsert %d: %v", i, err) }
-    }
-    if err := trans.Commit(ctx); err != nil { t.Fatalf("seed commit: %v", err) }
+	// Seed a couple of items in a fresh transaction.
+	trans, err := inredfs.NewTransactionWithReplication(ctx, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = trans.Begin(); err != nil {
+		t.Fatal(err)
+	}
+	b, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, trans, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := b.Upsert(ctx, 1, "alpha"); !ok || err != nil {
+		t.Fatalf("seed upsert: %v", err)
+	}
+	if ok, err := b.Upsert(ctx, 2, "bravo"); !ok || err != nil {
+		t.Fatalf("seed upsert: %v", err)
+	}
+	// Pre-seed more items to make copyStores take a measurable time during reinstate.
+	for i := 10; i <= 30; i++ {
+		if ok, err := b.Upsert(ctx, i, fmt.Sprintf("preseed-%d", i)); !ok || err != nil {
+			t.Fatalf("preseed upsert %d: %v", i, err)
+		}
+	}
+	if err := trans.Commit(ctx); err != nil {
+		t.Fatalf("seed commit: %v", err)
+	}
 
-    // Simulate a drive failure on PASSIVE registry to deterministically mark FailedToReplicate
-    // without requiring a true failover-qualified error on the active side.
-    makePassiveRegistryReadOnly(t, table)
-    trans2, err := inredfs.NewTransactionWithReplication(ctx, to)
-    if err != nil { t.Fatal(err) }
-    if err = trans2.Begin(); err != nil { t.Fatal(err) }
-    b2, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, trans2, nil)
-    if err != nil { t.Fatal(err) }
-    // Attempt to add a new key to force a registry write and hit the simulated failure
-    if ok, err := b2.Upsert(ctx, 1001, "new-after-failover-trigger"); !ok || err != nil {
-        // Expect commit to fail; keep going
-    }
-    _ = trans2.Commit(ctx) // ignore error; failover will be decided by tracker
+	// Simulate a drive failure on PASSIVE registry to deterministically mark FailedToReplicate
+	// without requiring a true failover-qualified error on the active side.
+	// Make passive paths read-only to force a replicate-to-passive failure through either registry or store repo.
+	makePassiveRegistryReadOnly(t, table)
+	makePassiveStoreInfoReadOnly(t, table)
+	trans2, err := inredfs.NewTransactionWithReplication(ctx, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = trans2.Begin(); err != nil {
+		t.Fatal(err)
+	}
+	b2, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, trans2, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Attempt to add a new key to force a registry write and hit the simulated failure
+	if ok, err := b2.Upsert(ctx, 1001, "new-after-failover-trigger"); !ok || err != nil {
+		// Expect commit to fail; keep going
+	}
+	_ = trans2.Commit(ctx) // ignore error; failover will be decided by tracker
 
-    // Verify we are in failed replication mode (replicate-to-passive failed sets this flag).
-    if fs.GlobalReplicationDetails == nil || !fs.GlobalReplicationDetails.FailedToReplicate {
-        t.Fatalf("expected FailedToReplicate after simulated IO error")
-    }
+	// Verify we are in failed replication mode (replicate-to-passive failed sets this flag).
+	// Use a robust wait that checks both in-memory state and replstat files to avoid flakiness.
+	if err := waitForFailedFlagTrue(3 * time.Second); err != nil {
+		t.Fatalf("expected FailedToReplicate after simulated IO error: %v", err)
+	}
 
-    // Restore permissions so reinstate and upcoming commits can proceed, then start reinstate in a goroutine.
-    restoreRegistryPermissions(t, table)
-    reinstateErr := make(chan error, 1)
-    go func() { reinstateErr <- inredfs.ReinstateFailedDrives(ctx, isolatedStores) }()
+	// Restore permissions so reinstate and upcoming commits can proceed, then start reinstate in a goroutine.
+	restoreRegistryPermissions(t, table)
+	restoreStoreInfoPermissions(t, table)
+	reinstateErr := make(chan error, 1)
+	go func() { reinstateErr <- inredfs.ReinstateFailedDrives(ctx, isolatedStores) }()
 
-    // Detect immediate reinstate failures (fail fast with clearer error).
-    select {
-    case err := <-reinstateErr:
-        if err != nil {
-            t.Fatalf("reinstate returned early: %v", err)
-        }
-    default:
-        // continue
-    }
+	// Detect immediate reinstate failures (fail fast with clearer error).
+	select {
+	case err := <-reinstateErr:
+		if err != nil {
+			t.Fatalf("reinstate returned early: %v", err)
+		}
+	default:
+		// continue
+	}
 
-    // While reinstate runs, continuously attempt small delta writes so at least some occur
-    // during the commit-logging window.
-    stopW := make(chan struct{})
-    go func() {
-        ticker := time.NewTicker(10 * time.Millisecond)
-        defer ticker.Stop()
-        for {
-            select {
-            case <-stopW:
-                return
-            case <-ticker.C:
-                tw, err := inredfs.NewTransactionWithReplication(ctx, to)
-                if err != nil { continue }
-                if err = tw.Begin(); err != nil { _ = tw.Rollback(ctx); continue }
-                bw, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, tw, nil)
-                if err != nil { _ = tw.Rollback(ctx); continue }
-                _, _ = bw.Upsert(ctx, 2, "bravo2")
-                _ = tw.Commit(ctx)
-            }
-        }
-    }()
+	// While reinstate runs, continuously attempt small delta writes so at least some occur
+	// during the commit-logging window.
+	stopW := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopW:
+				return
+			case <-ticker.C:
+				tw, err := inredfs.NewTransactionWithReplication(ctx, to)
+				if err != nil {
+					continue
+				}
+				if err = tw.Begin(); err != nil {
+					_ = tw.Rollback(ctx)
+					continue
+				}
+				bw, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, tw, nil)
+				if err != nil {
+					_ = tw.Rollback(ctx)
+					continue
+				}
+				_, _ = bw.Upsert(ctx, 2, "bravo2")
+				_ = tw.Commit(ctx)
+			}
+		}
+	}()
 
-    // Do an immediate delta write; the writer loop above will keep attempting more.
-    transU, err := inredfs.NewTransactionWithReplication(ctx, to)
-    if err != nil { t.Fatal(err) }
-    if err = transU.Begin(); err != nil { t.Fatal(err) }
-    bu, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, transU, nil)
-    if err != nil { t.Fatal(err) }
-    if ok, err := bu.Upsert(ctx, 2, "bravo2"); !ok || err != nil {
-        t.Fatalf("delta upsert existing: %v", err)
-    }
-    if err := transU.Commit(ctx); err != nil { t.Fatalf("delta commit existing: %v", err) }
+	// Do an immediate delta write; the writer loop above will keep attempting more.
+	transU, err := inredfs.NewTransactionWithReplication(ctx, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = transU.Begin(); err != nil {
+		t.Fatal(err)
+	}
+	bu, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, transU, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := bu.Upsert(ctx, 2, "bravo2"); !ok || err != nil {
+		t.Fatalf("delta upsert existing: %v", err)
+	}
+	if err := transU.Commit(ctx); err != nil {
+		t.Fatalf("delta commit existing: %v", err)
+	}
 
-    // Sanity-check the active store reflects the updated value; if not, retry with remove+add.
-    if gv, ok := getValue(ctx, to, table, 2, t); !ok || gv != "bravo2" {
-        transFix, err := inredfs.NewTransactionWithReplication(ctx, to)
-        if err != nil { t.Fatal(err) }
-        if err = transFix.Begin(); err != nil { t.Fatal(err) }
-        bf, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, transFix, nil)
-        if err != nil { t.Fatal(err) }
-        // Remove then add to force a concrete change
-        _, _ = bf.Remove(ctx, 2)
-        if ok, err := bf.Add(ctx, 2, "bravo2"); !ok || err != nil { t.Fatalf("force set existing key: %v", err) }
-        if err := transFix.Commit(ctx); err != nil { t.Fatalf("force set commit: %v", err) }
-        if gv2, ok2 := getValue(ctx, to, table, 2, t); !ok2 || gv2 != "bravo2" {
-            t.Fatalf("post-fix readback mismatch: got %q want %q", gv2, "bravo2")
-        }
-    }
+	// Sanity-check the active store reflects the updated value; if not, retry with remove+add.
+	if gv, ok := getValue(ctx, to, table, 2, t); !ok || gv != "bravo2" {
+		transFix, err := inredfs.NewTransactionWithReplication(ctx, to)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = transFix.Begin(); err != nil {
+			t.Fatal(err)
+		}
+		bf, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, transFix, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Remove then add to force a concrete change
+		_, _ = bf.Remove(ctx, 2)
+		if ok, err := bf.Add(ctx, 2, "bravo2"); !ok || err != nil {
+			t.Fatalf("force set existing key: %v", err)
+		}
+		if err := transFix.Commit(ctx); err != nil {
+			t.Fatalf("force set commit: %v", err)
+		}
+		if gv2, ok2 := getValue(ctx, to, table, 2, t); !ok2 || gv2 != "bravo2" {
+			t.Fatalf("post-fix readback mismatch: got %q want %q", gv2, "bravo2")
+		}
+	}
 
-    // Perform a few new-key delta writes while reinstate is running so fast-forward picks them up.
-    for i := 3; i <= 5; i++ {
-        transW, err := inredfs.NewTransactionWithReplication(ctx, to)
-        if err != nil { t.Fatal(err) }
-        if err = transW.Begin(); err != nil { t.Fatal(err) }
-        bw, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, transW, nil)
-        if err != nil { t.Fatal(err) }
-        if ok, err := bw.Upsert(ctx, i, fmt.Sprintf("delta-%d", i)); !ok || err != nil {
-            t.Fatalf("delta upsert: %v", err)
-        }
-        if err := transW.Commit(ctx); err != nil { t.Fatalf("delta commit: %v", err) }
-        // small delay to increase overlap with reinstate
-        time.Sleep(25 * time.Millisecond)
-    }
+	// Perform a few new-key delta writes while reinstate is running so fast-forward picks them up.
+	for i := 3; i <= 5; i++ {
+		transW, err := inredfs.NewTransactionWithReplication(ctx, to)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = transW.Begin(); err != nil {
+			t.Fatal(err)
+		}
+		bw, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, transW, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok, err := bw.Upsert(ctx, i, fmt.Sprintf("delta-%d", i)); !ok || err != nil {
+			t.Fatalf("delta upsert: %v", err)
+		}
+		if err := transW.Commit(ctx); err != nil {
+			t.Fatalf("delta commit: %v", err)
+		}
+		// small delay to increase overlap with reinstate
+		time.Sleep(25 * time.Millisecond)
+	}
 
-    // Reinstate must complete successfully.
-    if err := <-reinstateErr; err != nil {
-        close(stopW)
-        t.Fatalf("reinstate error: %v", err)
-    }
-    close(stopW)
+	// Reinstate must complete successfully.
+	if err := <-reinstateErr; err != nil {
+		close(stopW)
+		t.Fatalf("reinstate error: %v", err)
+	}
+	close(stopW)
 
-    // After reinstate, replication flags should be cleared and logging turned off.
-    if err := waitForFailedFlagFalse(2 * time.Second); err != nil {
-        t.Fatalf("expected FailedToReplicate=false after reinstate: %v", err)
-    }
+	// After reinstate, replication flags should be cleared and logging turned off.
+	if err := waitForFailedFlagFalse(2 * time.Second); err != nil {
+		t.Fatalf("expected FailedToReplicate=false after reinstate: %v", err)
+	}
 
-    // Validate data integrity: read all items and ensure delta writes are present.
-    got := readAll(ctx, to, table, t)
-    // Expect keys: 1,2,3,4,5 with respective values updated
-    want := map[int]string{1: "alpha", 2: "bravo2", 3: "delta-3", 4: "delta-4", 5: "delta-5"}
-    if len(got) < len(want) {
-        t.Fatalf("expected at least %d items, got %d (%v)", len(want), len(got), got)
-    }
-    for k, v := range want {
-        if gv, ok := got[k]; !ok || gv != v {
-            t.Fatalf("missing/incorrect item %d: got=%q want=%q; all=%v", k, gv, v, got)
-        }
-    }
+	// Validate data integrity: read all items and ensure delta writes are present.
+	got := readAll(ctx, to, table, t)
+	// Expect keys: 1,2,3,4,5 with respective values updated
+	want := map[int]string{1: "alpha", 2: "bravo2", 3: "delta-3", 4: "delta-4", 5: "delta-5"}
+	if len(got) < len(want) {
+		t.Fatalf("expected at least %d items, got %d (%v)", len(want), len(got), got)
+	}
+	for k, v := range want {
+		if gv, ok := got[k]; !ok || gv != v {
+			t.Fatalf("missing/incorrect item %d: got=%q want=%q; all=%v", k, gv, v, got)
+		}
+	}
 
-    // Note: we intentionally skip simulating another failover here to keep the integration test deterministic and fast.
+	// Note: we intentionally skip simulating another failover here to keep the integration test deterministic and fast.
 }
 
 func readAll(ctx context.Context, to inredfs.TransationOptionsWithReplication, table string, t *testing.T) map[int]string {
-    t.Helper()
-    trans, err := inredfs.NewTransactionWithReplication(ctx, to)
-    if err != nil { t.Fatal(err) }
-    if err = trans.Begin(); err != nil { t.Fatal(err) }
-    b, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, trans, nil)
-    if err != nil { t.Fatal(err) }
-    out := map[int]string{}
-    b.First(ctx)
-    for {
-        it, err := b.GetCurrentItem(ctx)
-        if err != nil { break }
-        if it.Value != nil {
-            out[it.Key] = *it.Value
-        }
-        if ok, _ := b.Next(ctx); !ok { break }
-    }
-    _ = trans.Commit(ctx)
-    return out
+	t.Helper()
+	trans, err := inredfs.NewTransactionWithReplication(ctx, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = trans.Begin(); err != nil {
+		t.Fatal(err)
+	}
+	b, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, trans, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[int]string{}
+	b.First(ctx)
+	for {
+		it, err := b.GetCurrentItem(ctx)
+		if err != nil {
+			break
+		}
+		if it.Value != nil {
+			out[it.Key] = *it.Value
+		}
+		if ok, _ := b.Next(ctx); !ok {
+			break
+		}
+	}
+	_ = trans.Commit(ctx)
+	return out
 }
 
 func getValue(ctx context.Context, to inredfs.TransationOptionsWithReplication, table string, key int, t *testing.T) (string, bool) {
-    t.Helper()
-    trans, err := inredfs.NewTransactionWithReplication(ctx, to)
-    if err != nil { t.Fatal(err) }
-    if err = trans.Begin(); err != nil { t.Fatal(err) }
-    b, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, trans, nil)
-    if err != nil { t.Fatal(err) }
-    ok, err := b.Find(ctx, key, false)
-    if err != nil || !ok {
-        _ = trans.Commit(ctx)
-        return "", false
-    }
-    it, err := b.GetCurrentItem(ctx)
-    _ = trans.Commit(ctx)
-    if err != nil || it.Value == nil { return "", false }
-    return *it.Value, true
+	t.Helper()
+	trans, err := inredfs.NewTransactionWithReplication(ctx, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = trans.Begin(); err != nil {
+		t.Fatal(err)
+	}
+	b, err := inredfs.OpenBtreeWithReplication[int, string](ctx, table, trans, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, err := b.Find(ctx, key, false)
+	if err != nil || !ok {
+		_ = trans.Commit(ctx)
+		return "", false
+	}
+	it, err := b.GetCurrentItem(ctx)
+	_ = trans.Commit(ctx)
+	if err != nil || it.Value == nil {
+		return "", false
+	}
+	return *it.Value, true
 }
 
 // ensureStoreExists opens the store if present, or creates it in a separate short transaction if missing.
 func ensureStoreExists(ctx context.Context, to inredfs.TransationOptionsWithReplication, name string) error {
-    // Try open first.
-    if trans, err := inredfs.NewTransactionWithReplication(ctx, to); err == nil {
-        if err = trans.Begin(); err == nil {
-            if _, err2 := inredfs.OpenBtreeWithReplication[int, string](ctx, name, trans, nil); err2 == nil {
-                _ = trans.Commit(ctx)
-                return nil
-            }
-        }
-        // Open path rolls back on not-found; ensure we close.
-        _ = trans.Rollback(ctx)
-    }
-    // Create it.
-    if trans, err := inredfs.NewTransactionWithReplication(ctx, to); err == nil {
-        if err = trans.Begin(); err == nil {
-            _, err2 := inredfs.NewBtreeWithReplication[int, string](ctx, sop.StoreOptions{
-                Name: name, SlotLength: 8, IsValueDataInNodeSegment: true,
-            }, trans, nil)
-            if err2 == nil {
-                return trans.Commit(ctx)
-            }
-            // If already exists, try open once more.
-            _ = trans.Rollback(ctx)
-            if trans2, err3 := inredfs.NewTransactionWithReplication(ctx, to); err3 == nil {
-                if err = trans2.Begin(); err == nil {
-                    if _, err4 := inredfs.OpenBtreeWithReplication[int, string](ctx, name, trans2, nil); err4 == nil {
-                        return trans2.Commit(ctx)
-                    }
-                }
-                _ = trans2.Rollback(ctx)
-            }
-            return err2
-        }
-        _ = trans.Rollback(ctx)
-    }
-    return fmt.Errorf("failed to ensure store exists: %s", name)
+	// Try open first.
+	if trans, err := inredfs.NewTransactionWithReplication(ctx, to); err == nil {
+		if err = trans.Begin(); err == nil {
+			if _, err2 := inredfs.OpenBtreeWithReplication[int, string](ctx, name, trans, nil); err2 == nil {
+				_ = trans.Commit(ctx)
+				return nil
+			}
+		}
+		// Open path rolls back on not-found; ensure we close.
+		_ = trans.Rollback(ctx)
+	}
+	// Create it.
+	if trans, err := inredfs.NewTransactionWithReplication(ctx, to); err == nil {
+		if err = trans.Begin(); err == nil {
+			_, err2 := inredfs.NewBtreeWithReplication[int, string](ctx, sop.StoreOptions{
+				Name: name, SlotLength: 8, IsValueDataInNodeSegment: true,
+			}, trans, nil)
+			if err2 == nil {
+				return trans.Commit(ctx)
+			}
+			// If already exists, try open once more.
+			_ = trans.Rollback(ctx)
+			if trans2, err3 := inredfs.NewTransactionWithReplication(ctx, to); err3 == nil {
+				if err = trans2.Begin(); err == nil {
+					if _, err4 := inredfs.OpenBtreeWithReplication[int, string](ctx, name, trans2, nil); err4 == nil {
+						return trans2.Commit(ctx)
+					}
+				}
+				_ = trans2.Rollback(ctx)
+			}
+			return err2
+		}
+		_ = trans.Rollback(ctx)
+	}
+	return fmt.Errorf("failed to ensure store exists: %s", name)
 }
 
 // waitForCommitLoggingOn polls the active replstat.txt until LogCommitChanges is true or timeout elapses.
 func waitForCommitLoggingOn(timeout time.Duration) error {
-    deadline := time.Now().Add(timeout)
-    for time.Now().Before(deadline) {
-        // Fast path: check in-memory global first.
-        if fs.GlobalReplicationDetails != nil && fs.GlobalReplicationDetails.LogCommitChanges {
-            return nil
-        }
-        // Fallback: check status files on both candidate folders in case toggler changed mid-run.
-        for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
-            fn := filepath.Join(base, "replstat.txt")
-            if ba, err := os.ReadFile(fn); err == nil && strings.Contains(string(ba), "\"LogCommitChanges\":true") {
-                return nil
-            }
-        }
-        time.Sleep(5 * time.Millisecond)
-    }
-    return fmt.Errorf("timed out waiting for LogCommitChanges=true")
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		// Fast path: check in-memory global first.
+		if fs.GlobalReplicationDetails != nil && fs.GlobalReplicationDetails.LogCommitChanges {
+			return nil
+		}
+		// Fallback: check status files on both candidate folders in case toggler changed mid-run.
+		for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
+			fn := filepath.Join(base, "replstat.txt")
+			if ba, err := os.ReadFile(fn); err == nil && strings.Contains(string(ba), "\"LogCommitChanges\":true") {
+				return nil
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for LogCommitChanges=true")
 }
 
 // waitForFailedFlagFalse waits until the replication status indicates FailedToReplicate=false.
 func waitForFailedFlagFalse(timeout time.Duration) error {
-    deadline := time.Now().Add(timeout)
-    for time.Now().Before(deadline) {
-        if fs.GlobalReplicationDetails != nil && !fs.GlobalReplicationDetails.FailedToReplicate {
-            return nil
-        }
-        // Also check status files on both potential active bases.
-        for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
-            fn := filepath.Join(base, "replstat.txt")
-            if ba, err := os.ReadFile(fn); err == nil && strings.Contains(string(ba), "\"FailedToReplicate\":false") {
-                return nil
-            }
-        }
-        time.Sleep(5 * time.Millisecond)
-    }
-    return fmt.Errorf("timed out waiting for FailedToReplicate=false; current=%v", func() any {
-        if fs.GlobalReplicationDetails == nil {
-            return nil
-        }
-        return *fs.GlobalReplicationDetails
-    }())
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fs.GlobalReplicationDetails != nil && !fs.GlobalReplicationDetails.FailedToReplicate {
+			return nil
+		}
+		// Also check status files on both potential active bases.
+		for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
+			fn := filepath.Join(base, "replstat.txt")
+			if ba, err := os.ReadFile(fn); err == nil && strings.Contains(string(ba), "\"FailedToReplicate\":false") {
+				return nil
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for FailedToReplicate=false; current=%v", func() any {
+		if fs.GlobalReplicationDetails == nil {
+			return nil
+		}
+		return *fs.GlobalReplicationDetails
+	}())
+}
+
+// waitForFailedFlagTrue waits until the replication status indicates FailedToReplicate=true.
+func waitForFailedFlagTrue(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fs.GlobalReplicationDetails != nil && fs.GlobalReplicationDetails.FailedToReplicate {
+			return nil
+		}
+		// Also check status files on both potential active bases.
+		for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
+			fn := filepath.Join(base, "replstat.txt")
+			if ba, err := os.ReadFile(fn); err == nil && strings.Contains(string(ba), "\"FailedToReplicate\":true") {
+				return nil
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for FailedToReplicate=true; current=%v", func() any {
+		if fs.GlobalReplicationDetails == nil {
+			return nil
+		}
+		return *fs.GlobalReplicationDetails
+	}())
 }
 
 func activeBaseFolder() string {
-    // Use isolated stores for this test
-    base0 := fmt.Sprintf("%s%cdisk8", dataPath, os.PathSeparator)
-    base1 := fmt.Sprintf("%s%cdisk9", dataPath, os.PathSeparator)
-    if fs.GlobalReplicationDetails != nil && fs.GlobalReplicationDetails.ActiveFolderToggler {
-        return base0
-    }
-    return base1
+	// Use isolated stores for this test
+	base0 := fmt.Sprintf("%s%cdisk8", dataPath, os.PathSeparator)
+	base1 := fmt.Sprintf("%s%cdisk9", dataPath, os.PathSeparator)
+	// Default to tracker semantics: when uninitialized, ActiveFolderToggler starts true => base0 is active.
+	if fs.GlobalReplicationDetails == nil {
+		return base0
+	}
+	if fs.GlobalReplicationDetails.ActiveFolderToggler {
+		return base0
+	}
+	return base1
 }
 
 func passiveBaseFolder() string {
-    base0 := fmt.Sprintf("%s%cdisk8", dataPath, os.PathSeparator)
-    base1 := fmt.Sprintf("%s%cdisk9", dataPath, os.PathSeparator)
-    if fs.GlobalReplicationDetails != nil && fs.GlobalReplicationDetails.ActiveFolderToggler {
-        return base1
-    }
-    return base0
+	base0 := fmt.Sprintf("%s%cdisk8", dataPath, os.PathSeparator)
+	base1 := fmt.Sprintf("%s%cdisk9", dataPath, os.PathSeparator)
+	// Default to tracker semantics: when uninitialized, base1 is passive.
+	if fs.GlobalReplicationDetails == nil {
+		return base1
+	}
+	if fs.GlobalReplicationDetails.ActiveFolderToggler {
+		return base1
+	}
+	return base0
 }
 
 func cleanupReplicationStatusFiles() {
-    for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
-        _ = os.Remove(fmt.Sprintf("%s%creplstat.txt", base, os.PathSeparator))
-        _ = os.RemoveAll(fmt.Sprintf("%s%ccommitlogs", base, os.PathSeparator))
-        _ = os.MkdirAll(base, 0o755)
-    }
+	for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
+		_ = os.Remove(fmt.Sprintf("%s%creplstat.txt", base, os.PathSeparator))
+		_ = os.RemoveAll(fmt.Sprintf("%s%ccommitlogs", base, os.PathSeparator))
+		_ = os.MkdirAll(base, 0o755)
+	}
 }
 
 // cleanupStoreEverywhere removes the store folder across this test's isolated replication disks to ensure a clean slate.
 func cleanupStoreEverywhere(name string) {
-    for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
-        _ = os.RemoveAll(filepath.Join(base, name))
-    }
+	for _, base := range []string{activeBaseFolder(), passiveBaseFolder()} {
+		_ = os.RemoveAll(filepath.Join(base, name))
+	}
 }
 
 // cleanupECShards removes EC blob store shards for this test's isolated disks.
 func cleanupECShards(name string) {
-    for i := 10; i <= 13; i++ {
-        base := fmt.Sprintf("%s%cdisk%d", dataPath, os.PathSeparator, i)
-        _ = os.RemoveAll(filepath.Join(base, name))
-    }
+	for i := 10; i <= 13; i++ {
+		base := fmt.Sprintf("%s%cdisk%d", dataPath, os.PathSeparator, i)
+		_ = os.RemoveAll(filepath.Join(base, name))
+	}
 }
 
 // cleanupStoreRepository removes store repository records on both isolated replication bases.
 func cleanupStoreRepository(name string, bases []string) {
-    for _, base := range bases {
-        // Ignore error; it will fail if the store doesn't exist which is fine for cleanup.
-        _ = inredfs.RemoveBtree(context.Background(), base, name)
-    }
+	for _, base := range bases {
+		// Ignore error; it will fail if the store doesn't exist which is fine for cleanup.
+		_ = inredfs.RemoveBtree(context.Background(), base, name)
+	}
 }
 
 // makeActiveRegistryReadOnly makes the current ACTIVE registry segment file read-only to trigger a failover
 // qualified error in the commit path.
 func makeActiveRegistryReadOnly(t *testing.T, table string) {
-    t.Helper()
-    base := activeBaseFolder()
-    ensureTableDir(t, base, table)
-    seg := registrySegmentPath(base, table)
-    _ = os.Chmod(seg, 0o444)
+	t.Helper()
+	base := activeBaseFolder()
+	ensureTableDir(t, base, table)
+	seg := registrySegmentPath(base, table)
+	_ = os.Chmod(seg, 0o444)
 }
 
 // Test_ActiveSide_FailoverFlip_Then_Reinstate_FastForward uses the DirectIO simulator to inject
 // EIO on active registry WriteAt, causing a failover (toggler flip). It then restores IO and
 // runs reinstate, verifying delta fast-forwarded writes are present and flags cleared.
-

--- a/inredfs/stresstests/replication/reinstate_concurrency_and_failover_test.go
+++ b/inredfs/stresstests/replication/reinstate_concurrency_and_failover_test.go
@@ -125,6 +125,14 @@ func Test_Reinstate_MultiTable_Concurrency_SecondFailover(t *testing.T) {
 	close(stop)
 	wg.Wait()
 
+	// Wait briefly for the flag to clear as status writes and L2 sync can be asynchronous across goroutines.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fs.GlobalReplicationDetails != nil && !fs.GlobalReplicationDetails.FailedToReplicate {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	if fs.GlobalReplicationDetails == nil || fs.GlobalReplicationDetails.FailedToReplicate {
 		t.Fatalf("expected FailedToReplicate false after reinstate")
 	}

--- a/inredfs/stresstests/replication/replication_test.go
+++ b/inredfs/stresstests/replication/replication_test.go
@@ -93,6 +93,10 @@ func TestMain(t *testing.T) {
 
 	// Restore permissions so reinstate can proceed.
 	restoreRegistryPermissions(t, tableName)
+	// Also restore perms for other known tables that other stress suites may have toggled,
+	// to avoid cross-test interference during reinstate (which scans all tables).
+	restoreRegistryPermissions(t, "repltable")
+	restoreRegistryPermissions(t, "repltable3")
 	// Reinstate drive should succeed to reinstate the (failed) drives back to replication.
 	reinstateDrive(t)
 

--- a/inredfs/stresstests/valuedatasegment/transaction_edge_cases_test.go
+++ b/inredfs/stresstests/valuedatasegment/transaction_edge_cases_test.go
@@ -371,10 +371,10 @@ func Test_TwoTransactionsOneUpdateItemOneAnotherUpdateItemLast(t *testing.T) {
 		t.Errorf("T1 & T2 Commits got 2 success, want 1 fail.")
 	}
 	if err1 != nil {
-		t.Logf(err1.Error())
+		t.Log(err1.Error())
 	}
 	if err2 != nil {
-		t.Logf(err2.Error())
+		t.Log(err2.Error())
 	}
 }
 

--- a/inredfs/transaction.go
+++ b/inredfs/transaction.go
@@ -16,7 +16,7 @@ func NewTransaction(ctx context.Context, to TransationOptions) (sop.Transaction,
 	if err != nil {
 		return nil, err
 	}
-	return sop.NewTransaction(to.Mode, twoPT, to.MaxTime, true)
+	return sop.NewTransaction(to.Mode, twoPT, true)
 }
 
 // NewTwoPhaseCommitTransaction will instantiate a transaction object for writing(forWriting=true)
@@ -67,7 +67,7 @@ func NewTransactionWithReplication(ctx context.Context, towr TransationOptionsWi
 	if err != nil {
 		return nil, err
 	}
-	return sop.NewTransaction(towr.Mode, twoPT, towr.MaxTime, true)
+	return sop.NewTransaction(towr.Mode, twoPT, true)
 }
 
 // NewTwoPhaseCommitTransactionWithReplication creates a two-phase commit transaction with replication enabled.

--- a/inredfs/transaction.go
+++ b/inredfs/transaction.go
@@ -21,6 +21,10 @@ func NewTransaction(ctx context.Context, to TransationOptions) (sop.Transaction,
 
 // NewTwoPhaseCommitTransaction will instantiate a transaction object for writing(forWriting=true)
 // or for reading(forWriting=false). Pass in -1 on maxTime to default to 15 minutes of max "commit" duration.
+//
+// Timeout semantics: the commit ends when the earlier of ctx deadline or maxTime is reached.
+// Locks use maxTime as TTL so they are bounded even if ctx is canceled. If you want replication/log
+// cleanup to finish under the same budget, set ctx.Deadline to at least maxTime plus a small grace period.
 func NewTwoPhaseCommitTransaction(ctx context.Context, to TransationOptions) (sop.TwoPhaseCommitTransaction, error) {
 	if !IsInitialized() {
 		return nil, fmt.Errorf("redis was not initialized")
@@ -67,6 +71,8 @@ func NewTransactionWithReplication(ctx context.Context, towr TransationOptionsWi
 }
 
 // NewTwoPhaseCommitTransactionWithReplication creates a two-phase commit transaction with replication enabled.
+//
+// Timeout semantics: see NewTwoPhaseCommitTransaction for guidance on ctx.Deadline vs maxTime and lock TTLs.
 // Returns sop.TwoPhaseCommitTransaction to allow integration with custom application transactions requiring direct access to SOP's API.
 func NewTwoPhaseCommitTransactionWithReplication(ctx context.Context, towr TransationOptionsWithReplication) (sop.TwoPhaseCommitTransaction, error) {
 	if towr.IsEmpty() {

--- a/inredfs/transactionoptions.go
+++ b/inredfs/transactionoptions.go
@@ -15,7 +15,9 @@ type TransationOptions struct {
 	StoresBaseFolder string
 	// Transaction Mode can be Read-only or Read-Write.
 	Mode sop.TransactionMode
-	// Transaction maximum "commit" time. If commits takes longer than this then transaction will roll back.
+	// Transaction maximum "commit" time. Acts as the commit window cap and lock TTL.
+	// Effective limit is min(ctx deadline, MaxTime). If commit exceeds this, the transaction will roll back.
+	// For end-to-end bounded operations, prefer ctx.Deadline >= MaxTime plus a small slack.
 	MaxTime time.Duration
 	// Registry hash modulo value used for hashing.
 	RegistryHashModValue int
@@ -31,7 +33,9 @@ type TransationOptionsWithReplication struct {
 	StoresBaseFolders []string `json:"stores_folders"`
 	// Transaction Mode can be Read-only or Read-Write.
 	Mode sop.TransactionMode `json:"mode"`
-	// Transaction maximum "commit" time. If commits takes longer than this then transaction will roll back.
+	// Transaction maximum "commit" time. Acts as the commit window cap and lock TTL.
+	// Effective limit is min(ctx deadline, MaxTime). If commit exceeds this, the transaction will roll back.
+	// For end-to-end bounded operations, prefer ctx.Deadline >= MaxTime plus a small slack.
 	MaxTime time.Duration `json:"max_time"`
 	// Registry hash modulo value used for hashing.
 	RegistryHashModValue int `json:"registry_hash_mod"`

--- a/internal/cassandra/transactionlog.go
+++ b/internal/cassandra/transactionlog.go
@@ -253,3 +253,6 @@ func (d dummy) Remove(ctx context.Context, tid sop.UUID) error {
 
 // Write a backup file for the priority log contents (payload).
 // Backup APIs removed; no-op methods deleted.
+
+// ClearRegistrySectorClaims is a no-op for Cassandra.
+func (d dummy) ClearRegistrySectorClaims(ctx context.Context) error { return nil }

--- a/internal/cassandra/transactionlog.go
+++ b/internal/cassandra/transactionlog.go
@@ -252,10 +252,4 @@ func (d dummy) Remove(ctx context.Context, tid sop.UUID) error {
 }
 
 // Write a backup file for the priority log contents (payload).
-func (d dummy) WriteBackup(ctx context.Context, tid sop.UUID, payload []byte) error {
-	return nil
-}
-
-func (d dummy) RemoveBackup(ctx context.Context, tid sop.UUID) error {
-	return nil
-}
+// Backup APIs removed; no-op methods deleted.

--- a/internal/inredcfs/transaction.go
+++ b/internal/inredcfs/transaction.go
@@ -28,7 +28,7 @@ func NewTransactionExt(toFilePath fs.ToFilePathFunc, mode sop.TransactionMode, m
 	if err != nil {
 		return nil, err
 	}
-	return sop.NewTransaction(mode, twoPT, maxTime, logging)
+	return sop.NewTransaction(mode, twoPT, logging)
 }
 
 // Create a transaction that supports Erasure Coding file IO.
@@ -49,5 +49,5 @@ func NewTransactionWithEC(mode sop.TransactionMode, maxTime time.Duration, loggi
 	if err != nil {
 		return nil, err
 	}
-	return sop.NewTransaction(mode, twoPT, maxTime, logging)
+	return sop.NewTransaction(mode, twoPT, logging)
 }

--- a/internal/inredck/transaction.go
+++ b/internal/inredck/transaction.go
@@ -16,7 +16,7 @@ func NewTransaction(mode sop.TransactionMode, maxTime time.Duration, logging boo
 	if err != nil {
 		return nil, err
 	}
-	return sop.NewTransaction(mode, twoPT, maxTime, logging)
+	return sop.NewTransaction(mode, twoPT, logging)
 }
 
 // NewTwoPhaseCommitTransaction instantiates a transaction for writing (forWriting=true) or reading (forWriting=false).

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -14,6 +14,8 @@ import (
 type client struct {
 	conn    *Connection
 	isOwner bool
+	// lastSeenRunID tracks the last observed Redis server run_id to detect restarts.
+	lastSeenRunID string
 }
 
 // NewClient returns a Cache backed by the default shared Redis connection.
@@ -62,6 +64,65 @@ func (c client) Ping(ctx context.Context) error {
 	// Output: PONG <nil>
 
 	return nil
+}
+
+// IsRestarted returns true if the Redis server run_id has changed since the previous call.
+// It uses the INFO server section to read run_id, caching it per client instance.
+func (c *client) IsRestarted(ctx context.Context) (bool, error) {
+	if c.conn == nil {
+		return false, fmt.Errorf("redis connection is not open; can't create new client")
+	}
+	// Use INFO server to get run_id which changes on restart.
+	info, err := c.conn.Client.Info(ctx, "server").Result()
+	if err != nil {
+		return false, err
+	}
+	// Parse run_id: lines are of the form key:value
+	runID := ""
+	for _, line := range splitLines(info) {
+		// skip comments and empty lines
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+		if len(line) > 7 && line[:7] == "run_id:" {
+			runID = line[7:]
+			break
+		}
+	}
+	if runID == "" {
+		return false, fmt.Errorf("unable to read run_id from INFO server response")
+	}
+	if c.lastSeenRunID == "" {
+		c.lastSeenRunID = runID
+		return false, nil
+	}
+	if runID != c.lastSeenRunID {
+		c.lastSeenRunID = runID
+		return true, nil
+	}
+	return false, nil
+}
+
+// splitLines is a tiny helper to avoid strings import bloat here.
+func splitLines(s string) []string {
+	// INFO uses \r\n line endings typically; support both.
+	lines := make([]string, 0, 32)
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			// trim optional carriage return
+			end := i
+			if end > start && s[end-1] == '\r' {
+				end--
+			}
+			lines = append(lines, s[start:end])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
 }
 
 // Clear removes all keys in the current Redis database. Use with caution.

--- a/repository.go
+++ b/repository.go
@@ -86,11 +86,6 @@ type TransactionPriorityLog interface {
 
 	// LogCommitChanges writes a special commit-change log used during drive reinstate for replication.
 	LogCommitChanges(ctx context.Context, stores []StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []RegistryPayload[Handle]) error
-
-	// WriteBackup writes a backup copy of the priority log payload.
-	WriteBackup(ctx context.Context, tid UUID, payload []byte) error
-	// RemoveBackup deletes the backup file for the transaction.
-	RemoveBackup(ctx context.Context, tid UUID) error
 }
 
 // TransactionLog persists transaction steps and provides job-distribution accessors for cleanup tasks.

--- a/repository.go
+++ b/repository.go
@@ -86,6 +86,11 @@ type TransactionPriorityLog interface {
 
 	// LogCommitChanges writes a special commit-change log used during drive reinstate for replication.
 	LogCommitChanges(ctx context.Context, stores []StoreInfo, newRootNodesHandles, addedNodesHandles, updatedNodesHandles, removedNodesHandles []RegistryPayload[Handle]) error
+
+	// ClearRegistrySectorClaims clears all per-sector claim markers used to coordinate exclusive
+	// access to registry file sector CUD operations. Implementations should make best-effort and
+	// return nil if there is nothing to clear.
+	ClearRegistrySectorClaims(ctx context.Context) error
 }
 
 // TransactionLog persists transaction steps and provides job-distribution accessors for cleanup tasks.

--- a/repository.go
+++ b/repository.go
@@ -162,6 +162,10 @@ type Cache interface {
 	// GetEx returns found(bool), value(string), err using TTL/sliding expiration semantics.
 	GetEx(ctx context.Context, key string, expiration time.Duration) (bool, string, error)
 
+	// IsRestarted reports whether the cache backend (e.g., Redis) has restarted since the last check.
+	// Implementations should return true once per backend restart event per-process and false otherwise.
+	IsRestarted(ctx context.Context) (bool, error)
+
 	// SetStruct upserts a struct value under a key.
 	SetStruct(ctx context.Context, key string, value interface{}, expiration time.Duration) error
 	// GetStruct fetches a struct value; first return indicates success (false for not found or error).
@@ -195,6 +199,14 @@ type Cache interface {
 	// Clear purges the entire cache database.
 	Clear(ctx context.Context) error
 }
+
+// CtxPriorityLogIgnoreAge is a context key used by priority log implementations to
+// opt into processing all .plg files regardless of age (used for restart-triggered sweeps).
+// When set to true in context, GetBatch should ignore the age filter.
+type contextKey string
+
+// ContextPriorityLogIgnoreAge signals priority log GetBatch to ignore age filter when true.
+const ContextPriorityLogIgnoreAge contextKey = "plg_ignore_age"
 
 // CloseableCache is a Cache that also implements io.Closer for explicit lifecycle control.
 type CloseableCache interface {

--- a/sleep_timeout_test.go
+++ b/sleep_timeout_test.go
@@ -1,0 +1,67 @@
+package sop
+
+import (
+    "context"
+    "errors"
+    "testing"
+    "time"
+)
+
+func TestTimedOut_WrapsContextError(t *testing.T) {
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel()
+
+    start := time.Now()
+    err := TimedOut(ctx, "transaction", start, 5*time.Second)
+    if err == nil {
+        t.Fatalf("expected timeout error, got nil")
+    }
+
+    var te ErrTimeout
+    if !errors.As(err, &te) {
+        t.Fatalf("expected ErrTimeout, got %T: %v", err, err)
+    }
+    if te.Name != "transaction" {
+        t.Fatalf("unexpected name: %q", te.Name)
+    }
+    if te.MaxTime != 5*time.Second {
+        t.Fatalf("unexpected MaxTime: %v", te.MaxTime)
+    }
+    if !errors.Is(err, context.Canceled) {
+        t.Fatalf("expected errors.Is(err, context.Canceled) to be true; err=%v", err)
+    }
+}
+
+func TestTimedOut_OperationDurationExceeded(t *testing.T) {
+    // Save and restore Now to avoid leaking changes across tests.
+    prevNow := Now
+    defer func() { Now = prevNow }()
+
+    // Start at a fixed point in time to make Now deterministic.
+    start := time.Unix(0, 0)
+    max := 100 * time.Millisecond
+
+    // Make Now return a time just beyond start+max to trigger operation timeout.
+    Now = func() time.Time { return start.Add(max + time.Millisecond) }
+
+    ctx := context.Background()
+    err := TimedOut(ctx, "lockFileBlockRegion", start, max)
+    if err == nil {
+        t.Fatalf("expected timeout error, got nil")
+    }
+
+    var te ErrTimeout
+    if !errors.As(err, &te) {
+        t.Fatalf("expected ErrTimeout, got %T: %v", err, err)
+    }
+    if te.Name != "lockFileBlockRegion" {
+        t.Fatalf("unexpected name: %q", te.Name)
+    }
+    if te.MaxTime != max {
+        t.Fatalf("unexpected MaxTime: %v", te.MaxTime)
+    }
+    // No context cause expected.
+    if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+        t.Fatalf("did not expect context cause, got err=%v", err)
+    }
+}

--- a/transaction.go
+++ b/transaction.go
@@ -86,12 +86,12 @@ type SinglePhaseTransaction struct {
 }
 
 // NewTransaction constructs a Transaction wrapper around a TwoPhaseCommitTransaction.
-// mode controls permissions; maxTime caps the allowed commit duration (-1 uses 15m). When logging is true
-// SOP records commit steps to aid recovery and cleanup of expired resources.
+// mode controls permissions. When logging is true, lower layers may record commit steps
+// to aid recovery and cleanup of expired resources.
 func NewTransaction(mode TransactionMode,
 	twoPhaseCommitTrans TwoPhaseCommitTransaction,
-	maxTime time.Duration, logging bool) (Transaction, error) {
-	twoPhase := twoPhaseCommitTrans // NewTwoPhaseCommitTransaction(mode, maxTime, logging)
+	logging bool) (Transaction, error) {
+	twoPhase := twoPhaseCommitTrans
 	return &SinglePhaseTransaction{
 		SopPhaseCommitTransaction: twoPhase,
 	}, nil


### PR DESCRIPTION
Summary:

* Introduces a priority rollback on transaction start to restore all (potentially) half finished Registry file sectors modified by in-flight transactions that never completed, before any operation is allowed. Puts a gate that pauses all upcoming transactions (across machines in the cluster) to wait for this new restore service to complete.
* Added a new feature to be resilient or accommodating of Redis failover (tail loss issue) on Registry CUD operations. Blob store is unaffected.
    - SOP uses a file marker (using atomic write technique) to resolve who wins locking a registry file sector, which will work even if Redis failover occurred and granting false locks to more than one transaction.
* Increased wait timeout from 30 secs to 3minutes on Registry file sector "wait for my turn max time".