### PR TITLE
Enhance KB routing and navigation with specialized handlers

### DIFF
--- a/AI_COPILOT.md
+++ b/AI_COPILOT.md
@@ -66,14 +66,189 @@ SOP treats operational guidance as managed data instead of static prompt text.
 
 The ReAct loop in SOP is progressive by design, not a blind repeat-until-success loop.
 
-#### Deep KB path routing and explicit LLM suffixes
+#### Gate 1: Advanced KB Routing & Specialized Focus
 
-Two retrieval patterns are now recognized as first-class routing cases:
+Gate 1 now provides powerful, deterministic knowledge base routing with flexible syntax that supports hierarchical category navigation, text search, and LLM-assisted filtering.
 
-*   **Deep slash-path KB prompts** such as `sop:/a/b/c` or `a/b/c/d` are treated as focused KB retrieval requests. The system tries direct category-path lookup first, which is faster and more deterministic than falling back to a generic discovery loop.
-*   **Explicit post-retrieval synthesis markers** use the form `:LLM <instruction>`, for example `a/b/c:LLM extract Apple company from the matches`. This suffix is reserved for cases where the user wants the model to summarize, filter, or synthesize after the KB results are already retrieved.
+##### Routing Syntax Patterns
 
-In other words, pure path-style lookup stays grounded in KB retrieval, while `:LLM ...` is the opt-in switch for higher-level reasoning over the matched items.
+**1. Root Category Display**
+
+Query just the KB name to explore available root categories:
+
+```
+omni:<KB>                                        # Display root categories
+```
+
+**Example:**
+
+```
+Query: omni:sop
+
+Response:
+Available Categories:
+
+• Language (150 items, 5 subcategories)
+  Programming language guides and tutorials
+  Navigate: omni:sop:language
+
+• Architecture (89 items, 3 subcategories)
+  System design and architecture patterns
+  Navigate: omni:sop:architecture
+
+• Operations (203 items, 7 subcategories)
+  DevOps, deployment, and operational guides
+  Navigate: omni:sop:operations
+```
+
+This provides directory-style exploration without needing to know category names upfront.
+
+**Pagination:** Category displays show 20 items per page. Navigation (supports both `:` and `/` separators):
+```
+omni:sop               # Page 1 (default)
+omni:sop:page:2        # Page 2
+omni:sop/page/3        # Page 3 (slash separator)
+
+omni:sop:language:page:2   # Page 2 of subcategories under 'language'
+omni:sop/language/page/2   # Same, using slash separator
+```
+
+When multiple pages exist, the response shows:
+```
+Available Categories: (Page 2 of 5, showing 21-40 of 87)
+...
+Previous: omni:sop:page:1 | Next: omni:sop:page:3
+```
+
+**2. Hierarchical Category Path Routing**
+
+Any-depth category hierarchies are supported with colon-separated paths:
+
+```
+omni:<KB>:cat1                                    # Single level
+omni:<KB>:cat1:subcat1.1                         # Two levels
+omni:<KB>:cat1:subcat1.1:subsubcat1.1.1          # Deep hierarchy
+omni:sop:operations:performance:caching          # Real-world example
+```
+
+The system performs intelligent category resolution:
+- **Direct lookup** via `CategoriesByPath` B-Tree (O(1) when exact match exists)
+- **Semantic fallback** using category embeddings when lexical match fails
+- **Text-based discovery** for natural language category queries
+
+**3. The `:llm <instruction>` Meta-Token**
+
+**3. The `:llm <instruction>` Meta-Token**
+
+Add `:llm <instruction>` after any routing query to have the LLM process the retrieved results:
+
+```
+omni:sop:operations:performance:llm summarize
+omni:sop:language bindings:c#:llm explain with code examples
+omni:myapp:cat1:subcat1.1:llm extract top 5 by relevance
+```
+
+**How it works:**
+- The `:llm <instruction>` portion is **stripped from the query** before KB search
+- KB retrieval proceeds normally using the clean category path
+- Results are passed to the LLM along with the instruction as meta-guidance
+- The LLM processes, filters, or synthesizes the matches according to the instruction
+
+**Example flow:**
+```
+Input:  omni:sop:operations:performance:caching:llm summarize the top 3
+Parse:  category_path = "operations/performance/caching"
+        search_text = (none)
+        llm_instruction = "summarize the top 3"
+Execute: Search KB → 8 matches found
+        Pass to LLM: "Here are 8 matches. summarize the top 3"
+```
+
+**4. Subcategory Navigation (Path-Level)**
+
+When a category path returns no direct items, Gate 1 automatically provides subcategory navigation:
+
+```
+Query: omni:sop:language bindings
+
+Response (no items in parent category):
+**Category "language bindings" has no direct items.**
+
+**Available subcategories (3):**
+1. **c#** (12 items) - C# language binding documentation
+2. **java** (8 items) - Java integration guides  
+3. **python** (15 items) - Python SDK reference
+
+*Navigate deeper: `omni:sop:language bindings:c#`*
+```
+
+This provides granular navigation when exploring deep category hierarchies.
+
+**5. Quoted Text Search (Roadmap)**
+
+Future support for combined category + text search:
+
+```
+omni:sop:language bindings "java tutorial"
+  → Search for "java tutorial" within the language bindings category
+
+omni:sop:operations:performance "caching strategies":llm summarize top 3
+  → Search for text within category, LLM summarizes results
+```
+
+**Proposed parsing logic:**
+- Category path: everything before the first quote
+- Search text: content within quotes
+- LLM instruction: everything after `:llm`
+
+##### Three-Way Routing Decision
+
+Gate 1 makes intelligent decisions based on result count:
+
+1. **Case 1: Few matches (1-5)** → Direct display, bypass LLM
+   - Shows results immediately with category paths
+   - Includes navigation tips
+   
+2. **Case 2: `:llm` instruction present** → LLM processes matches
+   - User explicitly requested LLM analysis
+   - LLM receives clean query + results + instruction
+   
+3. **Case 3: Too many matches (>5)** → LLM reduction
+   - Automatic LLM summarization to avoid overwhelming the user
+   - Instruction: "Analyze and present the most relevant matches"
+
+##### Clean Query Architecture
+
+The `:llm` token is treated as a **meta-instruction**, not part of the actual search query:
+
+```go
+type TaskContextClassification struct {
+    CleanQuery      string  // Query without :llm meta-token
+    LLMInstruction  string  // Extracted instruction
+    KBSearchResults string  // Retrieved matches
+    DirectDisplay   bool    // Whether to bypass LLM
+}
+```
+
+This ensures:
+- KB search operates on clean, semantic queries
+- LLM receives proper context (clean query + results + instruction)
+- No confusion between user intent and meta-commands
+
+##### Flexible Hierarchy Support
+
+All routing patterns work at any depth:
+
+```
+✅ omni:myapp:a:b:c:d:e:f:g:llm <instruction>
+✅ omni:medical:diagnosis:cardiology:procedures:stent:llm explain risks
+✅ omni:sop:architecture:patterns:microservices:llm compare with monolith
+```
+
+The routing system automatically:
+- Normalizes colon separators to forward slashes for internal paths
+- Preserves the full hierarchical context for LLM enrichment
+- Strips only the `:llm` meta-token, not the category structure
 
 *   **Clarification First When Needed**: Before routing and execution, Gate 0 can now keep the interaction in a clarification-first mode. If the assistant asks a focused clarification question, the next user reply is rewritten back onto the original target ask and the normal execution path resumes.
 *   **Macro Then Micro**: Routing gates prepare the Ask frame first. The inner native ReAct loop then executes inside that frame without re-running the gates on every retry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## SOP V2 build 54 (Upcoming)
+- **Gate 1 Advanced KB Routing**: Major enhancements to specialized focused routing for knowledge base queries.
+    - **Root Category Navigation**: Query `omni:<kb>` to display all root categories with item counts and subcategory information.
+        - Example: `omni:sop` shows all top-level categories in the SOP knowledge base
+        - Provides directory-style exploration without needing to know category names upfront
+        - Navigation hints included for deeper exploration (e.g., "Navigate: omni:sop:language")
+        - **Pagination**: 20 categories per page with `:page:<number>` or `/page/<number>` syntax
+            - `omni:sop:page:2` or `omni:sop/page/2` - View page 2 of root categories
+            - `omni:sop:language:page:3` or `omni:sop/language/page/3` - View page 3 of subcategories
+            - Supports both `:` and `/` as separators (matches user's query style)
+            - Shows page info: "(Page 2 of 5, showing 21-40 of 87)"
+            - Navigation hints: "Previous: omni:sop:page:1 | Next: omni:sop:page:3"
+            - LLM filtering suggestion for large sets (>40 categories)
+    - **`:llm <instruction>` Meta-Token**: Added support for explicit LLM post-processing instructions using `:llm` suffix (e.g., `omni:sop:operations:performance:llm summarize top 3`).
+        - **Clean Query Separation**: The `:llm` meta-token is automatically stripped from the KB search query and treated as post-retrieval guidance.
+        - **TaskContextClassification Fields**: Added `CleanQuery` and `LLMInstruction` fields to properly separate user intent from meta-commands.
+        - **Three-Way Routing**: Intelligent decision-making based on result count and `:llm` presence:
+            - `:llm` present → LLM processes with instruction (highest priority)
+            - 1-5 matches → Direct display (no LLM)
+            - 6+ matches → Automatic LLM summarization
+    - **Flexible Hierarchy Support**: Full support for any-depth category paths (e.g., `omni:kb:cat1:subcat1.1:subsubcat1.1.1:...`).
+    - **Subcategory Navigation**: When a category path has no direct items (and no `:llm` instruction), automatically returns child categories with item counts and descriptions as navigation hints.
+    - **Enhanced Parsing**: New `stripLLMInstruction()` function ensures consistent meta-token extraction across all query patterns.
+    - **Architecture Improvements**: 
+        - `getSubcategories()` function for root and path-level category display
+        - `buildKBEnrichedQuery()` now uses clean queries without meta-tokens for proper LLM context
+        - `trySpecializedFocusedRouting()` handles root navigation, flexible hierarchy, and meta-token parsing
+        - Comprehensive test coverage for all routing patterns and hierarchy depths
+    - **Roadmap - Quoted Text Search**: Proposed support for combined category + text queries (e.g., `omni:sop:language bindings "java tutorial"`).
+    - **Documentation Updates**: Updated `AI_COPILOT.md`, `AI_COPILOT_USAGE.md`, and `IMPLEMENTATION.md` with comprehensive routing guides including root category navigation.
+
 ## SOP V2 build 53 (Upcoming)
 - **Schema Format Enhancement**: Introduced flat schema format for better LLM understanding and correlation with Store Relations.
     - **New Fields**: Added `FlatSchema`, `KeyFields`, and `ValueFields` to `StoreInfo` for improved schema representation.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -244,15 +244,83 @@ If critical tool manuals are fragmented and left to probabilistic retrieval, a d
 
 ### Three-Gate Routing Architecture
 
-Gate 1: Focused prefix routing.
+Gate 1: Focused prefix routing with KB specialization.
 
-- Input shape: explicit namespace such as omni:stores:users, plus deep slash-path KB prompts such as `sop:/a/b/c` or `a/b/c/d`.
-- Action: parse hard constraints and classify only the missing parts (mainly layers and CRUD intent). Deep path-style KB prompts now short-circuit into focused KB retrieval rather than drifting into the generic discovery loop.
-- Result: deterministic route with low token overhead, and a clean path for direct category-path answers.
+**Input patterns:**
+- Root category display: `omni:<kb>` (e.g., `omni:sop`)
+- Root with paging: `omni:<kb>:page:<number>` or `omni:<kb>/page/<number>` (e.g., `omni:sop:page:2` or `omni:sop/page/2`)
+- Category path with paging: `omni:<kb>:<path>:page:<number>` (e.g., `omni:sop:language:page:3` or `omni:sop/language/page/3`)
+- Explicit namespace: `omni:stores:users`
+- Deep hierarchical KB paths: `omni:sop:operations:performance:caching`
+- KB paths with LLM instruction: `omni:sop:language bindings:c#:llm summarize`
+- Flexible depth support: `omni:<kb>:cat1:subcat1.1:subsubcat1.1.1`
 
-Optional follow-on instruction format:
+**Processing flow:**
+1. **Pattern recognition**: Detects `omni:` prefix routing queries via `looksLikeSpecializedRoutingQuery()`
+2. **KB extraction**: Identifies target KB name (defaults to "sop" if not specified)
+3. **Page extraction**: Uses `extractPageNumber()` to parse and remove `:page:<number>` suffix (defaults to 1)
+4. **Root navigation check**: If query is just `omni:<kb>` (no category path), retrieve and display root categories
+5. **Meta-token parsing**: Uses `stripLLMInstruction()` to extract and separate the `:llm <instruction>` suffix
+6. **Category path resolution**: Normalizes colon-separated paths to forward slashes for internal routing
+7. **Search orchestration**: Delegates to `searchKnowledgeBase()` with clean query (meta-token stripped)
+8. **Subcategory fallback**: If no items found at path (and no `:llm`), calls `getSubcategories()` with page number
+9. **Pagination display**: Shows page info, navigation hints (Previous/Next), and LLM filtering suggestion for large sets
 
-- If the user adds an explicit `:LLM <instruction>` suffix, for example `a/b/c:LLM extract Apple company from the matches`, the ask remains grounded in KB retrieval but the model is invited to synthesize or narrow the returned candidates after the path lookup.
+**Key architecture principles:**
+- **Clean query separation**: The `:llm` meta-token is treated as post-retrieval guidance, not part of the search query
+- **Hierarchical flexibility**: Supports any depth of category nesting (1 to N levels)
+- **Intelligent fallback**: Direct category path lookup → semantic category matching → text search fallback
+- **Subcategory navigation**: When a category has no items, returns child categories as navigation hints
+
+**Three-way routing decision:**
+1. **Case 1 (1-5 matches)**: Direct display, bypass LLM processing
+2. **Case 2 (`:llm` present)**: LLM processes matches according to user instruction
+3. **Case 3 (6+ matches)**: Automatic LLM summarization to reduce cognitive load
+
+**TaskContextClassification fields:**
+```go
+type TaskContextClassification struct {
+    CleanQuery      string  // Query without :llm meta-token
+    LLMInstruction  string  // Extracted instruction from :llm suffix
+    KBSearchResults string  // Retrieved KB matches
+    KBMatchCount    int     // Number of matches found
+    DirectDisplay   bool    // Whether to bypass LLM (Case 1)
+}
+```
+
+**Implementation reference:**
+- `trySpecializedFocusedRouting()` in `ai/agent/classifier.go`: Main routing logic
+- `stripLLMInstruction()` in `ai/agent/copilottools.search.go`: Meta-token parsing
+- `searchKnowledgeBase()` in `ai/agent/copilottools.search.go`: KB search orchestration
+- `buildKBEnrichedQuery()` in `ai/agent/copilot.go`: LLM context assembly
+
+**Example query flow:**
+```
+Input:  omni:sop:operations:performance:caching:llm summarize top 3
+Parse:  kb_name = "sop"
+        category_path = "operations/performance/caching"
+        clean_query = "operations:performance:caching"
+        llm_instruction = "summarize top 3"
+Execute: KB.Search(category_path) → 8 matches
+Route:  Case 2 (LLM instruction present)
+Output: buildKBEnrichedQuery(clean_query, results, instruction)
+        → LLM receives: query + 8 matches + "summarize top 3"
+```
+
+**Roadmap - Quoted text search:**
+Future support for explicit text queries within categories:
+```
+omni:sop:language bindings "java tutorial"
+  → category_path = "language bindings"
+  → search_text = "java tutorial"
+  
+omni:sop:operations "caching strategies":llm summarize
+  → Combined category + text + LLM instruction
+```
+
+**Action:** Parse hard constraints, extract meta-tokens, and classify missing parts (layers, CRUD intent). Deep path-style KB prompts now short-circuit into focused KB retrieval with proper meta-token handling.
+
+**Result:** Deterministic route with low token overhead, clean separation of query vs. instruction, and intelligent LLM delegation based on result count.
 
 Gate 2: MRU continuity or switch routing.
 

--- a/ai/AI_COPILOT_USAGE.md
+++ b/ai/AI_COPILOT_USAGE.md
@@ -250,6 +250,197 @@ The Spaces API is **high-level** (AI-oriented), while the Database API is **low-
 
 Instead, the AI should use its Space APIs such as `upsert_space_items` natively to manage the categories and items, ensuring correct memory ingestion sequences.
 
+### Advanced KB Routing: Prefix-Based Navigation
+
+SOP supports powerful **prefix-based routing** to directly navigate and query knowledge bases using a specialized syntax. This provides deterministic, fast access to hierarchical knowledge without relying on conversational interpretation.
+
+#### Basic Routing Syntax
+
+```
+omni:<knowledge_base>                         # Display root categories
+omni:<knowledge_base>:<category_path>        # Navigate to specific category
+```
+
+**Root Category Exploration:**
+```
+omni:sop                    # Show all root categories in SOP KB
+omni:medical                # Show all root categories in Medical KB
+omni:myapp                  # Show all root categories in custom KB
+```
+
+**Response example for `omni:sop`:**
+```
+Available Categories:
+
+• Language (150 items, 5 subcategories)
+  Programming language guides and tutorials
+  Navigate: omni:sop:language
+
+• Architecture (89 items, 3 subcategories)
+  System design and architecture patterns
+  Navigate: omni:sop:architecture
+
+• Operations (203 items, 7 subcategories)
+  DevOps, deployment, and operational guides
+  Navigate: omni:sop:operations
+```
+
+**Pagination:** Displays show 20 categories per page. To navigate (both `:` and `/` separators work):
+```bash
+omni:sop               # Page 1 (default)
+omni:sop:page:2        # Page 2  
+omni:sop/page/3        # Page 3 (slash separator)
+omni:sop:language:page:2   # Page 2 of subcategories
+omni:sop/language/page/2   # Same, using slash separator
+```
+
+**Multi-page response example:**
+```
+Available Categories: (Page 2 of 5, showing 21-40 of 87)
+
+• Category 21 (45 items, 2 subcategories)
+  ...
+• Category 40 (12 items)
+  ...
+
+Previous: omni:sop:page:1 | Next: omni:sop:page:3
+💡 Tip: Use `omni:sop:llm list categories matching <name>` to filter results.
+```
+
+**Category Path Navigation:**
+```
+omni:sop:language bindings
+omni:sop:operations:performance
+omni:medical:diagnosis:cardiology:procedures
+```
+
+**How it works:**
+- `omni:` signals specialized routing (Gate 1)
+- `<knowledge_base>` specifies which KB to query (e.g., `sop`, `medical`, `myapp`)
+- `<category_path>` uses colon-separated hierarchy at any depth
+
+The system performs intelligent resolution:
+1. **Root navigation** when only KB name is provided (displays all root categories)
+2. **Direct lookup** via category path index (O(1) when exact match exists)
+3. **Semantic fallback** using category embeddings when no exact match
+4. **Subcategory navigation** when the category has no direct items
+
+#### The `:llm <instruction>` Meta-Token
+
+Add `:llm <instruction>` to have the AI process the retrieved results:
+
+```
+omni:sop:operations:performance:llm summarize
+omni:sop:language bindings:c#:llm explain with code examples
+omni:myapp:tutorials:beginner:llm list top 5 by popularity
+```
+
+**What happens:**
+- The `:llm` portion is automatically stripped before KB search
+- KB retrieval proceeds normally
+- Results are passed to the AI along with your instruction
+- The AI filters, summarizes, or analyzes the matches
+
+**Real-world examples:**
+```
+omni:sop:operations:performance:caching:llm summarize the top 3
+  → Searches caching category, AI summarizes top 3 results
+
+omni:medical:treatments:cardiology:llm compare effectiveness
+  → Retrieves cardiology treatments, AI compares them
+
+omni:sop:architecture:patterns:llm explain pros and cons
+  → Gets architecture patterns, AI analyzes trade-offs
+```
+
+#### Automatic Routing Decisions
+
+The system makes intelligent decisions based on result count:
+
+| Scenario | Behavior |
+|----------|----------|
+| **1-5 matches** | Direct display (no LLM processing) |
+| **`:llm` present** | AI processes according to instruction |
+| **6+ matches** | AI automatically summarizes |
+| **No items found** | Shows subcategory navigation |
+
+#### Subcategory Navigation
+
+When a category has no direct items, you'll see subcategory hints:
+
+```
+Query: omni:sop:language bindings
+
+Response:
+📁 Category "language bindings" has no direct items.
+
+Available subcategories (3):
+  1. c# (12 items) - C# language binding documentation
+  2. java (8 items) - Java integration guides
+  3. python (15 items) - Python SDK reference
+
+💡 Navigate deeper: omni:sop:language bindings:c#
+```
+
+This lets you browse the knowledge hierarchy like a directory tree.
+
+#### Flexible Hierarchy Support
+
+Any depth is supported:
+
+```
+✅ Single level:     omni:sop:operations
+✅ Two levels:       omni:sop:operations:performance  
+✅ Three levels:     omni:sop:operations:performance:caching
+✅ Deep hierarchy:   omni:myapp:a:b:c:d:e:f:g
+```
+
+#### Combining with LLM Instructions
+
+All patterns work together:
+
+```
+# Category navigation
+omni:sop:language bindings:c#
+
+# With LLM summarization
+omni:sop:language bindings:c#:llm summarize
+
+# Deep path with instruction
+omni:medical:diagnosis:cardiology:procedures:stent:llm explain risks
+
+# Complex instruction
+omni:sop:architecture:microservices:llm compare with monolith architecture
+```
+
+#### Future: Quoted Text Search (Roadmap)
+
+Coming soon - combined category + text search:
+
+```
+omni:sop:language bindings "java tutorial"
+  → Search for "java tutorial" within language bindings category
+
+omni:sop:operations:performance "caching strategies":llm top 3
+  → Search for text, AI summarizes top 3 matches
+```
+
+**Syntax (proposed):**
+- Category path before quotes: `omni:sop:operations:performance`
+- Search text in quotes: `"caching strategies"`
+- Optional LLM instruction: `:llm summarize top 3`
+
+#### Quick Reference
+
+| Pattern | Example | Use Case |
+|---------|---------|----------|
+| **Direct routing** | `omni:sop:operations` | Browse a category |
+| **Deep path** | `omni:sop:ops:perf:cache` | Navigate deep hierarchy |
+| **LLM filter** | `omni:sop:guides:llm top 5` | AI selects best matches |
+| **LLM summarize** | `omni:sop:api:llm summarize` | AI condenses info |
+| **LLM analyze** | `omni:sop:patterns:llm compare` | AI provides analysis |
+| **Text search** | `omni:sop:docs "tutorial"` | *(Roadmap)* Search within category |
+
 ## 4. Memory & Learning: The Self-Correcting Copilot
 
 The AI is designed to evolve. It possesses two distinct types of memory, allowing it to adapt to your specific environment and business logic over time.

--- a/ai/README.md
+++ b/ai/README.md
@@ -230,7 +230,7 @@ The runtime-side flow mirrors the UI workflow:
 1. **Open the authored Space** with `ai/database` / `ai/memory`.
 2. **Manage categories and items** through the `KnowledgeBase` abstraction.
 3. **Vectorize** the Space or selected categories/items when you are ready to enable semantic retrieval.
-4. **Search** using `SearchKeywords(...)` for BM25-style retrieval and `SearchSemantics(...)` for vector retrieval.
+4. **Search** using the unified `Search(...)` API for keyword, semantic, and mixed retrieval flows.
 
 This gives your application the same Space-aware reasoning path that the AI Copilot uses, while keeping the authoring experience in SOP Data Manager.
 
@@ -240,7 +240,7 @@ A common pattern is to use the SOP Data Manager as the **authoring studio** for 
 
 1. Create or curate a Space in the SOP Data Manager / Knowledge Base Studio UI.
 2. Use the `ai/database` package to open that Space in your Go code with `OpenKnowledgeBase(...)`.
-3. Query it with the rich `KnowledgeBase` API, including `SearchKeywords(...)` and `SearchSemantics(...)`, to retrieve context for RAG or agent workflows.
+3. Query it with the rich `KnowledgeBase` API, using `Search(...)` as the single entry point for retrieval in RAG or agent workflows.
 
 This keeps the human-facing management and authoring experience in the UI, while your application uses the SOP AI runtime to manage, digest, and search the authored Spaces in-process.
 

--- a/ai/agent/STORES_VS_SPACES.md
+++ b/ai/agent/STORES_VS_SPACES.md
@@ -63,7 +63,7 @@ This is the end-user and developer path for Spaces:
 1. **Create / Mint a Space**: Establish a dedicated KB for a department, product, or persona.
 2. **Manage Categories and Items**: Curate the taxonomy, add summaries, and refine the structure in SOP Data Manager / Knowledge Base Studio.
 3. **Vectorize When Ready**: Generate embeddings for the whole Space, specific categories, or individual items.
-4. **Search Through AI Copilot or Code**: Use the Copilot UI for trial-and-error retrieval, then call the same logic from your app using `ai` APIs such as `SearchKeywords(...)` and `SearchSemantics(...)`.
+4. **Search Through AI Copilot or Code**: Use the Copilot UI for trial-and-error retrieval, then call the same logic from your app using the unified `Search(...)` API.
 
 This lifecycle is the bridge from human-managed authoring to app-managed runtime intelligence.
 

--- a/ai/agent/classifier.go
+++ b/ai/agent/classifier.go
@@ -30,6 +30,7 @@ type TaskContextClassification struct {
 	KBSearchResults string `json:"-"`
 	KBMatchCount    int    `json:"-"`
 	LLMInstruction  string `json:"-"`
+	CleanQuery      string `json:"-"` // Query without :llm meta-token
 	DirectDisplay   bool   `json:"-"`
 }
 
@@ -205,12 +206,24 @@ func (a *CopilotAgent) trySpecializedFocusedRouting(ctx context.Context, query, 
 	}
 
 	normalizedQuery := stripRoutingPrefix(query, kbName)
+
+	// Extract page number first (before other parsing)
+	normalizedQuery, pageNum := extractPageNumber(normalizedQuery)
+
 	pathQuery, llmInstruction := splitCategoryPathInstruction(normalizedQuery)
 	llmMode := strings.TrimSpace(llmInstruction) != "" || strings.Contains(strings.ToLower(normalizedQuery), ":llm")
 	if pathQuery == "" {
 		pathQuery = extractCategoryPathQuery(normalizedQuery)
 	}
-	log.Info("Specialized focused routing parsed", "normalized_query", normalizedQuery, "path_query", pathQuery, "llm_instruction", llmInstruction, "llm_mode", llmMode, "kb_name", kbName)
+
+	// Always extract clean query by stripping :llm instruction, even if no category path
+	cleanQuery, extractedInstruction := stripLLMInstruction(normalizedQuery)
+	if extractedInstruction != "" && llmInstruction == "" {
+		llmInstruction = extractedInstruction
+		llmMode = true
+	}
+
+	log.Info("Specialized focused routing parsed", "normalized_query", normalizedQuery, "path_query", pathQuery, "clean_query", cleanQuery, "llm_instruction", llmInstruction, "llm_mode", llmMode, "page", pageNum, "kb_name", kbName)
 
 	db := a.resolveDBForKB(ctx, kbName)
 	if db == nil {
@@ -218,19 +231,48 @@ func (a *CopilotAgent) trySpecializedFocusedRouting(ctx context.Context, query, 
 		return nil, false, nil
 	}
 
-	candidateText, err := a.searchKnowledgeBase(ctx, db, kbName, normalizedQuery, pathQuery, "", 5)
-	if err != nil {
-		return nil, false, err
+	// Special case: if normalizedQuery is empty (just "omni:KB"), show root categories
+	showSubcategories := false
+	if normalizedQuery == "" || (pathQuery == "" && cleanQuery == "") {
+		showSubcategories = true
 	}
 
-	// Count actual hits (each hit has both CategoryPath and Score, so count only one)
-	candidateCount := strings.Count(candidateText, "CategoryPath:")
-	if strings.Contains(strings.ToLower(candidateText), "no results found") {
-		candidateCount = 0
+	var candidateText string
+	var candidateCount int
+	var err error
+
+	if showSubcategories {
+		// Display root categories for navigation
+		candidateText, err = a.getSubcategories(ctx, db, kbName, "", pageNum)
+		if err != nil {
+			return nil, false, err
+		}
+		log.Info("Specialized focused routing: showing root categories", "kb_name", kbName, "page", pageNum)
+	} else {
+		// Normal KB search
+		candidateText, err = a.searchKnowledgeBase(ctx, db, kbName, normalizedQuery, pathQuery, "", 5)
+		if err != nil {
+			return nil, false, err
+		}
+
+		// Count actual hits (each hit has both CategoryPath and Score, so count only one)
+		candidateCount = strings.Count(candidateText, "CategoryPath:")
+		if strings.Contains(strings.ToLower(candidateText), "no results found") {
+			candidateCount = 0
+			// If no results found but we have a category path AND no :llm instruction, show subcategories
+			if pathQuery != "" && !llmMode {
+				subcatText, err := a.getSubcategories(ctx, db, kbName, pathQuery, pageNum)
+				if err == nil && subcatText != "" {
+					candidateText = fmt.Sprintf("No items found at this path.\n\n%s", subcatText)
+					showSubcategories = true
+					log.Info("Specialized focused routing: showing subcategories for path", "path", pathQuery, "page", pageNum)
+				}
+			}
+		}
 	}
 
-	handled := looksLikeSpecializedRoutingQuery(query) || llmMode || candidateCount > 0
-	log.Info("Specialized focused routing decision", "handled", handled, "llm_mode", llmMode, "candidate_count", candidateCount, "candidate_text_preview", summarizeCandidatePreview(candidateText))
+	handled := looksLikeSpecializedRoutingQuery(query) || llmMode || candidateCount > 0 || showSubcategories
+	log.Info("Specialized focused routing decision", "handled", handled, "llm_mode", llmMode, "candidate_count", candidateCount, "show_subcategories", showSubcategories, "candidate_text_preview", summarizeCandidatePreview(candidateText))
 	if !handled {
 		return nil, false, nil
 	}
@@ -247,18 +289,27 @@ func (a *CopilotAgent) trySpecializedFocusedRouting(ctx context.Context, query, 
 	taskCtx.KBSearchResults = candidateText
 	taskCtx.KBMatchCount = candidateCount
 	taskCtx.LLMInstruction = llmInstruction
+	// Store clean query without :llm meta-token for LLM context
+	// Use the cleanQuery which has :llm instruction stripped out
+	taskCtx.CleanQuery = cleanQuery
 
 	// Three-way routing decision:
-	// Case 1: Few matches (1-5) -> Direct display, bypass LLM
-	// Case 2: :llm instruction -> LLM processes matches with user instruction
+	// Case 0: :llm instruction present -> Always use LLM (even with 0 results)
+	// Case 1: Showing subcategories -> Direct display for navigation
+	// Case 2: Few matches (1-5) -> Direct display, bypass LLM
 	// Case 3: Too many matches (>5) -> LLM reduces/summarizes matches
 	if llmMode {
-		// Case 2: User wants LLM to process matches
+		// Case 0: User wants LLM to process (highest priority)
 		taskCtx.DirectDisplay = false
 		taskCtx.Layers = append(taskCtx.Layers, LayerInfo{Name: "LLMFilter", CRUD: []string{"R"}})
 		log.Info("KB routing: LLM filter mode", "instruction", llmInstruction)
+	} else if showSubcategories {
+		// Case 1: Showing subcategories for navigation - direct display
+		taskCtx.DirectDisplay = true
+		taskCtx.Layers = append(taskCtx.Layers, LayerInfo{Name: "KBRoute", CRUD: []string{"R"}})
+		log.Info("KB routing: Direct display (subcategories navigation)")
 	} else if candidateCount > 0 && candidateCount <= 5 {
-		// Case 1: Few matches - direct display
+		// Case 2: Few matches - direct display
 		taskCtx.DirectDisplay = true
 		taskCtx.Layers = append(taskCtx.Layers, LayerInfo{Name: "KBRoute", CRUD: []string{"R"}})
 		log.Info("KB routing: Direct display", "match_count", candidateCount)

--- a/ai/agent/classifier.go
+++ b/ai/agent/classifier.go
@@ -26,6 +26,11 @@ type TaskContextClassification struct {
 	Layers          []LayerInfo `json:"layers"`
 	ScriptAuthoring bool        `json:"-"`
 	RoutingGate     string      `json:"-"`
+	// KB Search Results (for specialized KB routing)
+	KBSearchResults string `json:"-"`
+	KBMatchCount    int    `json:"-"`
+	LLMInstruction  string `json:"-"`
+	DirectDisplay   bool   `json:"-"`
 }
 
 type continuityDigest struct {
@@ -160,9 +165,29 @@ func (a *CopilotAgent) ClassifyFocusedTaskContext(ctx context.Context, query, en
 }
 
 func looksLikeSpecializedRoutingQuery(query string) bool {
+
+	log.Info("routing ", "query", query)
+
 	trimmed := strings.TrimSpace(query)
 	lower := strings.ToLower(trimmed)
-	return strings.HasPrefix(lower, "omni:sop:") || strings.HasPrefix(lower, "sop:") || strings.HasPrefix(lower, "omni/sop/") || strings.HasPrefix(lower, "omni->sop->")
+
+	if strings.HasPrefix(lower, "omni:") {
+		parts := strings.Split(trimmed, ":")
+		return len(parts) >= 3 && strings.TrimSpace(parts[1]) != "" && strings.TrimSpace(parts[2]) != ""
+	}
+
+	return strings.HasPrefix(lower, "sop:") || strings.HasPrefix(lower, "omni/sop/") || strings.HasPrefix(lower, "omni->sop->")
+}
+
+func routingKBName(query string) string {
+	trimmed := strings.TrimSpace(query)
+	if strings.HasPrefix(strings.ToLower(trimmed), "omni:") {
+		parts := strings.Split(trimmed, ":")
+		if len(parts) >= 3 {
+			return strings.TrimSpace(parts[1])
+		}
+	}
+	return ""
 }
 
 func (a *CopilotAgent) trySpecializedFocusedRouting(ctx context.Context, query, entity, domain, artifact string) (*TaskContextClassification, bool, error) {
@@ -172,19 +197,20 @@ func (a *CopilotAgent) trySpecializedFocusedRouting(ctx context.Context, query, 
 
 	log.Info("Specialized focused routing activated", "query", query, "entity", entity, "domain", domain, "artifact", artifact)
 
-	normalizedQuery := stripRoutingPrefix(query, "sop")
+	kbName := ai.CanonicalKBName("sop")
+	if routedKB := routingKBName(query); routedKB != "" {
+		kbName = ai.CanonicalKBName(routedKB)
+	} else if domain != "" {
+		kbName = ai.CanonicalKBName(domain)
+	}
+
+	normalizedQuery := stripRoutingPrefix(query, kbName)
 	pathQuery, llmInstruction := splitCategoryPathInstruction(normalizedQuery)
 	llmMode := strings.TrimSpace(llmInstruction) != "" || strings.Contains(strings.ToLower(normalizedQuery), ":llm")
 	if pathQuery == "" {
 		pathQuery = extractCategoryPathQuery(normalizedQuery)
 	}
-	log.Info("Specialized focused routing parsed", "normalized_query", normalizedQuery, "path_query", pathQuery, "llm_instruction", llmInstruction, "llm_mode", llmMode)
-	kbName := ai.CanonicalKBName("sop")
-	if !looksLikeSpecializedRoutingQuery(query) {
-		if domain != "" {
-			kbName = ai.CanonicalKBName(domain)
-		}
-	}
+	log.Info("Specialized focused routing parsed", "normalized_query", normalizedQuery, "path_query", pathQuery, "llm_instruction", llmInstruction, "llm_mode", llmMode, "kb_name", kbName)
 
 	db := a.resolveDBForKB(ctx, kbName)
 	if db == nil {
@@ -192,23 +218,18 @@ func (a *CopilotAgent) trySpecializedFocusedRouting(ctx context.Context, query, 
 		return nil, false, nil
 	}
 
-	candidateText, err := a.searchKnowledgeBase(ctx, db, kbName, normalizedQuery, pathQuery, "", true, 5)
+	candidateText, err := a.searchKnowledgeBase(ctx, db, kbName, normalizedQuery, pathQuery, "", 5)
 	if err != nil {
 		return nil, false, err
 	}
 
-	candidateCount := 0
-	if strings.Contains(candidateText, "CategoryPath:") {
-		candidateCount += strings.Count(candidateText, "CategoryPath:")
-	}
-	if strings.Contains(candidateText, "Score:") {
-		candidateCount += strings.Count(candidateText, "Score:")
-	}
+	// Count actual hits (each hit has both CategoryPath and Score, so count only one)
+	candidateCount := strings.Count(candidateText, "CategoryPath:")
 	if strings.Contains(strings.ToLower(candidateText), "no results found") {
 		candidateCount = 0
 	}
 
-	handled := looksLikeSpecializedRoutingQuery(query) || llmMode || (candidateCount > 0 && candidateCount <= 5)
+	handled := looksLikeSpecializedRoutingQuery(query) || llmMode || candidateCount > 0
 	log.Info("Specialized focused routing decision", "handled", handled, "llm_mode", llmMode, "candidate_count", candidateCount, "candidate_text_preview", summarizeCandidatePreview(candidateText))
 	if !handled {
 		return nil, false, nil
@@ -221,12 +242,37 @@ func (a *CopilotAgent) trySpecializedFocusedRouting(ctx context.Context, query, 
 	if pathQuery != "" {
 		taskCtx.SpacesArtifacts = append(taskCtx.SpacesArtifacts, pathQuery)
 	}
+
+	// Populate KB search results
+	taskCtx.KBSearchResults = candidateText
+	taskCtx.KBMatchCount = candidateCount
+	taskCtx.LLMInstruction = llmInstruction
+
+	// Three-way routing decision:
+	// Case 1: Few matches (1-5) -> Direct display, bypass LLM
+	// Case 2: :llm instruction -> LLM processes matches with user instruction
+	// Case 3: Too many matches (>5) -> LLM reduces/summarizes matches
 	if llmMode {
+		// Case 2: User wants LLM to process matches
+		taskCtx.DirectDisplay = false
 		taskCtx.Layers = append(taskCtx.Layers, LayerInfo{Name: "LLMFilter", CRUD: []string{"R"}})
+		log.Info("KB routing: LLM filter mode", "instruction", llmInstruction)
+	} else if candidateCount > 0 && candidateCount <= 5 {
+		// Case 1: Few matches - direct display
+		taskCtx.DirectDisplay = true
+		taskCtx.Layers = append(taskCtx.Layers, LayerInfo{Name: "KBRoute", CRUD: []string{"R"}})
+		log.Info("KB routing: Direct display", "match_count", candidateCount)
+	} else if candidateCount > 5 {
+		// Case 3: Too many matches - LLM reduction
+		taskCtx.DirectDisplay = false
+		taskCtx.LLMInstruction = "Please analyze these search results and present the most relevant matches to the user."
+		taskCtx.Layers = append(taskCtx.Layers, LayerInfo{Name: "LLMFilter", CRUD: []string{"R"}})
+		log.Info("KB routing: LLM reduction mode", "match_count", candidateCount)
 	} else {
+		// Fallback for no matches
 		taskCtx.Layers = append(taskCtx.Layers, LayerInfo{Name: "KBRoute", CRUD: []string{"R"}})
 	}
-	log.Info("Specialized focused routing resolved", "routing_gate", taskCtx.RoutingGate, "layers", taskCtx.Layers, "spaces_artifacts", taskCtx.SpacesArtifacts)
+	log.Info("Specialized focused routing resolved", "routing_gate", taskCtx.RoutingGate, "layers", taskCtx.Layers, "spaces_artifacts", taskCtx.SpacesArtifacts, "direct_display", taskCtx.DirectDisplay)
 
 	normalizeTaskContext(taskCtx)
 	taskCtx.RoutingGate = RoutingGateFocused

--- a/ai/agent/classifier.go
+++ b/ai/agent/classifier.go
@@ -174,20 +174,56 @@ func looksLikeSpecializedRoutingQuery(query string) bool {
 
 	if strings.HasPrefix(lower, "omni:") {
 		parts := strings.Split(trimmed, ":")
-		return len(parts) >= 3 && strings.TrimSpace(parts[1]) != "" && strings.TrimSpace(parts[2]) != ""
+		// Allow omni:KB (2 parts) for root category navigation, or omni:KB:path (3+ parts)
+		if len(parts) >= 2 && strings.TrimSpace(parts[1]) != "" {
+			kbPart := strings.TrimSpace(strings.ToLower(parts[1]))
+
+			// Exclude domain names (Stores, Spaces) from specialized routing
+			// These should go through normal Gate1 classification
+			if kbPart == "stores" || kbPart == "spaces" {
+				return false
+			}
+
+			// If exactly 2 parts (omni:KB), allow it for root categories
+			if len(parts) == 2 {
+				return true
+			}
+			// If 3+ parts, ensure the third part isn't empty (unless it's a trailing colon)
+			return len(parts) >= 3
+		}
+		return false
 	}
 
-	return strings.HasPrefix(lower, "sop:") || strings.HasPrefix(lower, "omni/sop/") || strings.HasPrefix(lower, "omni->sop->")
+	// Support direct KB queries without omni: prefix
+	if strings.HasPrefix(lower, "sop:") || strings.HasPrefix(lower, "omni/sop/") || strings.HasPrefix(lower, "omni->sop->") {
+		return true
+	}
+
+	// Support just "sop" for root category navigation
+	if lower == "sop" {
+		return true
+	}
+
+	return false
 }
 
 func routingKBName(query string) string {
 	trimmed := strings.TrimSpace(query)
-	if strings.HasPrefix(strings.ToLower(trimmed), "omni:") {
+	lower := strings.ToLower(trimmed)
+
+	if strings.HasPrefix(lower, "omni:") {
 		parts := strings.Split(trimmed, ":")
-		if len(parts) >= 3 {
+		// Extract KB name from omni:KB or omni:KB:path patterns
+		if len(parts) >= 2 && strings.TrimSpace(parts[1]) != "" {
 			return strings.TrimSpace(parts[1])
 		}
 	}
+
+	// Support direct KB name patterns: "sop", "sop:path", etc.
+	if strings.HasPrefix(lower, "sop:") || lower == "sop" {
+		return "sop"
+	}
+
 	return ""
 }
 

--- a/ai/agent/copilot.go
+++ b/ai/agent/copilot.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -108,19 +109,70 @@ func cloneTaskContextClassification(taskCtx *TaskContextClassification) *TaskCon
 	return &cloned
 }
 
+// formatKBSourceLinks renders every available DocID as a clickable markdown link.
+func (a *CopilotAgent) formatKBSourceLinks(ctx context.Context, docIDs memory.DocIDs) string {
+	if len(docIDs) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(docIDs))
+	for _, docID := range docIDs {
+		docID = strings.TrimSpace(docID)
+		if docID == "" {
+			continue
+		}
+
+		viewerURL := &url.URL{Path: "/viewer"}
+		q := viewerURL.Query()
+		q.Set("docID", docID)
+		viewerURL.RawQuery = q.Encode()
+
+		if ctx != nil {
+			if baseURL, ok := ctx.Value(ai.CtxKeyAppBaseURL).(string); ok && strings.TrimSpace(baseURL) != "" {
+				base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+				if base != "" {
+					parsedBase, err := url.Parse(base)
+					if err == nil {
+						parsedBase.Path = strings.TrimRight(parsedBase.Path, "/") + viewerURL.Path
+						parsedBase.RawQuery = viewerURL.RawQuery
+						viewerURL = parsedBase
+					}
+				}
+			}
+		}
+
+		parts = append(parts, fmt.Sprintf("[%s](%s)", docID, viewerURL.String()))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("\nSources: %s", strings.Join(parts, ", "))
+}
+
 // formatKBSearchResultsForDisplay formats KB search results for direct display (Case 1: Few matches)
 func (a *CopilotAgent) formatKBSearchResultsForDisplay(results string, matchCount int) string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("**Found %d knowledge base match", matchCount))
-	if matchCount != 1 {
-		sb.WriteString("es")
-	}
-	sb.WriteString(":**\\n\\n")
 
-	// Results already formatted by searchKnowledgeBase with headers
-	sb.WriteString(results)
-	sb.WriteString("\\n\\n---\\n")
-	sb.WriteString("*Tip: Use `:llm <instruction>` to filter results with AI assistance*")
+	// Check if this is category navigation (matchCount=0 but results contain "Available Categories" or "Subcategories")
+	isCategoryNavigation := matchCount == 0 && (strings.Contains(results, "Available Categories:") || strings.Contains(results, "Subcategories under"))
+
+	if isCategoryNavigation {
+		// Direct category navigation - just return the formatted results
+		sb.WriteString(results)
+		sb.WriteString("\n\n---\n")
+		sb.WriteString("*Tip: Use `:llm <instruction>` to filter results with AI assistance*")
+	} else {
+		// Regular search results
+		sb.WriteString(fmt.Sprintf("**Found %d knowledge base match", matchCount))
+		if matchCount != 1 {
+			sb.WriteString("es")
+		}
+		sb.WriteString(":**\n\n")
+		sb.WriteString(results)
+		sb.WriteString("\n\n---\n")
+		sb.WriteString("*Tip: Use `:llm <instruction>` to filter results with AI assistance*")
+	}
 
 	return sb.String()
 }
@@ -133,22 +185,24 @@ func (a *CopilotAgent) buildKBEnrichedQuery(cleanQuery, kbResults, llmInstructio
 	// Start with the clean query (without :llm meta-token)
 	if strings.TrimSpace(cleanQuery) != "" {
 		sb.WriteString(cleanQuery)
-		sb.WriteString("\\n\\n")
+		sb.WriteString("\n\n")
 	}
 
 	// Add KB context header
-	sb.WriteString("---\\n")
-	sb.WriteString(fmt.Sprintf("**Knowledge Base Search Results (%d matches):**\\n", matchCount))
+	sb.WriteString("---\n")
+	sb.WriteString(fmt.Sprintf("**Knowledge Base Search Results (%d matches):**\n", matchCount))
 	sb.WriteString(kbResults)
-	sb.WriteString("\\n---\\n\\n")
+	sb.WriteString("\n---\n\n")
 
 	// Add instruction
 	if llmInstruction != "" {
-		sb.WriteString(fmt.Sprintf("**Instruction:** %s\\n", llmInstruction))
+		sb.WriteString(fmt.Sprintf("**Instruction:** %s\n", llmInstruction))
 	} else {
 		// Default reduction instruction for too many matches (Case 3)
-		sb.WriteString("**Instruction:** Please analyze the search results above and present the most relevant matches to the user.\\n")
+		sb.WriteString("**Instruction:** Please analyze the search results above and present the most relevant matches to the user.\n")
 	}
+	// Preserve source links verbatim so the final answer can remain clickable.
+	sb.WriteString("**Link Preservation:** Preserve the exact markdown source links from the KB results verbatim in your answer. Do not replace them with plain relative file paths or bare filenames.\n")
 
 	return sb.String()
 }
@@ -1244,6 +1298,16 @@ func (a *CopilotAgent) evaluateRoutingGates(ctx context.Context, query string, g
 	a.rehydrateMRUFromMemory(ctx)
 	isTest := isRoutingTestGenerator(gen)
 	anchor := parseRoutingAnchor(query)
+
+	// Fast-path: Check for specialized KB routing patterns (e.g., "sop", "sop:category")
+	// before falling through to the standard three-gate flow
+	if looksLikeSpecializedRoutingQuery(query) && anchor == nil {
+		if handledTaskCtx, handled, err := a.trySpecializedFocusedRouting(ctx, query, "Omni", "Spaces", ""); err != nil {
+			return nil, err
+		} else if handled {
+			return handledTaskCtx, nil
+		}
+	}
 
 	if taskClassification, err := a.tryPrefixBasedRouting(ctx, query, gen, isTest, anchor); err != nil {
 		return nil, err
@@ -3723,9 +3787,37 @@ func deepCopyValue(v any) any {
 	}
 }
 
+func shouldRouteToOmniInsteadOfAvatar(query string) bool {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return false
+	}
+
+	lower := strings.ToLower(trimmed)
+	if lower == "sop" || strings.HasPrefix(lower, "sop:") {
+		return true
+	}
+
+	if strings.HasPrefix(lower, "omni:") {
+		parts := strings.Split(trimmed, ":")
+		if len(parts) >= 2 {
+			kbName := strings.TrimSpace(strings.ToLower(parts[1]))
+			return kbName == "sop"
+		}
+	}
+
+	return false
+}
+
 func (a *CopilotAgent) classifyIntent(ctx context.Context, query string, gen ai.Generator) string {
 	if flag.Lookup("test.v") != nil {
 		// Bypass intent routing in unit tests
+		return ai.IntentOmni
+	}
+
+	log.Info("classifyIntent ", "query", query)
+
+	if shouldRouteToOmniInsteadOfAvatar(query) {
 		return ai.IntentOmni
 	}
 

--- a/ai/agent/copilot.go
+++ b/ai/agent/copilot.go
@@ -126,12 +126,15 @@ func (a *CopilotAgent) formatKBSearchResultsForDisplay(results string, matchCoun
 }
 
 // buildKBEnrichedQuery enriches the query with KB search results for LLM processing (Case 2 & 3)
-func (a *CopilotAgent) buildKBEnrichedQuery(originalQuery, kbResults, llmInstruction string, matchCount int) string {
+// The cleanQuery parameter should be the user's intent WITHOUT the :llm meta-token
+func (a *CopilotAgent) buildKBEnrichedQuery(cleanQuery, kbResults, llmInstruction string, matchCount int) string {
 	var sb strings.Builder
 
-	// Start with the original query
-	sb.WriteString(originalQuery)
-	sb.WriteString("\\n\\n")
+	// Start with the clean query (without :llm meta-token)
+	if strings.TrimSpace(cleanQuery) != "" {
+		sb.WriteString(cleanQuery)
+		sb.WriteString("\\n\\n")
+	}
 
 	// Add KB context header
 	sb.WriteString("---\\n")
@@ -766,8 +769,13 @@ func (a *CopilotAgent) Ask(ctx context.Context, query string, cfg *ai.ConfigMap)
 	// 6a. KB Search LLM Integration (Case 2: :llm instruction, Case 3: Too many matches)
 	if !taskContext.DirectDisplay && taskContext.KBSearchResults != "" {
 		log.Info("KB routing: LLM processing path", "match_count", taskContext.KBMatchCount, "has_instruction", taskContext.LLMInstruction != "")
+		// Use clean query (without :llm meta-token) for LLM context
+		cleanQuery := taskContext.CleanQuery
+		if cleanQuery == "" {
+			cleanQuery = query // fallback to original if clean query not set
+		}
 		// Inject KB results into the query for LLM processing
-		query = a.buildKBEnrichedQuery(query, taskContext.KBSearchResults, taskContext.LLMInstruction, taskContext.KBMatchCount)
+		query = a.buildKBEnrichedQuery(cleanQuery, taskContext.KBSearchResults, taskContext.LLMInstruction, taskContext.KBMatchCount)
 	}
 
 	// 7. Reasoning Engine Delegation

--- a/ai/agent/copilot.go
+++ b/ai/agent/copilot.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sharedcode/sop/ai"
 	"github.com/sharedcode/sop/ai/agent/parser"
 	"github.com/sharedcode/sop/ai/database"
+	"github.com/sharedcode/sop/ai/embed"
 	"github.com/sharedcode/sop/ai/generator"
 	"github.com/sharedcode/sop/ai/memory"
 	"github.com/sharedcode/sop/ai/obfuscation"
@@ -105,6 +106,48 @@ func cloneTaskContextClassification(taskCtx *TaskContextClassification) *TaskCon
 		cloned.Layers = append([]LayerInfo(nil), taskCtx.Layers...)
 	}
 	return &cloned
+}
+
+// formatKBSearchResultsForDisplay formats KB search results for direct display (Case 1: Few matches)
+func (a *CopilotAgent) formatKBSearchResultsForDisplay(results string, matchCount int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("**Found %d knowledge base match", matchCount))
+	if matchCount != 1 {
+		sb.WriteString("es")
+	}
+	sb.WriteString(":**\\n\\n")
+
+	// Results already formatted by searchKnowledgeBase with headers
+	sb.WriteString(results)
+	sb.WriteString("\\n\\n---\\n")
+	sb.WriteString("*Tip: Use `:llm <instruction>` to filter results with AI assistance*")
+
+	return sb.String()
+}
+
+// buildKBEnrichedQuery enriches the query with KB search results for LLM processing (Case 2 & 3)
+func (a *CopilotAgent) buildKBEnrichedQuery(originalQuery, kbResults, llmInstruction string, matchCount int) string {
+	var sb strings.Builder
+
+	// Start with the original query
+	sb.WriteString(originalQuery)
+	sb.WriteString("\\n\\n")
+
+	// Add KB context header
+	sb.WriteString("---\\n")
+	sb.WriteString(fmt.Sprintf("**Knowledge Base Search Results (%d matches):**\\n", matchCount))
+	sb.WriteString(kbResults)
+	sb.WriteString("\\n---\\n\\n")
+
+	// Add instruction
+	if llmInstruction != "" {
+		sb.WriteString(fmt.Sprintf("**Instruction:** %s\\n", llmInstruction))
+	} else {
+		// Default reduction instruction for too many matches (Case 3)
+		sb.WriteString("**Instruction:** Please analyze the search results above and present the most relevant matches to the user.\\n")
+	}
+
+	return sb.String()
 }
 
 func shouldPreserveMRUOnTopicSwitch(item MRUItem) bool {
@@ -690,7 +733,10 @@ func (a *CopilotAgent) Ask(ctx context.Context, query string, cfg *ai.ConfigMap)
 
 	// TODO: process unpacking IsNewTopic from Options, and use that as added signal for routing in Gate 2 (MRU).
 
-	taskContext := a.evaluateRoutingGates(ctx, query, gen)
+	taskContext, err := a.evaluateRoutingGates(ctx, query, gen)
+	if err != nil {
+		return "", err
+	}
 	if taskContext == nil {
 		taskContext = &TaskContextClassification{Domain: "General"}
 	}
@@ -699,11 +745,30 @@ func (a *CopilotAgent) Ask(ctx context.Context, query string, cfg *ai.ConfigMap)
 		"task_context", summarizeTaskContextForLog(*taskContext),
 	)
 
+	// 4a. KB Search Direct Display (Case 1: Few matches)
+	if taskContext.DirectDisplay && taskContext.KBSearchResults != "" {
+		log.Info("KB routing: Direct display path", "match_count", taskContext.KBMatchCount)
+		// Track episode metadata for MRU
+		a.trackEpisodeMetadata(ctx, intent)
+		// Format and return KB results immediately without LLM delegation
+		response := a.formatKBSearchResultsForDisplay(taskContext.KBSearchResults, taskContext.KBMatchCount)
+		// Track ask outcome for continuity
+		a.epilogueAndCleanup(ctx, rawQuery, intent, response, nil, nil, nil, nil)
+		return response, nil
+	}
+
 	// 5. Episode Metadata Tracking (MRU Cache)
 	a.trackEpisodeMetadata(ctx, intent)
 
 	// 6. System Prompt Construction
 	fullPrompt := a.buildSystemPrompt(ctx, query, *taskContext)
+
+	// 6a. KB Search LLM Integration (Case 2: :llm instruction, Case 3: Too many matches)
+	if !taskContext.DirectDisplay && taskContext.KBSearchResults != "" {
+		log.Info("KB routing: LLM processing path", "match_count", taskContext.KBMatchCount, "has_instruction", taskContext.LLMInstruction != "")
+		// Inject KB results into the query for LLM processing
+		query = a.buildKBEnrichedQuery(query, taskContext.KBSearchResults, taskContext.LLMInstruction, taskContext.KBMatchCount)
+	}
 
 	// 7. Reasoning Engine Delegation
 	finalText, toolCalls, outcomeFacts, outcomeRecipes, carryoverState, err := a.delegateToReasoningEngine(ctx, query, gen, fullPrompt)
@@ -1167,16 +1232,21 @@ func lastNonEmptyQueryLine(query string) string {
 	return ""
 }
 
-func (a *CopilotAgent) evaluateRoutingGates(ctx context.Context, query string, gen ai.Generator) *TaskContextClassification {
+func (a *CopilotAgent) evaluateRoutingGates(ctx context.Context, query string, gen ai.Generator) (*TaskContextClassification, error) {
 	a.rehydrateMRUFromMemory(ctx)
 	isTest := isRoutingTestGenerator(gen)
 	anchor := parseRoutingAnchor(query)
 
-	if taskClassification := a.tryPrefixBasedRouting(ctx, query, gen, isTest, anchor); taskClassification != nil {
-		return taskClassification
+	if taskClassification, err := a.tryPrefixBasedRouting(ctx, query, gen, isTest, anchor); err != nil {
+		return nil, err
+	} else if taskClassification != nil {
+		return taskClassification, nil
 	}
-	if taskClassification := a.tryAskContinuationBasedRouting(ctx, query, gen, isTest, anchor); taskClassification != nil {
-		return taskClassification
+
+	if taskClassification, err := a.tryAskContinuationBasedRouting(ctx, query, gen, isTest, anchor); err != nil {
+		return nil, err
+	} else if taskClassification != nil {
+		return taskClassification, nil
 	}
 
 	return a.tryColdStartBasedRouting(ctx, query, gen, isTest)
@@ -2408,7 +2478,7 @@ func (a *CopilotAgent) buildSystemPrompt(ctx context.Context, query string, task
 		"components_present", summarizePromptComponentsPresent(budgetReport),
 		"trimmed_components", summarizePromptBudgetTrim(budgetReport),
 	)
-	log.Info("LLM Context (OMNI)", "SystemPrompt", fullPrompt)
+	log.Debug("LLM Context (OMNI)", "SystemPrompt", fullPrompt)
 
 	return fullPrompt
 }
@@ -2928,7 +2998,7 @@ func (a *CopilotAgent) logThought(ctx context.Context, query string, toolsExecut
 		embedCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		vecs, err := embedder.EmbedTexts(embedCtx, []string{thought})
+		vecs, err := embed.DocumentTexts(embedCtx, embedder, []string{thought})
 		if err != nil || len(vecs) == 0 {
 			return
 		}

--- a/ai/agent/copilot_lifecycle_test.go
+++ b/ai/agent/copilot_lifecycle_test.go
@@ -151,7 +151,7 @@ func TestAgentFullMemoryLifeCycleTest(t *testing.T) {
 	ag.service.domain = &mockDomain{emb: embedder}
 
 	db := ag.resolveDBForKB(ctx, "ltm_agent123")
-	res, err := ag.searchKnowledgeBase(ctx, db, "ltm_agent123", "learned something", "", "", false, 5)
+	res, err := ag.searchKnowledgeBase(ctx, db, "ltm_agent123", "learned something", "", "", 5)
 	if err != nil {
 		t.Fatalf("toolSearchDomainKB failed: %v", err)
 	}

--- a/ai/agent/copilot_pipeline_gate1_test.go
+++ b/ai/agent/copilot_pipeline_gate1_test.go
@@ -220,6 +220,176 @@ func TestTrySpecializedFocusedRouting_SupportsWhitespaceAroundLLM(t *testing.T) 
 	if len(taskCtx.SpacesArtifacts) == 0 || taskCtx.SpacesArtifacts[0] != "language/c#/tutorial" {
 		t.Fatalf("expected category path to be preserved in spaces artifacts, got %+v", taskCtx.SpacesArtifacts)
 	}
+	// Verify CleanQuery field is set (without :llm instruction)
+	if taskCtx.CleanQuery != "language/c#/tutorial" {
+		t.Fatalf("expected CleanQuery to be 'language/c#/tutorial', got %q", taskCtx.CleanQuery)
+	}
+	// Verify LLMInstruction field is set
+	if taskCtx.LLMInstruction != "summarize" {
+		t.Fatalf("expected LLMInstruction to be 'summarize', got %q", taskCtx.LLMInstruction)
+	}
+}
+
+func TestTrySpecializedFocusedRouting_StripsLLMInstructionWithoutCategoryPath(t *testing.T) {
+	ctx := context.Background()
+	sysDB := database.NewDatabase(sop.DatabaseOptions{Type: sop.Standalone, StoresFolders: []string{t.TempDir()}})
+
+	tx, err := sysDB.BeginTransaction(ctx, sop.ForWriting)
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	kb, err := sysDB.OpenKnowledgeBase(ctx, "sop", tx, nil, nil, false)
+	if err != nil {
+		t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	}
+	if err := kb.SetConfig(ctx, &memory.KnowledgeBaseConfig{TextSearchEnabled: true, LastVectorized: 1}); err != nil {
+		t.Fatalf("SetConfig failed: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, sysDB)
+	taskCtx, handled, err := ag.trySpecializedFocusedRouting(ctx, "omni:sop:performance tips:llm summarize the top 5", "Omni", "Spaces", "")
+	if err != nil {
+		t.Fatalf("trySpecializedFocusedRouting failed: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected specialized focused routing to handle the query with :llm")
+	}
+	if taskCtx == nil {
+		t.Fatal("expected a focused task context")
+	}
+	// Verify CleanQuery has :llm instruction stripped out
+	if taskCtx.CleanQuery != "performance tips" {
+		t.Fatalf("expected CleanQuery to be 'performance tips' (without :llm), got %q", taskCtx.CleanQuery)
+	}
+	// Verify LLMInstruction field is set
+	if taskCtx.LLMInstruction != "summarize the top 5" {
+		t.Fatalf("expected LLMInstruction to be 'summarize the top 5', got %q", taskCtx.LLMInstruction)
+	}
+	// Should be in LLM mode
+	if !hasLayer(taskCtx.Layers, "LLMFilter") {
+		t.Fatalf("expected LLMFilter layer for :llm instruction, got %+v", taskCtx.Layers)
+	}
+}
+
+func TestBuildKBEnrichedQuery_UsesCleanQueryWithoutLLMToken(t *testing.T) {
+	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, nil)
+
+	// Simulate what happens in the Ask flow
+	cleanQuery := "performance tips" // This is what CleanQuery would be set to (without :llm)
+	kbResults := "CategoryPath: operations/performance\nScore: 0.95\nDescription: Performance optimization guide"
+	llmInstruction := "summarize the top 5"
+	matchCount := 1
+
+	enrichedQuery := ag.buildKBEnrichedQuery(cleanQuery, kbResults, llmInstruction, matchCount)
+
+	// Verify the enriched query contains the clean query (without :llm token)
+	if !strings.Contains(enrichedQuery, "performance tips") {
+		t.Errorf("expected enriched query to contain clean query 'performance tips', got: %s", enrichedQuery)
+	}
+	// Verify it does NOT contain the :llm token
+	if strings.Contains(enrichedQuery, ":llm") {
+		t.Errorf("expected enriched query to NOT contain ':llm' token, got: %s", enrichedQuery)
+	}
+	// Verify the instruction is included separately
+	if !strings.Contains(enrichedQuery, "summarize the top 5") {
+		t.Errorf("expected enriched query to contain instruction 'summarize the top 5', got: %s", enrichedQuery)
+	}
+	// Verify KB results are included
+	if !strings.Contains(enrichedQuery, "operations/performance") {
+		t.Errorf("expected enriched query to contain KB results, got: %s", enrichedQuery)
+	}
+}
+
+func TestTrySpecializedFocusedRouting_FlexibleHierarchyDepth(t *testing.T) {
+	ctx := context.Background()
+	sysDB := database.NewDatabase(sop.DatabaseOptions{Type: sop.Standalone, StoresFolders: []string{t.TempDir()}})
+
+	tx, err := sysDB.BeginTransaction(ctx, sop.ForWriting)
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	kb, err := sysDB.OpenKnowledgeBase(ctx, "myapp", tx, nil, nil, false)
+	if err != nil {
+		t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	}
+	if err := kb.SetConfig(ctx, &memory.KnowledgeBaseConfig{TextSearchEnabled: true, LastVectorized: 1}); err != nil {
+		t.Fatalf("SetConfig failed: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, sysDB)
+
+	testCases := []struct {
+		name          string
+		query         string
+		expectedClean string
+		expectedInstr string
+		expectLLMMode bool
+	}{
+		{
+			name:          "deep hierarchy with llm",
+			query:         "omni:myapp:cat1:subcat1.1:subsubcat1.1.1:llm summarize performance tips",
+			expectedClean: "cat1:subcat1.1:subsubcat1.1.1",
+			expectedInstr: "summarize performance tips",
+			expectLLMMode: true,
+		},
+		{
+			name:          "medium hierarchy with llm",
+			query:         "omni:myapp:cat1:subcat1.1:llm explain in detail",
+			expectedClean: "cat1:subcat1.1",
+			expectedInstr: "explain in detail",
+			expectLLMMode: true,
+		},
+		{
+			name:          "shallow hierarchy with llm",
+			query:         "omni:myapp:cat1:llm list the top 5",
+			expectedClean: "cat1",
+			expectedInstr: "list the top 5",
+			expectLLMMode: true,
+		},
+		{
+			name:          "operations path with llm",
+			query:         "omni:myapp:operations:performance:caching:llm summarize",
+			expectedClean: "operations:performance:caching",
+			expectedInstr: "summarize",
+			expectLLMMode: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			taskCtx, handled, err := ag.trySpecializedFocusedRouting(ctx, tc.query, "Omni", "Spaces", "")
+			if err != nil {
+				t.Fatalf("trySpecializedFocusedRouting failed: %v", err)
+			}
+			if !handled {
+				t.Fatal("expected specialized focused routing to handle the query")
+			}
+			if taskCtx == nil {
+				t.Fatal("expected a focused task context")
+			}
+
+			// Verify CleanQuery has :llm instruction stripped out
+			if taskCtx.CleanQuery != tc.expectedClean {
+				t.Errorf("expected CleanQuery to be %q, got %q", tc.expectedClean, taskCtx.CleanQuery)
+			}
+
+			// Verify LLMInstruction field is set
+			if taskCtx.LLMInstruction != tc.expectedInstr {
+				t.Errorf("expected LLMInstruction to be %q, got %q", tc.expectedInstr, taskCtx.LLMInstruction)
+			}
+
+			// Verify LLM mode
+			if tc.expectLLMMode && !hasLayer(taskCtx.Layers, "LLMFilter") {
+				t.Errorf("expected LLMFilter layer for :llm instruction, got %+v", taskCtx.Layers)
+			}
+		})
+	}
 }
 
 func TestClassifyFocusedTaskContext_PromptEncouragesStoreNameParsing(t *testing.T) {

--- a/ai/agent/copilot_pipeline_gate1_test.go
+++ b/ai/agent/copilot_pipeline_gate1_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -123,11 +124,23 @@ func TestClassifyFocusedTaskContext_EnforcesExplicitConstraints(t *testing.T) {
 }
 
 func TestLooksLikeSpecializedRoutingQuery_RecognizesSOPPrefixes(t *testing.T) {
+	if !looksLikeSpecializedRoutingQuery("omni:sop") {
+		t.Fatal("expected omni:sop (root KB query) to be recognized as specialized")
+	}
 	if !looksLikeSpecializedRoutingQuery("omni:sop:language:c# tutorial") {
 		t.Fatal("expected SOP-style query to be recognized as specialized")
 	}
 	if !looksLikeSpecializedRoutingQuery("omni:medical:skin diseases") {
 		t.Fatal("expected Omni custom-KB query to be recognized as specialized")
+	}
+	if !looksLikeSpecializedRoutingQuery("sop") {
+		t.Fatal("expected sop (KB name alone) to be recognized as specialized")
+	}
+	if !looksLikeSpecializedRoutingQuery("sop:category") {
+		t.Fatal("expected sop:category to be recognized as specialized")
+	}
+	if !looksLikeSpecializedRoutingQuery("sop:cat1:cat2") {
+		t.Fatal("expected sop:cat1:cat2 to be recognized as specialized")
 	}
 	if looksLikeSpecializedRoutingQuery("just a regular ask") {
 		t.Fatal("expected plain ask to stay outside specialized routing")
@@ -137,6 +150,21 @@ func TestLooksLikeSpecializedRoutingQuery_RecognizesSOPPrefixes(t *testing.T) {
 func TestRoutingKBName_UsesOmniTargetKB(t *testing.T) {
 	if got := routingKBName("omni:medical:skin diseases"); got != "medical" {
 		t.Fatalf("routingKBName() = %q, want %q", got, "medical")
+	}
+}
+
+func TestShouldRouteToOmniInsteadOfAvatar_ForKBStyleShorthand(t *testing.T) {
+	if !shouldRouteToOmniInsteadOfAvatar("sop:language bindings:c#") {
+		t.Fatal("expected shorthand KB query to be treated as Omni-focused routing")
+	}
+	if !shouldRouteToOmniInsteadOfAvatar("omni:sop:language bindings:c#") {
+		t.Fatal("expected omni-prefixed SOP routing to be treated as Omni-focused routing")
+	}
+	if shouldRouteToOmniInsteadOfAvatar("omni:medical:skin diseases") {
+		t.Fatal("expected non-SOP KB routing to remain on the normal path")
+	}
+	if shouldRouteToOmniInsteadOfAvatar("Please summarize the architecture") {
+		t.Fatal("expected a general ask to remain on the normal routing path")
 	}
 }
 
@@ -178,6 +206,68 @@ func TestTrySpecializedFocusedRouting_ShortCircuitsSOPStyleQuery(t *testing.T) {
 	}
 	if !hasLayer(taskCtx.Layers, "KBRoute") {
 		t.Fatalf("expected KBRoute layer to be attached, got %+v", taskCtx.Layers)
+	}
+}
+
+func TestEvaluateRoutingGates_HandlesBareSopQuery(t *testing.T) {
+	ctx := context.Background()
+	sysDB := database.NewDatabase(sop.DatabaseOptions{Type: sop.Standalone, StoresFolders: []string{t.TempDir()}})
+
+	tx, err := sysDB.BeginTransaction(ctx, sop.ForWriting)
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	kb, err := sysDB.OpenKnowledgeBase(ctx, "sop", tx, nil, nil, false)
+	if err != nil {
+		t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	}
+	if err := kb.SetConfig(ctx, &memory.KnowledgeBaseConfig{TextSearchEnabled: true, LastVectorized: 1}); err != nil {
+		t.Fatalf("SetConfig failed: %v", err)
+	}
+	if err := kb.IngestThought(ctx, "Getting Started", "installation/setup", "Omni", nil, map[string]any{"description": "setup guide"}); err != nil {
+		t.Fatalf("IngestThought failed: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, sysDB)
+	if ag.service == nil {
+		ag.service = &Service{}
+	}
+	ag.service.session = &RunnerSession{MRU: []MRUItem{}}
+
+	ctx = context.WithValue(ctx, "session_payload", &ai.SessionPayload{Variables: make(map[string]any)})
+
+	tests := []struct {
+		name                string
+		query               string
+		expectDirectDisplay bool
+	}{
+		{"bare sop", "sop", true},
+		{"sop with colon", "sop:", true},
+		{"sop with category", "sop:installation", false}, // No results, so not direct display
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			taskCtx, err := ag.evaluateRoutingGates(ctx, tc.query, nil)
+			if err != nil {
+				t.Fatalf("evaluateRoutingGates failed: %v", err)
+			}
+			if taskCtx == nil {
+				t.Fatal("expected a routing classification for sop query")
+			}
+			if taskCtx.RoutingGate != RoutingGateFocused {
+				t.Fatalf("expected specialized focused routing gate, got %q", taskCtx.RoutingGate)
+			}
+			if !hasLayer(taskCtx.Layers, "KBRoute") {
+				t.Fatalf("expected KBRoute layer to be attached, got %+v", taskCtx.Layers)
+			}
+			if taskCtx.DirectDisplay != tc.expectDirectDisplay {
+				t.Fatalf("expected direct display=%v, got %v", tc.expectDirectDisplay, taskCtx.DirectDisplay)
+			}
+		})
 	}
 }
 
@@ -274,6 +364,246 @@ func TestTrySpecializedFocusedRouting_StripsLLMInstructionWithoutCategoryPath(t 
 	}
 }
 
+func TestExtractPageNumber_SupportsColonAndSlashSeparators(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantQuery string
+		wantPage  int
+	}{
+		{name: "colon separator", query: "omni:sop:page:3", wantQuery: "omni:sop", wantPage: 3},
+		{name: "slash separator", query: "omni:sop/page/2", wantQuery: "omni:sop", wantPage: 2},
+		{name: "mixed path with slash page", query: "omni:sop:language/page/4", wantQuery: "omni:sop:language", wantPage: 4},
+		{name: "defaults when no page suffix", query: "omni:sop:language", wantQuery: "omni:sop:language", wantPage: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotQuery, gotPage := extractPageNumber(tc.query)
+			if gotQuery != tc.wantQuery {
+				t.Fatalf("extractPageNumber(%q) query = %q, want %q", tc.query, gotQuery, tc.wantQuery)
+			}
+			if gotPage != tc.wantPage {
+				t.Fatalf("extractPageNumber(%q) page = %d, want %d", tc.query, gotPage, tc.wantPage)
+			}
+		})
+	}
+}
+
+func TestGetSubcategories_PaginatesAndReportsPageCount(t *testing.T) {
+	ctx := context.Background()
+	sysDB := database.NewDatabase(sop.DatabaseOptions{Type: sop.Standalone, StoresFolders: []string{t.TempDir()}})
+
+	tx, err := sysDB.BeginTransaction(ctx, sop.ForWriting)
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+
+	kb, err := sysDB.OpenKnowledgeBase(ctx, "demo", tx, nil, nil, false)
+	if err != nil {
+		t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	}
+
+	for i := 1; i <= 25; i++ {
+		cat := &memory.Category{
+			ID:        sop.NewUUID(),
+			Name:      fmt.Sprintf("Cat%02d", i),
+			Path:      fmt.Sprintf("cat%02d", i),
+			ItemCount: i,
+		}
+		if _, err := kb.Store.AddCategory(ctx, cat); err != nil {
+			t.Fatalf("AddCategory(%d) failed: %v", i, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, sysDB)
+	text, err := ag.getSubcategories(ctx, sysDB, "demo", "", 2)
+	if err != nil {
+		t.Fatalf("getSubcategories failed: %v", err)
+	}
+
+	if !strings.Contains(text, "Page 2 of 2") {
+		t.Fatalf("expected pagination header to report total pages, got: %s", text)
+	}
+	if !strings.Contains(text, "showing 21-25 of 25") {
+		t.Fatalf("expected page range to show 21-25 of 25, got: %s", text)
+	}
+	if !strings.Contains(text, "Previous: omni:demo:page:1") {
+		t.Fatalf("expected previous page hint, got: %s", text)
+	}
+}
+
+func TestTrySpecializedFocusedRouting_ShowsRootCategoriesForOmniKBQuery(t *testing.T) {
+	ctx := context.Background()
+	sysDB := database.NewDatabase(sop.DatabaseOptions{Type: sop.Standalone, StoresFolders: []string{t.TempDir()}})
+
+	tx, err := sysDB.BeginTransaction(ctx, sop.ForWriting)
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+
+	kb, err := sysDB.OpenKnowledgeBase(ctx, "sop", tx, nil, nil, false)
+	if err != nil {
+		t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	}
+	if err := kb.SetConfig(ctx, &memory.KnowledgeBaseConfig{TextSearchEnabled: true, LastVectorized: 1}); err != nil {
+		t.Fatalf("SetConfig failed: %v", err)
+	}
+
+	// Add some root categories
+	for _, name := range []string{"Language", "Operations", "Architecture"} {
+		cat := &memory.Category{
+			ID:        sop.NewUUID(),
+			Name:      name,
+			Path:      strings.ToLower(name),
+			ItemCount: 10,
+		}
+		if _, err := kb.Store.AddCategory(ctx, cat); err != nil {
+			t.Fatalf("AddCategory(%s) failed: %v", name, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, sysDB)
+
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{name: "omni:KB pattern", query: "omni:sop"},
+		{name: "direct KB name", query: "sop"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			taskCtx, handled, err := ag.trySpecializedFocusedRouting(ctx, tc.query, "Omni", "Spaces", "")
+			if err != nil {
+				t.Fatalf("trySpecializedFocusedRouting failed: %v", err)
+			}
+			if !handled {
+				t.Fatalf("expected specialized focused routing to handle %q query", tc.query)
+			}
+			if taskCtx == nil {
+				t.Fatal("expected a focused task context")
+			}
+			if !hasLayer(taskCtx.Layers, "KBRoute") {
+				t.Fatalf("expected KBRoute layer to be attached, got %+v", taskCtx.Layers)
+			}
+			// Should be direct display (subcategories/root categories)
+			if !taskCtx.DirectDisplay {
+				t.Fatal("expected DirectDisplay to be true for root category navigation")
+			}
+		})
+	}
+}
+
+func TestTrySpecializedFocusedRouting_SupportsDirectSOPPathQueries(t *testing.T) {
+	ctx := context.Background()
+	sysDB := database.NewDatabase(sop.DatabaseOptions{Type: sop.Standalone, StoresFolders: []string{t.TempDir()}})
+
+	tx, err := sysDB.BeginTransaction(ctx, sop.ForWriting)
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+
+	kb, err := sysDB.OpenKnowledgeBase(ctx, "sop", tx, nil, nil, false)
+	if err != nil {
+		t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	}
+	if err := kb.SetConfig(ctx, &memory.KnowledgeBaseConfig{TextSearchEnabled: true, LastVectorized: 1}); err != nil {
+		t.Fatalf("SetConfig failed: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, sysDB)
+
+	testCases := []struct {
+		name         string
+		query        string
+		expectedPath string
+	}{
+		{name: "single level", query: "sop:language", expectedPath: "language"},
+		{name: "multi level", query: "sop:language:c#", expectedPath: "language/c#"},
+		{name: "deep path", query: "sop:operations:performance:caching", expectedPath: "operations/performance/caching"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			taskCtx, handled, err := ag.trySpecializedFocusedRouting(ctx, tc.query, "Omni", "Spaces", "")
+			if err != nil {
+				t.Fatalf("trySpecializedFocusedRouting failed: %v", err)
+			}
+			if !handled {
+				t.Fatalf("expected specialized focused routing to handle %q query", tc.query)
+			}
+			if taskCtx == nil {
+				t.Fatal("expected a focused task context")
+			}
+			if !hasLayer(taskCtx.Layers, "KBRoute") {
+				t.Fatalf("expected KBRoute layer to be attached, got %+v", taskCtx.Layers)
+			}
+		})
+	}
+}
+
+func TestFormatKBSourceLinks_RendersEveryDocIDAsClickableLink(t *testing.T) {
+	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, nil)
+
+	ctx := context.WithValue(context.Background(), ai.CtxKeyAppBaseURL, "https://example.test")
+	links := ag.formatKBSourceLinks(ctx, memory.DocIDs{"doc-1", "https://example.test/doc-2"})
+
+	if !strings.Contains(links, "https://example.test/viewer?docID=doc-1") {
+		t.Fatalf("expected first doc ID to be rendered as an absolute link, got: %s", links)
+	}
+	if !strings.Contains(links, "https://example.test/viewer?docID=https%3A%2F%2Fexample.test%2Fdoc-2") {
+		t.Fatalf("expected encoded external doc ID to be rendered as an absolute link, got: %s", links)
+	}
+	if strings.Count(links, "[") != 2 {
+		t.Fatalf("expected two clickable links, got: %s", links)
+	}
+}
+
+func TestFormatKBSearchResultsForDisplay_HandlesCategories(t *testing.T) {
+	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, nil)
+
+	// Test category navigation output (matchCount = 0)
+	categoryResults := "Available Categories: (3 total)\n\n• Language (10 items)\n  Navigate: omni:sop:language"
+	output := ag.formatKBSearchResultsForDisplay(categoryResults, 0)
+
+	// Should NOT have "Found 0 knowledge base matches"
+	if strings.Contains(output, "Found 0 knowledge base matches") {
+		t.Errorf("expected category navigation to not show 'Found 0 matches', got: %s", output)
+	}
+
+	// Should contain the category results
+	if !strings.Contains(output, "Available Categories:") {
+		t.Errorf("expected output to contain category results, got: %s", output)
+	}
+
+	// Should use real newlines, not escaped ones
+	if strings.Contains(output, "\\n") {
+		t.Errorf("expected real newlines, not escaped ones, got: %s", output)
+	}
+
+	// Test regular search results output (matchCount > 0)
+	searchResults := "CategoryPath: language/go\nScore: 0.95"
+	output2 := ag.formatKBSearchResultsForDisplay(searchResults, 3)
+
+	// Should have "Found 3 knowledge base matches"
+	if !strings.Contains(output2, "Found 3 knowledge base matches") {
+		t.Errorf("expected search results to show match count, got: %s", output2)
+	}
+}
+
 func TestBuildKBEnrichedQuery_UsesCleanQueryWithoutLLMToken(t *testing.T) {
 	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, nil)
 
@@ -300,6 +630,10 @@ func TestBuildKBEnrichedQuery_UsesCleanQueryWithoutLLMToken(t *testing.T) {
 	// Verify KB results are included
 	if !strings.Contains(enrichedQuery, "operations/performance") {
 		t.Errorf("expected enriched query to contain KB results, got: %s", enrichedQuery)
+	}
+	// Verify the prompt explicitly tells the model to preserve absolute source links
+	if !strings.Contains(enrichedQuery, "Preserve the exact markdown source links") {
+		t.Errorf("expected enriched query to preserve source links, got: %s", enrichedQuery)
 	}
 }
 

--- a/ai/agent/copilot_pipeline_gate1_test.go
+++ b/ai/agent/copilot_pipeline_gate1_test.go
@@ -126,8 +126,17 @@ func TestLooksLikeSpecializedRoutingQuery_RecognizesSOPPrefixes(t *testing.T) {
 	if !looksLikeSpecializedRoutingQuery("omni:sop:language:c# tutorial") {
 		t.Fatal("expected SOP-style query to be recognized as specialized")
 	}
+	if !looksLikeSpecializedRoutingQuery("omni:medical:skin diseases") {
+		t.Fatal("expected Omni custom-KB query to be recognized as specialized")
+	}
 	if looksLikeSpecializedRoutingQuery("just a regular ask") {
 		t.Fatal("expected plain ask to stay outside specialized routing")
+	}
+}
+
+func TestRoutingKBName_UsesOmniTargetKB(t *testing.T) {
+	if got := routingKBName("omni:medical:skin diseases"); got != "medical" {
+		t.Fatalf("routingKBName() = %q, want %q", got, "medical")
 	}
 }
 

--- a/ai/agent/copilot_pipeline_test.go
+++ b/ai/agent/copilot_pipeline_test.go
@@ -527,7 +527,10 @@ func TestCopilotPipeline_Phases(t *testing.T) {
 
 	// --- Phase 2: Domain Classification ---
 	fakeGen.Response = `{"domain": "Spaces"}` // Simulate LLM returning 'Spaces' domain
-	taskCtx := ag.evaluateRoutingGates(ctx, query, fakeGen)
+	taskCtx, err := ag.evaluateRoutingGates(ctx, query, fakeGen)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if taskCtx == nil {
 		t.Fatalf("Expected non-nil TaskContextClassification")
 	}

--- a/ai/agent/copilot_routing.go
+++ b/ai/agent/copilot_routing.go
@@ -28,11 +28,13 @@ func isRoutingTestGenerator(gen ai.Generator) bool {
 }
 
 func parseRoutingAnchor(query string) *routingAnchor {
+
+	log.Info("query: ", "query", query)
 	parts := strings.Split(query, ":")
 	if len(parts) <= 1 {
 		return nil
 	}
-	if !(strings.EqualFold(parts[0], "omni") || strings.EqualFold(parts[0], "medical") || strings.EqualFold(parts[0], "support")) {
+	if !(strings.EqualFold(parts[0], "omni")) {
 		return nil
 	}
 	anchor := &routingAnchor{
@@ -45,6 +47,9 @@ func parseRoutingAnchor(query string) *routingAnchor {
 	if len(parts) >= 3 {
 		anchor.artifact = strings.TrimSpace(parts[2])
 	}
+
+	log.Info("anchor ", "anchor", anchor)
+
 	anchor.taskCtx = enrichFocusedTaskContext(nil, anchor.entity, anchor.domain, anchor.artifact)
 	return anchor
 }
@@ -94,16 +99,20 @@ func (a *CopilotAgent) tryPathStyleRouting(ctx context.Context, query string) *T
 	return taskCtx
 }
 
-func (a *CopilotAgent) tryPrefixBasedRouting(ctx context.Context, query string, gen ai.Generator, isTest bool, anchor *routingAnchor) *TaskContextClassification {
+func (a *CopilotAgent) tryPrefixBasedRouting(ctx context.Context, query string, gen ai.Generator, isTest bool, anchor *routingAnchor) (*TaskContextClassification, error) {
 	if anchor == nil {
-		return nil
+		return nil, nil
 	}
 
 	log.Info("Prefix-Based Routing Activated", "prefix", anchor.prefix)
 
 	var taskCtx *TaskContextClassification
 	if !isTest && gen != nil {
-		taskCtx, _ = a.ClassifyFocusedTaskContext(ctx, query, anchor.entity, anchor.domain, anchor.artifact, gen)
+		var err error
+		taskCtx, err = a.ClassifyFocusedTaskContext(ctx, query, anchor.entity, anchor.domain, anchor.artifact, gen)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	taskCtx = enrichFocusedTaskContext(taskCtx, anchor.entity, anchor.domain, anchor.artifact)
@@ -122,17 +131,17 @@ func (a *CopilotAgent) tryPrefixBasedRouting(ctx context.Context, query string, 
 	annotateTaskContextIntent(taskCtx, query)
 	taskCtx.RoutingGate = RoutingGateFocused
 	a.persistRoutingState(ctx, taskCtx)
-	return taskCtx
+	return taskCtx, nil
 }
 
-func (a *CopilotAgent) tryAskContinuationBasedRouting(ctx context.Context, query string, gen ai.Generator, isTest bool, anchor *routingAnchor) *TaskContextClassification {
+func (a *CopilotAgent) tryAskContinuationBasedRouting(ctx context.Context, query string, gen ai.Generator, isTest bool, anchor *routingAnchor) (*TaskContextClassification, error) {
 	p := ai.GetSessionPayload(ctx)
 	if p == nil || p.Variables == nil {
-		return nil
+		return nil, nil
 	}
 	rs, ok := p.Variables["RoutingState"].(*TaskContextClassification)
 	if !ok || rs == nil {
-		return nil
+		return nil, nil
 	}
 
 	if !isTest && gen != nil {
@@ -144,42 +153,42 @@ func (a *CopilotAgent) tryAskContinuationBasedRouting(ctx context.Context, query
 		if err == nil && isSwitch {
 			log.Info("Ask-Continuation Routing Detected Topic Switch. Falling through to Cold-Start Routing.")
 			a.resetRoutingForTopicSwitch(query, p)
-			return nil
+			return nil, nil
 		}
 		if err == nil && updatedRS != nil {
 			log.Info("Ask-Continuation Routing Activated: Inheriting MRU Context with Updates", "domain", updatedRS.Domain)
 			annotateTaskContextIntent(updatedRS, query)
 			updatedRS.RoutingGate = RoutingGateContinuity
 			a.persistRoutingState(ctx, updatedRS)
-			return updatedRS
+			return updatedRS, nil
 		}
-		return nil
+		return nil, err
 	}
 
 	log.Info("Ask-Continuation Routing Activated: Inheriting MRU Context (Test Mode)", "domain", rs.Domain)
 	annotateTaskContextIntent(rs, query)
 	rs.RoutingGate = RoutingGateContinuity
 	a.persistRoutingState(ctx, rs)
-	return rs
+	return rs, nil
 }
 
-func (a *CopilotAgent) tryColdStartBasedRouting(ctx context.Context, query string, gen ai.Generator, isTest bool) *TaskContextClassification {
+func (a *CopilotAgent) tryColdStartBasedRouting(ctx context.Context, query string, gen ai.Generator, isTest bool) (*TaskContextClassification, error) {
 	if len(strings.Split(query, ":")) == 1 {
 		log.Info("Cold-Start Routing Activated")
 	}
 	if gen == nil || isTest {
-		return nil
+		return nil, nil
 	}
 
 	taskCtx, err := a.ClassifyTaskContext(ctx, query, gen)
 	if err != nil || taskCtx == nil {
 		log.Warn("Cold-start routing classification failed or returned nil", "error", err)
-		return nil
+		return nil, err
 	}
 
 	log.Info("Cold-start routing classification success", "domain", taskCtx.Domain)
 	annotateTaskContextIntent(taskCtx, query)
 	taskCtx.RoutingGate = RoutingGateDiscovery
 	a.persistRoutingState(ctx, taskCtx)
-	return taskCtx
+	return taskCtx, nil
 }

--- a/ai/agent/copilot_routing_gates_test.go
+++ b/ai/agent/copilot_routing_gates_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sharedcode/sop"
 	"github.com/sharedcode/sop/ai"
 	"github.com/sharedcode/sop/ai/database"
+	"github.com/sharedcode/sop/ai/memory"
 )
 
 type RouterTestGen struct {
@@ -37,10 +38,25 @@ func (m *RouterTestGen) PrewarmCache(ctx context.Context, opts ai.GenOptions) er
 	return nil
 }
 
-func TestEvaluateRoutingGates_ColdStartFallbackClassifiesDeepPathQueries(t *testing.T) {
+func TestEvaluateRoutingGates_SpecializedRoutingHandlesDeepPathQueries(t *testing.T) {
 	ctx := context.Background()
 	sysDBOptions := sop.DatabaseOptions{Type: sop.Standalone, StoresFolders: []string{t.TempDir()}}
 	sysDB := database.NewDatabase(sysDBOptions)
+
+	tx, err := sysDB.BeginTransaction(ctx, sop.ForWriting)
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	kb, err := sysDB.OpenKnowledgeBase(ctx, "sop", tx, nil, nil, false)
+	if err != nil {
+		t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	}
+	if err := kb.SetConfig(ctx, &memory.KnowledgeBaseConfig{TextSearchEnabled: true, LastVectorized: 1}); err != nil {
+		t.Fatalf("SetConfig failed: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
 
 	ag := NewCopilotAgent(Config{}, map[string]sop.DatabaseOptions{}, sysDB)
 	if ag.service == nil {
@@ -48,24 +64,20 @@ func TestEvaluateRoutingGates_ColdStartFallbackClassifiesDeepPathQueries(t *test
 	}
 	ag.service.session = &RunnerSession{MRU: []MRUItem{}}
 
-	gen := &RouterTestGen{Response: `{"entity": "Omni", "domain": "Discovery", "db_artifacts": [], "layers": []}`}
 	ctx = context.WithValue(ctx, "session_payload", &ai.SessionPayload{Variables: make(map[string]any)})
 
-	taskCtx, err := ag.evaluateRoutingGates(ctx, "SOP:language/c#/tutorial", gen)
+	taskCtx, err := ag.evaluateRoutingGates(ctx, "SOP:language/c#/tutorial", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if taskCtx == nil {
 		t.Fatalf("expected a routing classification for deep path query")
 	}
-	if got := taskCtx.RoutingGate; got != RoutingGateDiscovery {
-		t.Fatalf("expected the reverted cold-start classifier path to classify deep path query as discovery, got %q", got)
+	if got := taskCtx.RoutingGate; got != RoutingGateFocused {
+		t.Fatalf("expected specialized focused routing to handle SOP path query, got %q", got)
 	}
-	if got := taskCtx.Domain; got != "Discovery" {
-		t.Fatalf("expected the cold-start classifier to preserve the discovered domain, got %q", got)
-	}
-	if got := taskCtx.Entity; got != "Omni" {
-		t.Fatalf("expected the cold-start classifier to preserve the entity, got %q", got)
+	if !hasLayer(taskCtx.Layers, "KBRoute") {
+		t.Fatalf("expected KBRoute layer for specialized KB routing, got %+v", taskCtx.Layers)
 	}
 }
 

--- a/ai/agent/copilot_routing_gates_test.go
+++ b/ai/agent/copilot_routing_gates_test.go
@@ -51,7 +51,10 @@ func TestEvaluateRoutingGates_ColdStartFallbackClassifiesDeepPathQueries(t *test
 	gen := &RouterTestGen{Response: `{"entity": "Omni", "domain": "Discovery", "db_artifacts": [], "layers": []}`}
 	ctx = context.WithValue(ctx, "session_payload", &ai.SessionPayload{Variables: make(map[string]any)})
 
-	taskCtx := ag.evaluateRoutingGates(ctx, "SOP:language/c#/tutorial", gen)
+	taskCtx, err := ag.evaluateRoutingGates(ctx, "SOP:language/c#/tutorial", gen)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if taskCtx == nil {
 		t.Fatalf("expected a routing classification for deep path query")
 	}
@@ -93,7 +96,10 @@ func TestThreeGates_RoutingArchitecture(t *testing.T) {
 		ctx = context.WithValue(ctx, "session_payload", payload)
 
 		query := "Omni:Stores:TestStore"
-		taskCtx := ag.evaluateRoutingGates(ctx, query, gen)
+		taskCtx, err := ag.evaluateRoutingGates(ctx, query, gen)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if taskCtx == nil {
 			t.Fatal("Gate 1 expected a routing classification")
@@ -130,7 +136,10 @@ func TestThreeGates_RoutingArchitecture(t *testing.T) {
 		ctx = context.WithValue(ctx, "session_payload", payload)
 
 		query := "Keep going but use TestInherited"
-		taskCtx := ag.evaluateRoutingGates(ctx, query, gen)
+		taskCtx, err := ag.evaluateRoutingGates(ctx, query, gen)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if taskCtx == nil {
 			t.Fatal("Gate 2 expected a routing classification")
@@ -140,9 +149,6 @@ func TestThreeGates_RoutingArchitecture(t *testing.T) {
 		}
 		if taskCtx.RoutingGate == "" {
 			t.Errorf("Gate 2 should mark a routing gate, got %+v", taskCtx)
-		}
-		if taskCtx == nil {
-			t.Fatal("Gate 2 expected a routing classification")
 		}
 		if toolsCtx := ag.getSystemToolsContext(ctx); toolsCtx != "" {
 			t.Fatalf("expected Gate 2 continuity classification to avoid system tool injection, got %q", toolsCtx)
@@ -167,7 +173,10 @@ func TestThreeGates_RoutingArchitecture(t *testing.T) {
 		ag.markMRUCategoryWithSource("PERSONA_omni", "durable persona", MRUSourcePersona)
 
 		query := "Nevermind, let's create a New App"
-		taskCtx := ag.evaluateRoutingGates(ctx, query, gen)
+		taskCtx, err := ag.evaluateRoutingGates(ctx, query, gen)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if taskCtx == nil {
 			t.Fatal("Gate 2 expected a routing classification")
@@ -196,7 +205,10 @@ func TestThreeGates_RoutingArchitecture(t *testing.T) {
 		ctx = context.WithValue(ctx, "session_payload", payload)
 
 		query := "Cold start query"
-		taskCtx := ag.evaluateRoutingGates(ctx, query, gen)
+		taskCtx, err := ag.evaluateRoutingGates(ctx, query, gen)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if taskCtx == nil {
 			t.Fatal("Gate 3 expected a routing classification")
@@ -224,7 +236,10 @@ func TestThreeGates_RoutingArchitecture(t *testing.T) {
 			Layers:      []LayerInfo{{Name: "Single-Domain", CRUD: []string{"R"}}},
 		})
 
-		taskCtx := ag.evaluateRoutingGates(ctx, "show users again", gen)
+		taskCtx, err := ag.evaluateRoutingGates(ctx, "show users again", gen)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if taskCtx == nil {
 			t.Fatalf("expected a routing classification after STM rehydration, got %+v", taskCtx)
 		}

--- a/ai/agent/copilottools.routing.go
+++ b/ai/agent/copilottools.routing.go
@@ -49,7 +49,7 @@ func (a *CopilotAgent) toolSearchKB(ctx context.Context, args map[string]any) (s
 		return "", fmt.Errorf("could not resolve DB for KB '%s'", kbName)
 	}
 
-	return a.searchKnowledgeBase(ctx, db, kbName, query, "", "", true, limit)
+	return a.searchKnowledgeBase(ctx, db, kbName, query, "", "", limit)
 }
 
 func (a *CopilotAgent) toolHandoffToAvatar(ctx context.Context, args map[string]any) (string, error) {

--- a/ai/agent/copilottools.search.go
+++ b/ai/agent/copilottools.search.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	log "log/slog"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/sharedcode/sop"
@@ -96,6 +97,52 @@ func extractCategoryPathQuery(query string) string {
 	}
 
 	return ""
+}
+
+// stripLLMInstruction extracts and removes the :llm <instruction> suffix from any query
+// Returns (cleanQuery, instruction) where cleanQuery has the :llm part removed
+func stripLLMInstruction(query string) (string, string) {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return "", ""
+	}
+
+	re := regexp.MustCompile(`(?i)^(?P<query>.+?)(?:\s*:\s*llm\b\s*(?P<instruction>.*))?$`)
+	matches := re.FindStringSubmatch(trimmed)
+	if len(matches) != 3 {
+		return trimmed, ""
+	}
+
+	cleanQuery := strings.TrimSpace(matches[1])
+	instruction := strings.TrimSpace(matches[2])
+	return cleanQuery, instruction
+}
+
+// extractPageNumber extracts and removes the :page:<number> or /page/<number> suffix from a query
+// Returns (cleanQuery, pageNumber) where pageNumber is 1 if not specified
+func extractPageNumber(query string) (string, int) {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return "", 1
+	}
+
+	// Match :page:<number> or /page/<number> at the end (case insensitive)
+	// Supports both : and / as separators (e.g., :page:2 or /page/2)
+	re := regexp.MustCompile(`(?i)^(?P<query>.+?)(?:\s*[:/]\s*page\s*[:/]\s*(?P<page>\d+))$`)
+	matches := re.FindStringSubmatch(trimmed)
+	if len(matches) != 3 {
+		return trimmed, 1
+	}
+
+	cleanQuery := strings.TrimSpace(matches[1])
+	pageStr := strings.TrimSpace(matches[2])
+
+	page := 1
+	if pageNum, err := strconv.Atoi(pageStr); err == nil && pageNum > 0 {
+		page = pageNum
+	}
+
+	return cleanQuery, page
 }
 
 func splitCategoryPathInstruction(query string) (string, string) {
@@ -228,6 +275,209 @@ func extractHitCategory(v any) string {
 		}
 	}
 	return ""
+}
+
+// getSubcategories retrieves subcategories for navigation display with pagination support.
+// If categoryPath is empty, it returns root categories (categories with no parents).
+// If categoryPath is provided, it returns children of that category.
+// page parameter controls pagination (1-based, 0 or negative means page 1).
+func (a *CopilotAgent) getSubcategories(ctx context.Context, db *database.Database, kbName string, categoryPath string, page int) (string, error) {
+	if db == nil {
+		return "", fmt.Errorf("database is null")
+	}
+
+	if page <= 0 {
+		page = 1
+	}
+
+	tx, err := db.BeginTransaction(ctx, sop.ForReading)
+	if err != nil {
+		return "", fmt.Errorf("failed to begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var embedder ai.Embeddings
+	if a.service != nil && a.service.Domain() != nil && a.service.Domain().Embedder() != nil {
+		embedder = a.service.Domain().Embedder()
+	}
+
+	kb, err := db.OpenKnowledgeBase(ctx, kbName, tx, a.brain, embedder, false)
+	if err != nil {
+		return "", fmt.Errorf("failed to open kb %s: %w", kbName, err)
+	}
+
+	categoriesTree, err := kb.Store.Categories(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get categories tree: %w", err)
+	}
+
+	var targetCategories []*memory.Category
+
+	// If no category path, get root categories (categories with no parents)
+	if categoryPath == "" {
+		// Scan all categories to find roots
+		ok, err := categoriesTree.First(ctx)
+		if err != nil {
+			return "", err
+		}
+		for ok {
+			cat, err := categoriesTree.GetCurrentValue(ctx)
+			if err != nil {
+				return "", err
+			}
+			// Root categories have no parents
+			if len(cat.ParentIDs) == 0 {
+				targetCategories = append(targetCategories, cat)
+			}
+			ok, err = categoriesTree.Next(ctx)
+			if err != nil {
+				return "", err
+			}
+		}
+	} else {
+		// Find the category by path and get its children
+		catsByPath, err := kb.Store.CategoriesByPath(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to get categories by path: %w", err)
+		}
+
+		found, err := catsByPath.Find(ctx, categoryPath, false)
+		if err != nil {
+			return "", fmt.Errorf("failed to find category by path: %w", err)
+		}
+		if !found {
+			return fmt.Sprintf("Category path '%s' not found.", categoryPath), nil
+		}
+
+		catID, err := catsByPath.GetCurrentValue(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to get category ID: %w", err)
+		}
+
+		ok, err := categoriesTree.Find(ctx, catID, false)
+		if err != nil || !ok {
+			return fmt.Sprintf("Category path '%s' not found.", categoryPath), nil
+		}
+
+		parentCat, err := categoriesTree.GetCurrentValue(ctx)
+		if err != nil {
+			return "", err
+		}
+
+		// Get children of this category
+		for _, childID := range parentCat.ChildrenIDs {
+			ok, err := categoriesTree.Find(ctx, childID, false)
+			if err != nil {
+				continue
+			}
+			if ok {
+				childCat, err := categoriesTree.GetCurrentValue(ctx)
+				if err != nil {
+					continue
+				}
+				targetCategories = append(targetCategories, childCat)
+			}
+		}
+	}
+
+	if len(targetCategories) == 0 {
+		if categoryPath == "" {
+			return "No root categories found in this knowledge base.", nil
+		}
+		return fmt.Sprintf("No subcategories found under '%s'.", categoryPath), nil
+	}
+
+	// Apply pagination
+	const pageSize = 20
+	totalCategories := len(targetCategories)
+	totalPages := (totalCategories + pageSize - 1) / pageSize // Ceiling division
+
+	// Clamp page to valid range
+	if page > totalPages {
+		page = totalPages
+	}
+
+	// Calculate slice bounds
+	startIdx := (page - 1) * pageSize
+	endIdx := startIdx + pageSize
+	if endIdx > totalCategories {
+		endIdx = totalCategories
+	}
+
+	displayCategories := targetCategories[startIdx:endIdx]
+
+	// Format subcategories for display
+	var results []string
+	header := "Available Categories:"
+	if categoryPath != "" {
+		header = fmt.Sprintf("Subcategories under '%s':", categoryPath)
+	}
+
+	// Add page info if multiple pages exist
+	if totalPages > 1 {
+		header = fmt.Sprintf("%s (Page %d of %d, showing %d-%d of %d)",
+			header, page, totalPages, startIdx+1, endIdx, totalCategories)
+	} else if totalCategories > 0 {
+		header = fmt.Sprintf("%s (%d total)", header, totalCategories)
+	}
+
+	results = append(results, header)
+	results = append(results, "")
+
+	for _, cat := range displayCategories {
+		name := cat.Name
+		if name == "" {
+			name = cat.Path
+		}
+		itemInfo := fmt.Sprintf("%d items", cat.ItemCount)
+		subcatInfo := ""
+		if len(cat.ChildrenIDs) > 0 {
+			subcatInfo = fmt.Sprintf(", %d subcategories", len(cat.ChildrenIDs))
+		}
+
+		description := ""
+		if cat.Description != "" {
+			description = fmt.Sprintf("\n  %s", cat.Description)
+		}
+
+		// Show the path to navigate to this category
+		navPath := cat.Path
+		if navPath == "" {
+			navPath = cat.Name
+		}
+
+		results = append(results, fmt.Sprintf("• %s (%s%s)%s\n  Navigate: omni:%s:%s",
+			name, itemInfo, subcatInfo, description, kbName, navPath))
+	}
+
+	// Add pagination navigation if multiple pages exist
+	if totalPages > 1 {
+		results = append(results, "")
+		var navHints []string
+
+		pathPrefix := fmt.Sprintf("omni:%s", kbName)
+		if categoryPath != "" {
+			pathPrefix = fmt.Sprintf("%s:%s", pathPrefix, categoryPath)
+		}
+
+		if page > 1 {
+			navHints = append(navHints, fmt.Sprintf("Previous: %s:page:%d", pathPrefix, page-1))
+		}
+		if page < totalPages {
+			navHints = append(navHints, fmt.Sprintf("Next: %s:page:%d", pathPrefix, page+1))
+		}
+
+		if len(navHints) > 0 {
+			results = append(results, strings.Join(navHints, " | "))
+		}
+
+		// Also suggest LLM filtering for large sets
+		if totalCategories > 40 {
+			results = append(results, fmt.Sprintf("💡 Tip: Use `%s:llm list categories matching <name>` to filter results.", pathPrefix))
+		}
+	}
+
+	return strings.Join(results, "\n"), nil
 }
 
 func (a *CopilotAgent) resolveDBForKB(ctx context.Context, kbName string) *database.Database {

--- a/ai/agent/copilottools.search.go
+++ b/ai/agent/copilottools.search.go
@@ -47,6 +47,22 @@ func stripRoutingPrefix(query, kbName string) string {
 	return strings.TrimSpace(trimmed)
 }
 
+func normalizeCategoryPathSeparators(query string) string {
+	trimmed := strings.TrimSpace(query)
+	trimmed = strings.Trim(trimmed, "\"'`")
+	if trimmed == "" {
+		return trimmed
+	}
+
+	match := regexp.MustCompile(`(?i)^(?P<path>.+?)(?:\s*:\s*llm\b\s*(?P<instruction>.*))?$`).FindStringSubmatch(trimmed)
+	if len(match) == 3 {
+		path := strings.TrimSpace(match[1])
+		return strings.ReplaceAll(path, ":", "/")
+	}
+
+	return strings.ReplaceAll(trimmed, ":", "/")
+}
+
 func looksLikeCategoryPath(query string) bool {
 	trimmed := strings.TrimSpace(query)
 	trimmed = strings.Trim(trimmed, "\"'`")
@@ -54,8 +70,9 @@ func looksLikeCategoryPath(query string) bool {
 		return false
 	}
 
-	if strings.ContainsAny(trimmed, "/\\") {
-		parts := strings.FieldsFunc(trimmed, func(r rune) bool {
+	normalized := normalizeCategoryPathSeparators(trimmed)
+	if strings.ContainsAny(normalized, "/\\") {
+		parts := strings.FieldsFunc(normalized, func(r rune) bool {
 			return r == '/' || r == '\\'
 		})
 		return len(parts) >= 2
@@ -73,8 +90,9 @@ func extractCategoryPathQuery(query string) string {
 		return path
 	}
 
-	if strings.Contains(trimmed, "/") || strings.Contains(trimmed, "\\") {
-		return trimmed
+	normalized := normalizeCategoryPathSeparators(trimmed)
+	if strings.Contains(normalized, "/") || strings.Contains(normalized, "\\") {
+		return normalized
 	}
 
 	return ""
@@ -97,37 +115,23 @@ func splitCategoryPathInstruction(query string) (string, string) {
 
 	path := strings.TrimSpace(matches[1])
 	instruction := strings.TrimSpace(matches[2])
-	if path == "" || !looksLikeCategoryPath(path) {
+	normalizedPath := normalizeCategoryPathSeparators(path)
+	if normalizedPath == "" || !looksLikeCategoryPath(normalizedPath) {
 		return "", ""
 	}
 
-	return path, instruction
+	return normalizedPath, instruction
 }
 
-func embedCategoryPath(ctx context.Context, catPath string, embedder ai.Embeddings) ([][]float32, error) {
-	parts := strings.Split(catPath, "/")
-	if len(parts) == 0 || (len(parts) == 1 && strings.TrimSpace(parts[0]) == "") {
-		parts = strings.Split(catPath, "\\")
-	}
-	if len(parts) == 0 || (len(parts) == 1 && strings.TrimSpace(parts[0]) == "") {
-		return nil, nil
-	}
-	vecs, err := embedder.EmbedTexts(ctx, parts)
-	if err != nil {
-		return nil, err
-	}
-	return vecs, nil
-}
-
-func (a *CopilotAgent) searchKnowledgeBase(ctx context.Context, db *database.Database, kbName string, query string, catPath string, category string, textSearchEnabled bool, limit int) (string, error) {
+func (a *CopilotAgent) searchKnowledgeBase(ctx context.Context, db *database.Database, kbName string, query string, catPath string, category string, limit int) (string, error) {
 	if db == nil {
 		return "", fmt.Errorf("database is null")
 	}
 	kbName = ai.CanonicalKBName(kbName)
 	query = stripRoutingPrefix(query, kbName)
-	pathQuery, llmInstruction := splitCategoryPathInstruction(query)
-	pathPrompt := pathQuery != "" || looksLikeCategoryPath(query)
-	log.Info("searchKnowledgeBase start", "kb_name", kbName, "query", query, "category_path_query", pathQuery, "llm_instruction", llmInstruction, "path_prompt", pathPrompt, "category", category, "category_path", catPath, "text_search_enabled", textSearchEnabled, "limit", limit)
+	pathQuery, _ := splitCategoryPathInstruction(query)
+
+	log.Info("searchKnowledgeBase start", "kb_name", kbName, "query", query, "category_path_query", pathQuery, "category", category, "category_path", catPath, "limit", limit)
 
 	tx, err := db.BeginTransaction(ctx, sop.ForReading)
 	if err != nil {
@@ -140,216 +144,92 @@ func (a *CopilotAgent) searchKnowledgeBase(ctx context.Context, db *database.Dat
 		embedder = a.service.Domain().Embedder()
 	}
 
-	// We pass documentMode=false. TextSearch configuration is now inferred natively within the DB.
 	kb, err := db.OpenKnowledgeBase(ctx, kbName, tx, a.brain, embedder, false)
 	if err != nil {
 		log.Error("searchKnowledgeBase open failed", "kb_name", kbName, "error", err)
 		return "", fmt.Errorf("failed to open kb %s: %w", kbName, err)
 	}
 
-	var results []string
-
-	if pathQuery != "" {
-		searchText := ""
-		if !pathPrompt {
-			searchText = query
-		}
-		if embedder != nil {
-			vecs, err := embedCategoryPath(ctx, pathQuery, embedder)
-			if err == nil && len(vecs) > 0 {
-				cats, err := kb.Store.SemanticCategoryByPath(ctx, vecs)
-				if err == nil && len(cats) > 0 {
-					results = append(results, "--- Semantic Category Candidates ---")
-					for _, cat := range cats {
-						if cat == nil {
-							continue
-						}
-						uri := cat.Path
-						if strings.TrimSpace(uri) == "" {
-							uri = cat.ID.String()
-						}
-						results = append(results, fmt.Sprintf("SemanticCategoryURI: %s\nCategoryPath: %s\nCategoryID: %s", uri, cat.Path, cat.ID.String()))
-					}
-				}
-			}
-		}
-		pathHits, err := kb.SearchByPath(ctx, []memory.PathSearchParam{{CategoryPath: pathQuery, SearchText: searchText}})
-		if err == nil && len(pathHits) > 0 {
-			results = append(results, "--- Category Path Matches ---")
-			for _, h := range pathHits {
-				if len(results) >= limit+1 {
-					break
-				}
-				text := ""
-				categoryVal := ""
-				if descVal, ok := h.Data["description"].(string); ok {
-					text = descVal
-				} else if textVal, ok := h.Data["text"].(string); ok {
-					text = textVal
-				}
-				if text == "" {
-					b, _ := json.Marshal(h.Data)
-					text = string(b)
-				}
-				if catVal, ok := h.Data["category"].(string); ok {
-					categoryVal = catVal
-				}
-				docID := h.DocID.First()
-				link := ""
-				if docID != "" {
-					link = fmt.Sprintf("\n[View Source Document](/viewer?docID=%s)", docID)
-				}
-				results = append(results, fmt.Sprintf("CategoryPath: %s\nText: %s%s", categoryVal, text, link))
-			}
-		}
+	// Determine effective category path: pathQuery takes precedence, then catPath, then category
+	effectivePath := pathQuery
+	if effectivePath == "" {
+		effectivePath = catPath
+	}
+	if effectivePath == "" {
+		effectivePath = category
 	}
 
-	if catPath != "" {
-		pathHits, err := kb.SearchByPath(ctx, []memory.PathSearchParam{{CategoryPath: catPath, SearchText: query}})
-		if err == nil && len(pathHits) > 0 {
-			results = append(results, "--- Lexical Path Matches ---")
-			limitHit := 0
-			for _, h := range pathHits {
-				if limitHit >= limit {
-					break
-				}
-				text := ""
-				categoryVal := ""
-				if h.Data != nil {
-					if descVal, ok := h.Data["description"].(string); ok {
-						text = descVal
-					} else if textVal, ok := h.Data["text"].(string); ok {
-						text = textVal
-					}
-					if text == "" {
-						b, _ := json.Marshal(h.Data)
-						text = string(b)
-					}
-					if catVal, ok := h.Data["category"].(string); ok {
-						categoryVal = catVal
-					}
-				} else if len(h.Summaries) > 0 {
-					text = strings.Join(h.Summaries, " ")
-				}
-
-				if text == "" {
-					continue
-				}
-
-				docID := h.DocID.First()
-				link := ""
-				if docID != "" {
-					link = fmt.Sprintf("\n[View Source Document](/viewer?docID=%s)", docID)
-				}
-
-				results = append(results, fmt.Sprintf("CategoryPath: %s\nText: %s%s", categoryVal, text, link))
-				limitHit++
-			}
-		}
-	} else if category != "" && embedder != nil {
-		vecs, err := embedder.EmbedTexts(ctx, []string{query})
-		if err == nil && len(vecs) > 0 {
-			hits, err := kb.SearchSemantics(ctx, vecs[0], &memory.SearchOptions[map[string]any]{CategoryPath: category, Limit: limit})
-			if err == nil && len(hits) > 0 {
-				results = append(results, "--- Semantic Matches ---")
-				for _, h := range hits {
-					text := ""
-					categoryVal := ""
-					if descVal, ok := h.Payload["description"].(string); ok {
-						text = descVal
-					} else if textVal, ok := h.Payload["text"].(string); ok {
-						text = textVal
-					}
-					if text == "" {
-						b, _ := json.Marshal(h.Payload)
-						text = string(b)
-					}
-					if catVal, ok := h.Payload["category"].(string); ok {
-						categoryVal = catVal
-					}
-
-					docID := memory.DocIDs(h.DocID).First()
-					link := ""
-					if docID != "" {
-						link = fmt.Sprintf("\n[View Source Document](/viewer?docID=%s)", docID)
-					}
-
-					results = append(results, fmt.Sprintf("Score: %.2f | CategoryPath: %s\nText: %s%s", h.Score, categoryVal, text, link))
-				}
-			}
-		}
-	} else if textSearchEnabled {
-		keywordHits, err := kb.SearchKeywords(ctx, query, &memory.SearchOptions[map[string]any]{Limit: limit})
-		if err == nil && len(keywordHits) > 0 {
-			results = append(results, "--- Keyword Matches ---")
-			for _, h := range keywordHits {
-				text := ""
-				categoryVal := ""
-				if descVal, ok := h.Payload["description"].(string); ok {
-					text = descVal
-				} else if textVal, ok := h.Payload["text"].(string); ok {
-					text = textVal
-				}
-				if text == "" {
-					b, _ := json.Marshal(h.Payload)
-					text = string(b)
-				}
-				if catVal, ok := h.Payload["category"].(string); ok {
-					categoryVal = catVal
-				}
-
-				docID := memory.DocIDs(h.DocID).First()
-				link := ""
-				if docID != "" {
-					link = fmt.Sprintf("\n[View Source Document](/viewer?docID=%s)", docID)
-				}
-
-				results = append(results, fmt.Sprintf("Score: %.2f | CategoryPath: %s\nText: %s%s", h.Score, categoryVal, text, link))
-			}
-		}
-	} else if embedder != nil {
-		vecs, err := embedder.EmbedTexts(ctx, []string{query})
-		if err == nil && len(vecs) > 0 {
-			hits, err := kb.SearchSemantics(ctx, vecs[0], &memory.SearchOptions[map[string]any]{Limit: limit})
-			if err == nil && len(hits) > 0 {
-				results = append(results, "--- Semantic Matches ---")
-				for _, h := range hits {
-					text := ""
-					categoryVal := ""
-					if descVal, ok := h.Payload["description"].(string); ok {
-						text = descVal
-					} else if textVal, ok := h.Payload["text"].(string); ok {
-						text = textVal
-					}
-					if text == "" {
-						b, _ := json.Marshal(h.Payload)
-						text = string(b)
-					}
-					if catVal, ok := h.Payload["category"].(string); ok {
-						categoryVal = catVal
-					}
-
-					docID := memory.DocIDs(h.DocID).First()
-					link := ""
-					if docID != "" {
-						link = fmt.Sprintf("\n[View Source Document](/viewer?docID=%s)", docID)
-					}
-
-					results = append(results, fmt.Sprintf("Score: %.2f | CategoryPath: %s\nText: %s%s", h.Score, categoryVal, text, link))
-				}
-			}
-		}
+	// Single unified search - let Search() handle all intelligent routing:
+	// - CategoryPath resolution (lexical + semantic fallback)
+	// - Text-based category discovery
+	// - Vector search across all candidate categories
+	searchReq := memory.SearchRequest[map[string]any]{
+		Text:         query,
+		CategoryPath: effectivePath,
+		Limit:        limit,
 	}
 
-	if len(results) == 0 {
+	batch, err := kb.Search(ctx, []memory.SearchRequest[map[string]any]{searchReq})
+	if err != nil {
+		return "", err
+	}
+
+	if len(batch) == 0 || len(batch[0]) == 0 {
 		return "No results found.", nil
+	}
+
+	// Unified result formatting
+	var results []string
+	for _, h := range batch[0] {
+		text := extractHitText(h.Payload)
+		categoryVal := extractHitCategory(h.Payload)
+		docID := memory.DocIDs(h.DocID).First()
+		link := ""
+		if docID != "" {
+			link = fmt.Sprintf("\n[View Source Document](/viewer?docID=%s)", docID)
+		}
+		results = append(results, fmt.Sprintf("Score: %.2f | CategoryPath: %s\nText: %s%s", h.Score, categoryVal, text, link))
 	}
 
 	a.MarkMRUCategory(kbName, fmt.Sprintf("Last searched query: %s", query))
 	return strings.Join(results, "\n\n"), nil
 }
 
-// resolveDBForKB implements Namespace Shadowing Logic: Tenant DB overrides System DB
+func extractHitText(v any) string {
+	switch data := v.(type) {
+	case map[string]any:
+		for _, field := range []string{"text", "description", "content", "page_content", "_raw_content"} {
+			if text, ok := data[field].(string); ok && strings.TrimSpace(text) != "" {
+				return text
+			}
+		}
+		b, _ := json.Marshal(data)
+		return string(b)
+	case string:
+		return data
+	default:
+		b, _ := json.Marshal(data)
+		return string(b)
+	}
+}
+
+func extractHitCategory(v any) string {
+	switch data := v.(type) {
+	case map[string]any:
+		// Prefer category_path (full hierarchical path) over category (leaf name only)
+		if categoryPath, ok := data["category_path"].(string); ok && strings.TrimSpace(categoryPath) != "" {
+			return categoryPath
+		}
+		if category, ok := data["category"].(string); ok {
+			return category
+		}
+		if category, ok := data["path"].(string); ok {
+			return category
+		}
+	}
+	return ""
+}
+
 func (a *CopilotAgent) resolveDBForKB(ctx context.Context, kbName string) *database.Database {
 	p := ai.GetSessionPayload(ctx)
 	if p != nil && p.CurrentDB != "" {

--- a/ai/agent/copilottools.search.go
+++ b/ai/agent/copilottools.search.go
@@ -45,6 +45,11 @@ func stripRoutingPrefix(query, kbName string) string {
 		}
 	}
 
+	// If what remains is just the KB name itself (e.g., "sop" from "omni:sop"), strip it
+	if strings.EqualFold(trimmed, canonicalName) {
+		trimmed = ""
+	}
+
 	return strings.TrimSpace(trimmed)
 }
 
@@ -230,11 +235,7 @@ func (a *CopilotAgent) searchKnowledgeBase(ctx context.Context, db *database.Dat
 	for _, h := range batch[0] {
 		text := extractHitText(h.Payload)
 		categoryVal := extractHitCategory(h.Payload)
-		docID := memory.DocIDs(h.DocID).First()
-		link := ""
-		if docID != "" {
-			link = fmt.Sprintf("\n[View Source Document](/viewer?docID=%s)", docID)
-		}
+		link := a.formatKBSourceLinks(ctx, memory.DocIDs(h.DocID))
 		results = append(results, fmt.Sprintf("Score: %.2f | CategoryPath: %s\nText: %s%s", h.Score, categoryVal, text, link))
 	}
 
@@ -446,8 +447,14 @@ func (a *CopilotAgent) getSubcategories(ctx context.Context, db *database.Databa
 			navPath = cat.Name
 		}
 
-		results = append(results, fmt.Sprintf("• %s (%s%s)%s\n  Navigate: omni:%s:%s",
-			name, itemInfo, subcatInfo, description, kbName, navPath))
+		entry := fmt.Sprintf("• %s (%s%s)%s\n  Navigate: omni:%s:%s", name, itemInfo, subcatInfo, description, kbName, navPath)
+		results = append(results, entry)
+	}
+
+	// Separate each category entry with a blank line for readability
+	if len(results) > 2 {
+		joined := strings.Join(results[2:], "\n\n")
+		results = []string{results[0], results[1], joined}
 	}
 
 	// Add pagination navigation if multiple pages exist

--- a/ai/agent/copilottools_routing_test.go
+++ b/ai/agent/copilottools_routing_test.go
@@ -150,3 +150,20 @@ func TestSplitCategoryPathInstruction_HandlesWhitespaceAroundLLM(t *testing.T) {
 		t.Fatalf("splitCategoryPathInstruction instruction = %q, want %q", instruction, "summarize examples")
 	}
 }
+
+func TestExtractCategoryPathQuery_NormalizesColonNestingToCategoryPath(t *testing.T) {
+	got := extractCategoryPathQuery("omni:sop:language bindings:c#")
+	if got != "language bindings/c#" {
+		t.Fatalf("extractCategoryPathQuery() = %q, want %q", got, "language bindings/c#")
+	}
+}
+
+func TestSplitCategoryPathInstruction_NormalizesColonNesting(t *testing.T) {
+	path, instruction := splitCategoryPathInstruction("omni:sop:language bindings:c#")
+	if path != "language bindings/c#" {
+		t.Fatalf("splitCategoryPathInstruction path = %q, want %q", path, "language bindings/c#")
+	}
+	if instruction != "" {
+		t.Fatalf("splitCategoryPathInstruction instruction = %q, want %q", instruction, "")
+	}
+}

--- a/ai/agent/copilottools_search_test_export.go
+++ b/ai/agent/copilottools_search_test_export.go
@@ -1,0 +1,17 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/sharedcode/sop/ai/database"
+)
+
+// ExportSplitCategoryPathInstruction exports the private function for testing
+func ExportSplitCategoryPathInstruction(query string) (string, string) {
+	return splitCategoryPathInstruction(query)
+}
+
+// ExportSearchKnowledgeBase exports searchKnowledgeBase for testing
+func (a *CopilotAgent) ExportSearchKnowledgeBase(ctx context.Context, db *database.Database, kbName string, query string, catPath string, category string, limit int) (string, error) {
+	return a.searchKnowledgeBase(ctx, db, kbName, query, catPath, category, limit)
+}

--- a/ai/agent/copilottools_search_unit_test.go
+++ b/ai/agent/copilottools_search_unit_test.go
@@ -1,0 +1,58 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestExtractHitCategory_PrefersFullPath(t *testing.T) {
+	testCases := []struct {
+		name     string
+		payload  any
+		expected string
+	}{
+		{
+			name: "Full category_path available",
+			payload: map[string]any{
+				"category":      "C#",
+				"category_path": "Language Bindings & Tooling/C#",
+			},
+			expected: "Language Bindings & Tooling/C#",
+		},
+		{
+			name: "Only category available",
+			payload: map[string]any{
+				"category": "C#",
+			},
+			expected: "C#",
+		},
+		{
+			name: "Only path available",
+			payload: map[string]any{
+				"path": "Some/Path",
+			},
+			expected: "Some/Path",
+		},
+		{
+			name: "Empty category_path falls back to category",
+			payload: map[string]any{
+				"category":      "C#",
+				"category_path": "   ",
+			},
+			expected: "C#",
+		},
+		{
+			name:     "No category fields",
+			payload:  map[string]any{"other": "data"},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractHitCategory(tc.payload)
+			if result != tc.expected {
+				t.Errorf("extractHitCategory() = %q, want %q", result, tc.expected)
+			}
+		})
+	}
+}

--- a/ai/agent/eval_kb_integ_test.go
+++ b/ai/agent/eval_kb_integ_test.go
@@ -155,7 +155,7 @@ func ingestKBFile(ctx context.Context, db *database.Database, kbName string, fil
 		}
 
 		// Use real embeddings if the pipeline supports it,
-		vecs, embErr := embedder.EmbedTexts(ctx, []string{content})
+		vecs, embErr := embed.DocumentTexts(ctx, embedder, []string{content})
 		if embErr != nil || len(vecs) == 0 {
 			return fmt.Errorf("failed generating real vector embedding: %v", embErr)
 		}

--- a/ai/agent/factory.go
+++ b/ai/agent/factory.go
@@ -267,7 +267,7 @@ func NewFromConfig(ctx context.Context, cfg Config, deps Dependencies) (ai.Agent
 			texts[i] = fmt.Sprintf("%s %s", item.Text, item.Description)
 		}
 
-		vecs, err := emb.EmbedTexts(ctx, texts)
+		vecs, err := embed.DocumentTexts(ctx, emb, texts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to embed seed data: %w", err)
 		}

--- a/ai/agent/service.go
+++ b/ai/agent/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sharedcode/sop"
 	"github.com/sharedcode/sop/ai"
 	"github.com/sharedcode/sop/ai/database"
+	"github.com/sharedcode/sop/ai/embed"
 	"github.com/sharedcode/sop/ai/generator"
 	"github.com/sharedcode/sop/ai/memory"
 	"github.com/sharedcode/sop/ai/obfuscation"
@@ -810,7 +811,7 @@ func (s *Service) Search(ctx context.Context, query string, limit int) ([]ai.Hit
 		queryToEmbed = query
 	}
 
-	vecs, err := emb.EmbedTexts(ctx, []string{queryToEmbed})
+	vecs, err := embed.QueryTexts(ctx, emb, []string{queryToEmbed})
 	if err != nil {
 		return nil, fmt.Errorf("embedding failed: %w", err)
 	}
@@ -1197,9 +1198,12 @@ func (s *Service) getToolInfo(ctx context.Context, toolName string) (string, err
 	}
 
 	searchQuery := fmt.Sprintf("%s Tool Operations", toolName)
-	options := &memory.SearchOptions[map[string]any]{Limit: 1}
-	hits, err := kb.SearchKeywords(ctx, searchQuery, options)
-	if err == nil && len(hits) > 0 {
+	batch, err := kb.Search(ctx, []memory.SearchRequest[map[string]any]{{
+		Text:  searchQuery,
+		Limit: 1,
+	}})
+	if err == nil && len(batch) > 0 && len(batch[0]) > 0 {
+		hits := batch[0]
 		if content, ok := hits[0].Payload["Content"].(string); ok {
 			return content, nil
 		}
@@ -1535,7 +1539,8 @@ func (s *Service) buildPromptInputs(ctx context.Context, query string, hits []ai
 		kbName := memory.BuildLTMStoreName(agentID, p.UserID)
 		if tx, err := s.systemDB.BeginTransaction(ctx, sop.ForReading); err == nil {
 			if kb, err := s.systemDB.OpenKnowledgeBase(ctx, kbName, tx, s.generator, nil, false, true); err == nil {
-				if userHits, err := kb.SearchKeywords(ctx, query, &memory.SearchOptions[map[string]any]{Limit: 5}); err == nil && len(userHits) > 0 {
+				if batch, err := kb.Search(ctx, []memory.SearchRequest[map[string]any]{{Text: query, Limit: 5}}); err == nil && len(batch) > 0 && len(batch[0]) > 0 {
+					userHits := batch[0]
 					var prefText strings.Builder
 					prefText.WriteString("\n\n[User Preferences & Active Memory Ledger for this query]\n")
 					for _, hit := range userHits {

--- a/ai/cmd/knowledge_compiler/main.go
+++ b/ai/cmd/knowledge_compiler/main.go
@@ -247,11 +247,11 @@ type explicitItemBlock struct {
 }
 
 func escapeCategoryPart(value string) string {
-	return strings.ReplaceAll(value, " / ", categorySlashPlaceholder)
+	return strings.ReplaceAll(value, "/", categorySlashPlaceholder)
 }
 
 func unescapeCategoryPart(value string) string {
-	return strings.ReplaceAll(value, categorySlashPlaceholder, " / ")
+	return strings.ReplaceAll(value, categorySlashPlaceholder, "/")
 }
 
 func getCat(catPath string) *memory.Category {
@@ -259,21 +259,21 @@ func getCat(catPath string) *memory.Category {
 		return c
 	}
 
-	parts := strings.Split(catPath, " / ")
+	parts := strings.Split(catPath, "/")
 	displayParts := make([]string, len(parts))
 	for i, part := range parts {
 		displayParts[i] = unescapeCategoryPart(part)
 	}
 
 	id := sop.UUID(uuid.New())
-	displayPath := strings.Join(displayParts, " / ")
+	displayPath := strings.Join(displayParts, "/")
 	c := &memory.Category{
 		ID:   id,
 		Name: removePrefix(displayParts[len(displayParts)-1], prefix),
 		Path: displayPath,
 	}
 	if len(parts) > 1 {
-		parentPath := strings.Join(parts[:len(parts)-1], " / ")
+		parentPath := strings.Join(parts[:len(parts)-1], "/")
 		parentCat := getCat(parentPath)
 		c.ParentIDs = append(c.ParentIDs, memory.CategoryParent{ParentID: parentCat.ID})
 	}
@@ -286,12 +286,12 @@ func buildExportItems(chunks []KnowledgeChunk) []memory.ExportItem[map[string]an
 	for _, chunk := range chunks {
 		catKey := chunk.CategoryKey
 		if catKey == "" {
-			parts := strings.Split(chunk.Category, " / ")
+			parts := strings.Split(chunk.Category, "/")
 			encodedParts := make([]string, len(parts))
 			for i, part := range parts {
 				encodedParts[i] = escapeCategoryPart(part)
 			}
-			catKey = strings.Join(encodedParts, " / ")
+			catKey = strings.Join(encodedParts, "/")
 		}
 		cat := getCat(catKey)
 		summaries := chunk.Summaries
@@ -719,7 +719,7 @@ func processFlattenedTreeIntoChunks(node *Section, currentPathContext []string, 
 
 	var catPath string
 	if len(normalizedPaths) > 0 {
-		catPath = strings.Join(normalizedPaths, " / ")
+		catPath = strings.Join(normalizedPaths, "/")
 	} else {
 		catPath = normalizeCategoryName(node.Title)
 	}
@@ -728,7 +728,7 @@ func processFlattenedTreeIntoChunks(node *Section, currentPathContext []string, 
 	for _, p := range normalizedPaths {
 		encodedPaths = append(encodedPaths, escapeCategoryPart(p))
 	}
-	catKey := strings.Join(encodedPaths, " / ")
+	catKey := strings.Join(encodedPaths, "/")
 
 	explicitBlocks, remainingParagraphs := parseExplicitItemBlocks(node.Paragraphs)
 
@@ -827,18 +827,18 @@ func main() {
 			}
 
 			for catPath, indices := range itemsPerCat {
-				if len(indices) == 1 && strings.Contains(catPath, " / ") {
+				if len(indices) == 1 && strings.Contains(catPath, "/") {
 					hasChildren := false
 					for otherCat := range itemsPerCat {
-						if strings.HasPrefix(otherCat, catPath+" / ") {
+						if strings.HasPrefix(otherCat, catPath+"/") {
 							hasChildren = true
 							break
 						}
 					}
 
 					if !hasChildren {
-						parts := strings.Split(catPath, " / ")
-						parentPath := strings.Join(parts[:len(parts)-1], " / ")
+						parts := strings.Split(catPath, "/")
+						parentPath := strings.Join(parts[:len(parts)-1], "/")
 
 						idx := indices[0]
 						if allChunks[idx].Explicit {

--- a/ai/cmd/knowledge_compiler/normalize.go
+++ b/ai/cmd/knowledge_compiler/normalize.go
@@ -26,5 +26,11 @@ func cleanText(s string) string {
 
 func normalizeCategoryName(s string) string {
 	s = strings.TrimLeft(s, "# ")
-	return strings.TrimSpace(prefixRegex.ReplaceAllString(s, ""))
+	s = prefixRegex.ReplaceAllString(s, "")
+	s = strings.TrimSpace(s)
+	// Remove spaces around slashes in category names (e.g., "CLI / Examples" -> "CLI/Examples")
+	s = strings.ReplaceAll(s, " / ", "/")
+
+	// Keep category names stable; language-specific canonicalization happens in the runtime memory pipeline.
+	return s
 }

--- a/ai/cmd/knowledge_compiler/normalize_test.go
+++ b/ai/cmd/knowledge_compiler/normalize_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestNormalizeCategoryName_DoesNotRewriteProgrammingLanguageTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "csharp", in: "C#", want: "C#"},
+		{name: "cpp", in: "C++", want: "C++"},
+		{name: "dotnet", in: ".NET", want: ".NET"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeCategoryName(tt.in); got != tt.want {
+				t.Fatalf("normalizeCategoryName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/ai/database/memory.go
+++ b/ai/database/memory.go
@@ -35,6 +35,9 @@ func itemKeyComparer(a, b memory.ItemKey) int {
 }
 
 func distanceKeyComparer(a, b memory.DistanceKey) int {
+	if cmp := a.ParentID.Compare(b.ParentID); cmp != 0 {
+		return cmp
+	}
 	if a.Distance < b.Distance {
 		return -1
 	}

--- a/ai/database/vectorize.go
+++ b/ai/database/vectorize.go
@@ -41,7 +41,7 @@ func ensureDomainReference(ctx context.Context, kb *memory.KnowledgeBase[map[str
 			return nil
 		}
 
-		vecs, err := embed.QueryTexts(ctx, embedder, []string{anchor})
+		vecs, err := embed.CategoryTexts(ctx, embedder, []string{anchor})
 		if err != nil {
 			return err
 		}
@@ -162,11 +162,12 @@ func (db *Database) Vectorize(
 
 		catCenterVector := cat.CenterVector
 
-		// Vectorize the category itself using its own name as the semantic anchor.
+		// Vectorize the category itself using its own canonicalized name as the semantic anchor.
 		embedText := strings.TrimSpace(cat.Name)
 		if embedText == "" {
 			embedText = strings.TrimSpace(cat.Description)
 		}
+		embedText = memory.NormalizeCategoryToken(embedText)
 		expectedCatHash := memory.ComputeVectorHash(embedderDim, embedText)
 		if cat.VectorHash != expectedCatHash || len(cat.CenterVector) == 0 {
 			log.Debug("Vectorizing category", "catID", catID)
@@ -179,11 +180,11 @@ func (db *Database) Vectorize(
 				if len(cat.CenterVector) > 0 {
 					if len(cat.ParentIDs) > 0 {
 						for _, p := range cat.ParentIDs {
-							oldDist := memory.EuclideanDistance(oldCategoryVectors[p.ParentID], cat.CenterVector)
+							oldDist := memory.Distance(oldCategoryVectors[p.ParentID], cat.CenterVector, true)
 							catsByDist.Remove(ctx, memory.DistanceKey{ParentID: p.ParentID, Distance: oldDist, ID: cat.ID})
 						}
 					} else {
-						oldDist := memory.EuclideanDistance(kb.Store.DomainReference(), cat.CenterVector)
+						oldDist := memory.Distance(kb.Store.DomainReference(), cat.CenterVector, true)
 						catsByDist.Remove(ctx, memory.DistanceKey{ParentID: sop.NilUUID, Distance: oldDist, ID: cat.ID})
 					}
 				}
@@ -199,18 +200,15 @@ func (db *Database) Vectorize(
 						if len(refVec) == 0 {
 							refVec = oldCategoryVectors[p.ParentID]
 						}
-						newDist := memory.EuclideanDistance(refVec, cat.CenterVector)
+						newDist := memory.Distance(refVec, cat.CenterVector, true)
 						catsByDist.Add(ctx, memory.DistanceKey{ParentID: p.ParentID, Distance: newDist, ID: cat.ID}, 0)
 					}
 				} else {
-					newDist := memory.EuclideanDistance(kb.Store.DomainReference(), cat.CenterVector)
+					newDist := memory.Distance(kb.Store.DomainReference(), cat.CenterVector, true)
 					catsByDist.Add(ctx, memory.DistanceKey{ParentID: sop.NilUUID, Distance: newDist, ID: cat.ID}, 0)
 				}
 
 				catBtree.UpdateCurrentItem(ctx, cat.ID, cat)
-			} else if err != nil {
-				tx.Rollback(ctx)
-				return err
 			}
 		}
 
@@ -282,7 +280,14 @@ func (db *Database) Vectorize(
 			if len(batchTasks) >= batchSize {
 				if len(batchSummaries) > 0 {
 					log.Debug("Vectorize embedding items batch", "kb_name", kbName, "count", len(batchSummaries))
+					// Embed as DocumentTexts for item storage (768 dim)
 					allVecs, err := embed.DocumentTexts(ctx, embedder, batchSummaries)
+					if err != nil {
+						tx.Rollback(ctx)
+						return err
+					}
+					// Embed as CategoryTexts for classification (256 dim)
+					allClassificationVecs, err := embed.CategoryTexts(ctx, embedder, batchSummaries)
 					if err != nil {
 						tx.Rollback(ctx)
 						return err
@@ -293,9 +298,10 @@ func (db *Database) Vectorize(
 					for _, task := range batchTasks {
 						count := task.summaryCnt
 						itemVecs := allVecs[vecIdx : vecIdx+count]
+						classificationVecs := allClassificationVecs[vecIdx : vecIdx+count]
 						vecIdx += count
 
-						err = kb.Store.UpsertByCategoryID(ctx, task.catID, task.centerVec, *task.item, itemVecs)
+						err = kb.Store.UpsertByCategoryID(ctx, task.catID, task.centerVec, *task.item, itemVecs, classificationVecs)
 						if err != nil {
 							tx.Rollback(ctx)
 							return err
@@ -368,6 +374,10 @@ func (db *Database) Vectorize(
 			}
 
 			iok, err = itemsBtree.Next(ctx)
+			if err != nil {
+				tx.Rollback(ctx)
+				return err
+			}
 			log.Debug("After item cursor restore, Next", "iok", iok, "err", err)
 		}
 		log.Debug("After items loop", "catID", catID, "totalItemCount", totalItemCount)
@@ -378,7 +388,11 @@ func (db *Database) Vectorize(
 			catBtree.UpdateCurrentItem(ctx, cat.ID, cat)
 		}
 
-		ok, _ = categoriesByPath.Next(ctx)
+		ok, err = categoriesByPath.Next(ctx)
+		if err != nil {
+			tx.Rollback(ctx)
+			return err
+		}
 	}
 	log.Debug("After categories loop")
 
@@ -386,7 +400,14 @@ func (db *Database) Vectorize(
 	if len(batchTasks) > 0 {
 		if len(batchSummaries) > 0 {
 			log.Debug("Vectorize embedding items batch (final)", "kb_name", kbName, "count", len(batchSummaries))
+			// Embed as DocumentTexts for item storage (768 dim)
 			allVecs, err := embed.DocumentTexts(ctx, embedder, batchSummaries)
+			if err != nil {
+				tx.Rollback(ctx)
+				return err
+			}
+			// Embed as CategoryTexts for classification (256 dim)
+			allClassificationVecs, err := embed.CategoryTexts(ctx, embedder, batchSummaries)
 			if err != nil {
 				tx.Rollback(ctx)
 				return err
@@ -396,9 +417,10 @@ func (db *Database) Vectorize(
 			for _, task := range batchTasks {
 				count := task.summaryCnt
 				itemVecs := allVecs[vecIdx : vecIdx+count]
+				classificationVecs := allClassificationVecs[vecIdx : vecIdx+count]
 				vecIdx += count
 
-				err = kb.Store.UpsertByCategoryID(ctx, task.catID, task.centerVec, *task.item, itemVecs)
+				err = kb.Store.UpsertByCategoryID(ctx, task.catID, task.centerVec, *task.item, itemVecs, classificationVecs)
 				if err != nil {
 					tx.Rollback(ctx)
 					return err
@@ -503,11 +525,12 @@ func (db *Database) VectorizeCategories(
 
 		catCenterVector := cat.CenterVector
 
-		// Vectorize the category itself using its own name as the semantic anchor.
+		// Vectorize the category itself using its own canonicalized name as the semantic anchor.
 		embedText := strings.TrimSpace(cat.Name)
 		if embedText == "" {
 			embedText = strings.TrimSpace(cat.Description)
 		}
+		embedText = memory.NormalizeCategoryToken(embedText)
 		expectedCatHash := memory.ComputeVectorHash(embedderDim, embedText)
 		if cat.VectorHash != expectedCatHash || len(cat.CenterVector) == 0 {
 			log.Debug("Vectorizing category", "catID", catID)
@@ -520,11 +543,11 @@ func (db *Database) VectorizeCategories(
 				if len(cat.CenterVector) > 0 {
 					if len(cat.ParentIDs) > 0 {
 						for _, p := range cat.ParentIDs {
-							oldDist := memory.EuclideanDistance(oldCategoryVectors[p.ParentID], cat.CenterVector)
+							oldDist := memory.Distance(oldCategoryVectors[p.ParentID], cat.CenterVector, true)
 							catsByDist.Remove(ctx, memory.DistanceKey{ParentID: p.ParentID, Distance: oldDist, ID: cat.ID})
 						}
 					} else {
-						oldDist := memory.EuclideanDistance(kb.Store.DomainReference(), cat.CenterVector)
+						oldDist := memory.Distance(kb.Store.DomainReference(), cat.CenterVector, true)
 						catsByDist.Remove(ctx, memory.DistanceKey{ParentID: sop.NilUUID, Distance: oldDist, ID: cat.ID})
 					}
 				}
@@ -540,18 +563,15 @@ func (db *Database) VectorizeCategories(
 						if len(refVec) == 0 {
 							refVec = oldCategoryVectors[p.ParentID]
 						}
-						newDist := memory.EuclideanDistance(refVec, cat.CenterVector)
+						newDist := memory.Distance(refVec, cat.CenterVector, true)
 						catsByDist.Add(ctx, memory.DistanceKey{ParentID: p.ParentID, Distance: newDist, ID: cat.ID}, 0)
 					}
 				} else {
-					newDist := memory.EuclideanDistance(kb.Store.DomainReference(), cat.CenterVector)
+					newDist := memory.Distance(kb.Store.DomainReference(), cat.CenterVector, true)
 					catsByDist.Add(ctx, memory.DistanceKey{ParentID: sop.NilUUID, Distance: newDist, ID: cat.ID}, 0)
 				}
 
 				catBtree.UpdateCurrentItem(ctx, cat.ID, cat)
-			} else if err != nil {
-				tx.Rollback(ctx)
-				return err
 			}
 		}
 
@@ -623,7 +643,14 @@ func (db *Database) VectorizeCategories(
 			if len(batchTasks) >= batchSize {
 				if len(batchSummaries) > 0 {
 					log.Debug("Vectorize embedding items batch", "kb_name", kbName, "count", len(batchSummaries))
+					// Embed as DocumentTexts for item storage (768 dim)
 					allVecs, err := embed.DocumentTexts(ctx, embedder, batchSummaries)
+					if err != nil {
+						tx.Rollback(ctx)
+						return err
+					}
+					// Embed as CategoryTexts for classification (256 dim)
+					allClassificationVecs, err := embed.CategoryTexts(ctx, embedder, batchSummaries)
 					if err != nil {
 						tx.Rollback(ctx)
 						return err
@@ -634,9 +661,10 @@ func (db *Database) VectorizeCategories(
 					for _, task := range batchTasks {
 						count := task.summaryCnt
 						itemVecs := allVecs[vecIdx : vecIdx+count]
+						classificationVecs := allClassificationVecs[vecIdx : vecIdx+count]
 						vecIdx += count
 
-						err = kb.Store.UpsertByCategoryID(ctx, task.catID, task.centerVec, *task.item, itemVecs)
+						err = kb.Store.UpsertByCategoryID(ctx, task.catID, task.centerVec, *task.item, itemVecs, classificationVecs)
 						if err != nil {
 							tx.Rollback(ctx)
 							return err
@@ -715,7 +743,14 @@ func (db *Database) VectorizeCategories(
 	if len(batchTasks) > 0 {
 		if len(batchSummaries) > 0 {
 			log.Debug("Vectorize embedding items batch (final)", "kb_name", kbName, "count", len(batchSummaries))
+			// Embed as DocumentTexts for item storage (768 dim)
 			allVecs, err := embed.DocumentTexts(ctx, embedder, batchSummaries)
+			if err != nil {
+				tx.Rollback(ctx)
+				return err
+			}
+			// Embed as CategoryTexts for classification (256 dim)
+			allClassificationVecs, err := embed.CategoryTexts(ctx, embedder, batchSummaries)
 			if err != nil {
 				tx.Rollback(ctx)
 				return err
@@ -725,9 +760,10 @@ func (db *Database) VectorizeCategories(
 			for _, task := range batchTasks {
 				count := task.summaryCnt
 				itemVecs := allVecs[vecIdx : vecIdx+count]
+				classificationVecs := allClassificationVecs[vecIdx : vecIdx+count]
 				vecIdx += count
 
-				err = kb.Store.UpsertByCategoryID(ctx, task.catID, task.centerVec, *task.item, itemVecs)
+				err = kb.Store.UpsertByCategoryID(ctx, task.catID, task.centerVec, *task.item, itemVecs, classificationVecs)
 				if err != nil {
 					tx.Rollback(ctx)
 					return err

--- a/ai/database/vectorize_items.go
+++ b/ai/database/vectorize_items.go
@@ -130,7 +130,13 @@ func (db *Database) VectorizeItems(
 			continue
 		}
 
+		// Embed as DocumentTexts for item storage (768 dim)
 		allVecs, err := embed.DocumentTexts(ctx, embedder, batchSummaries)
+		if err != nil {
+			return err
+		}
+		// Embed as CategoryTexts for classification (256 dim)
+		allClassificationVecs, err := embed.CategoryTexts(ctx, embedder, batchSummaries)
 		if err != nil {
 			return err
 		}
@@ -139,9 +145,10 @@ func (db *Database) VectorizeItems(
 		for j, item := range batch {
 			count := itemSummaryCounts[j]
 			itemVecs := allVecs[vecIdx : vecIdx+count]
+			classificationVecs := allClassificationVecs[vecIdx : vecIdx+count]
 			vecIdx += count
 
-			err = kb.Store.UpsertByCategoryID(ctx, categoryID, category.CenterVector, *item, itemVecs)
+			err = kb.Store.UpsertByCategoryID(ctx, categoryID, category.CenterVector, *item, itemVecs, classificationVecs)
 			if err != nil {
 				return err
 			}

--- a/ai/embed/factory.go
+++ b/ai/embed/factory.go
@@ -1,0 +1,40 @@
+package embed
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sharedcode/sop/ai"
+)
+
+// NewFromName creates an embedder using the configured provider/model name.
+// It is intentionally lightweight and self-contained so callers can construct
+// a concrete embedder without needing a separate factory callback.
+func NewFromName(name string, dim int) (ai.Embeddings, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		trimmed = "simple"
+	}
+
+	normalized := strings.ToLower(trimmed)
+	switch {
+	case normalized == "simple" || normalized == "mock" || normalized == "default":
+		if dim <= 0 {
+			dim = 384
+		}
+		return NewSimple(trimmed, dim, nil), nil
+	case strings.Contains(normalized, "local-kelindar"):
+		return NewLocalWithProvider("kelindar", trimmed, 0)
+	case strings.Contains(normalized, "gemini"):
+		return NewGemini("", trimmed), nil
+	case strings.Contains(normalized, "openai") || strings.Contains(normalized, "text-embedding"):
+		return NewOpenAI("", trimmed, ""), nil
+	case strings.Contains(normalized, "ollama") || strings.Contains(normalized, "nomic"):
+		return NewOllama("", trimmed), nil
+	default:
+		if dim <= 0 {
+			dim = 384
+		}
+		return nil, fmt.Errorf("unsupported embedder name %q", name)
+	}
+}

--- a/ai/embed/modes.go
+++ b/ai/embed/modes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sharedcode/sop/ai"
 )
 
+
 func CategoryTexts(ctx context.Context, embedder ai.Embeddings, texts []string) ([][]float32, error) {
 	if modeAware, ok := embedder.(ai.EmbeddingModeSupport); ok {
 		return modeAware.EmbedCategoryTexts(ctx, texts)

--- a/ai/interfaces.go
+++ b/ai/interfaces.go
@@ -20,6 +20,8 @@ const (
 	CtxKeyAPIKey ContextKey = "ai_api_key"
 	// CtxKeyBaseURL is the context key for passing a transient Base URL
 	CtxKeyBaseURL ContextKey = "ai_base_url"
+	// CtxKeyAppBaseURL is the context key for passing the public app origin used to build absolute viewer links.
+	CtxKeyAppBaseURL ContextKey = "ai_app_base_url"
 	// CtxKeyExecutor is the context key for passing the ToolExecutor.
 	CtxKeyExecutor ContextKey = "ai_executor"
 	// CtxKeyDeobfuscator is the context key for passing the Deobfuscator.

--- a/ai/memory/digest.go
+++ b/ai/memory/digest.go
@@ -55,7 +55,7 @@ func DigestKnowledgeBase(ctx context.Context, kb *KnowledgeBase[map[string]any],
 	for _, query := range queries {
 		categoryFilter := ""
 		if embedder != nil {
-			vecs, err := embed.QueryTexts(ctx, embedder, []string{query})
+			vecs, err := embed.CategoryTexts(ctx, embedder, []string{normalize(query)})
 			if err == nil && len(vecs) > 0 {
 				if req.UseClosestCategory {
 					closestCat, _, err := kb.Manager.FindClosestCategory(ctx, vecs[0])
@@ -73,11 +73,22 @@ func DigestKnowledgeBase(ctx context.Context, kb *KnowledgeBase[map[string]any],
 				}
 
 				for _, opts := range semanticOpts {
-					hits, err := kb.SearchSemantics(ctx, vecs[0], opts)
+					vecs, err = embed.QueryTexts(ctx, embedder, []string{normalize(query)})
 					if err != nil {
 						return nil, err
 					}
-					for _, hit := range hits {
+					batch, err := kb.Search(ctx, []SearchRequest[map[string]any]{{
+						Vector:       vecs[0],
+						Limit:        opts.Limit,
+						CategoryPath: opts.CategoryPath,
+					}})
+					if err != nil {
+						return nil, err
+					}
+					if len(batch) == 0 {
+						continue
+					}
+					for _, hit := range batch[0] {
 						relevance := digestSemanticRelevance(hit.Score)
 						if relevance < minScore {
 							continue
@@ -96,13 +107,17 @@ func DigestKnowledgeBase(ctx context.Context, kb *KnowledgeBase[map[string]any],
 		}
 
 		if req.KeywordFallback {
-			hits, err := kb.SearchKeywords(ctx, query, &SearchOptions[map[string]any]{
+			batch, err := kb.Search(ctx, []SearchRequest[map[string]any]{{
+				Text:  query,
 				Limit: perQueryLimit,
-			})
+			}})
 			if err != nil {
 				return nil, err
 			}
-			for _, hit := range hits {
+			if len(batch) == 0 {
+				continue
+			}
+			for _, hit := range batch[0] {
 				mergeDigestHit(merged, KBDigestHit{
 					DocID:      hit.DocID,
 					Score:      hit.Score,

--- a/ai/memory/interfaces.go
+++ b/ai/memory/interfaces.go
@@ -28,7 +28,8 @@ type MemoryStore[T any] interface {
 	UpsertByCategoryPath(ctx context.Context, categoryName string, item Item[T], vecs [][]float32) error
 
 	// UpsertByCategoryID inserts data bypassing Category lookup.
-	UpsertByCategoryID(ctx context.Context, catID sop.UUID, catCenterVector []float32, item Item[T], vecs [][]float32) error
+	// vecs are DocumentTexts (768 dim), classificationVecs are CategoryTexts (256 dim) for DistanceToCategory.
+	UpsertByCategoryID(ctx context.Context, catID sop.UUID, catCenterVector []float32, item Item[T], vecs [][]float32, classificationVecs [][]float32) error
 
 	// UpsertBatch adds or updates multiple items in the store efficiently.
 	UpsertBatch(ctx context.Context, items []Item[T], vecs [][]float32) error
@@ -53,6 +54,10 @@ type MemoryStore[T any] interface {
 	// Query searches for the nearest neighbors to the given vector coordinates.
 	// filters is a function that returns true if the item should be included.
 	Query(ctx context.Context, vec []float32, opts *SearchOptions[T]) ([]ai.Hit[T], error)
+
+	// QueryItems searches stored items for the already-resolved category.
+	// This lets the KnowledgeBase path reuse resolved categories instead of resolving them again.
+	QueryItems(ctx context.Context, vec []float32, category *Category, opts *SearchOptions[T]) ([]ai.Hit[T], error)
 
 	// QueryBatch searches for the nearest neighbors for a slice of query vectors.
 	QueryBatch(ctx context.Context, vecs [][]float32, opts *SearchOptions[T]) ([][]ai.Hit[T], error)
@@ -129,5 +134,15 @@ type SearchOptions[T any] struct {
 	// CategoryVector can be used to search for items within a given category.
 	// The Category whose CenterVector is closest to this vector will be used as the search Category.
 	CategoryVector []float32
+	Filter         func(T) bool
+}
+
+// SearchRequest is the reusable public contract for single and batch retrieval.
+type SearchRequest[T any] struct {
+	Text           string
+	Vector         []float32
+	CategoryPath   string
+	CategoryVector []float32
+	Limit          int
 	Filter         func(T) bool
 }

--- a/ai/memory/knowledge_base.go
+++ b/ai/memory/knowledge_base.go
@@ -1,17 +1,21 @@
 package memory
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	log "log/slog"
-
+	"reflect"
+	"sort"
+	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/sharedcode/sop"
 	"github.com/sharedcode/sop/ai"
+	"github.com/sharedcode/sop/ai/embed"
 )
 
 // KnowledgeBase provides a clean, unified API for developers.
@@ -32,21 +36,223 @@ func (kb *KnowledgeBase[T]) Name() string {
 	return kb.Store.Name()
 }
 
-func (kb *KnowledgeBase[T]) SearchSemanticsBatch(ctx context.Context, queryVectors [][]float32, opts *SearchOptions[T]) ([][]ai.Hit[T], error) {
-	config, err := kb.GetConfig(ctx)
-	if err == nil && config != nil && config.LastVectorized == 0 {
-		return nil, fmt.Errorf("Knowledge base is not vectorized")
+func isNilGenericValue[T any](v T) bool {
+	value := reflect.ValueOf(v)
+	if !value.IsValid() {
+		return true
 	}
-	return kb.Store.QueryBatch(ctx, queryVectors, opts)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
-// SearchKeywordsBatch executes textual BM25 text-matched sparse searches for multiple text payloads.
-func (kb *KnowledgeBase[T]) SearchKeywordsBatch(ctx context.Context, textQueries []string, opts *SearchOptions[T]) ([][]ai.Hit[T], error) {
-	config, err := kb.GetConfig(ctx)
-	if err == nil && config != nil && config.LastVectorized == 0 {
-		return nil, fmt.Errorf("Knowledge base is not vectorized")
+func uniqueCategories(cats []*Category) []*Category {
+	seen := make(map[sop.UUID]struct{}, len(cats))
+	unique := make([]*Category, 0, len(cats))
+	for _, cat := range cats {
+		if cat == nil || cat.ID.IsNil() {
+			continue
+		}
+		if _, ok := seen[cat.ID]; ok {
+			continue
+		}
+		seen[cat.ID] = struct{}{}
+		unique = append(unique, cat)
 	}
-	return kb.Store.QueryTextBatch(ctx, textQueries, opts)
+	return unique
+}
+
+// findCategoryByPath tries lexical lookup first, then semantic fallback via CategoryText embedding.
+func (kb *KnowledgeBase[T]) findCategoryByPath(ctx context.Context, path string) ([]*Category, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+
+	// Try lexical lookup
+	catsByPath, err := kb.Store.CategoriesByPath(ctx)
+	if err != nil {
+		return nil, err
+	}
+	found, err := catsByPath.Find(ctx, path, false)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		catID, err := catsByPath.GetCurrentValue(ctx)
+		if err != nil {
+			return nil, err
+		}
+		cats, err := kb.Store.Categories(ctx)
+		if err != nil {
+			return nil, err
+		}
+		foundCat, err := cats.Find(ctx, catID, false)
+		if err != nil {
+			return nil, err
+		}
+		if foundCat {
+			cat, err := cats.GetCurrentValue(ctx)
+			if err == nil && cat != nil && !cat.ID.IsNil() {
+				return []*Category{cat}, nil
+			}
+		}
+	}
+
+	// Semantic fallback via CategoryByDistance.
+	// If the KB has not been vectorized yet, skip the semantic path instead of failing the lookup.
+	if kb.Manager != nil && kb.Manager.embedder != nil {
+		partsVecs, err := embedCategoryPath(ctx, path, kb.Manager.embedder)
+		if err != nil {
+			return nil, err
+		}
+		cats, err := kb.Store.SemanticCategoryByPath(ctx, partsVecs)
+		if err != nil {
+			if strings.Contains(strings.ToLower(err.Error()), "domain reference vector is not set") {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return cats, nil
+	}
+
+	return nil, nil
+}
+
+func NormalizeCategoryToken(text string) string {
+	text = strings.TrimSpace(text)
+	text = strings.ToLower(text)
+	text = strings.NewReplacer(
+		"c#", "csharp",
+		"c++", "cpp",
+		".net", "dotnet",
+		"&", " and ",
+		"＆", " and ",
+		"/", " ",
+		"／", " ",
+		"\\", " ",
+		">", " ",
+		"|", " ",
+		"-", " ",
+		"_", " ",
+		":", " ",
+		"：", " ",
+		";", " ",
+		"；", " ",
+		"(", " ",
+		")", " ",
+		"（", " ",
+		"）", " ",
+		"[", " ",
+		"]", " ",
+		"【", " ",
+		"】", " ",
+		"{", " ",
+		"}", " ",
+		"+", " ",
+		"=", " ",
+		"@", " ",
+		"#", " ",
+		"%", " ",
+		"$", " ",
+		"!", " ",
+		"?", " ",
+		".", " ",
+		",", " ",
+		"'", " ",
+		"\"", " ",
+		"，", " ",
+		"。", " ",
+		"！", " ",
+		"？", " ",
+	).Replace(text)
+	text = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'Ａ' && r <= 'Ｚ':
+			return r - 'Ａ' + 'A'
+		case r >= 'ａ' && r <= 'ｚ':
+			return r - 'ａ' + 'a'
+		case r >= '０' && r <= '９':
+			return r - '０' + '0'
+		case unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsSpace(r):
+			return r
+		default:
+			return ' '
+		}
+	}, text)
+	text = strings.Join(strings.Fields(text), " ")
+	return text
+}
+
+func normalize(text string) string {
+	return NormalizeCategoryToken(text)
+}
+
+func embedCategoryPath(ctx context.Context, catPath string, embedder ai.Embeddings) ([][]float32, error) {
+	return CategoryPathVectors(ctx, catPath, embedder)
+}
+
+func CategoryPathVectors(ctx context.Context, catPath string, embedder ai.Embeddings) ([][]float32, error) {
+	parts := strings.Split(catPath, "/")
+	if len(parts) == 0 || (len(parts) == 1 && strings.TrimSpace(parts[0]) == "") {
+		parts = strings.Split(catPath, "\\")
+	}
+	if len(parts) == 0 || (len(parts) == 1 && strings.TrimSpace(parts[0]) == "") {
+		return nil, nil
+	}
+
+	cleanParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		cleanPart := normalize(part)
+		if cleanPart != "" {
+			cleanParts = append(cleanParts, cleanPart)
+		}
+	}
+	if len(cleanParts) == 0 {
+		return nil, nil
+	}
+
+	vecs, err := embed.CategoryTexts(ctx, embedder, cleanParts)
+	if err != nil {
+		return nil, err
+	}
+	return vecs, nil
+}
+
+// findCategoriesByTextSearch extracts categories from text search results.
+func (kb *KnowledgeBase[T]) findCategoriesByTextSearch(ctx context.Context, text string, limit int) ([]*Category, error) {
+	if strings.TrimSpace(text) == "" {
+		return nil, nil
+	}
+
+	// Delegate to store to extract categories from text index
+	if s, ok := kb.Store.(interface {
+		GetCategoriesFromTextSearch(context.Context, string) ([]*Category, error)
+	}); ok {
+		return s.GetCategoriesFromTextSearch(ctx, text)
+	}
+
+	return nil, nil
+}
+
+func mergeSearchHits[T any](semanticHits, textHits []ai.Hit[T]) []ai.Hit[T] {
+	seen := make(map[string]struct{}, len(semanticHits)+len(textHits))
+	merged := make([]ai.Hit[T], 0, len(semanticHits)+len(textHits))
+
+	for _, hit := range append(append([]ai.Hit[T]{}, semanticHits...), textHits...) {
+		key := fmt.Sprintf("%v", hit.ID)
+		if hit.DocID != nil {
+			key = fmt.Sprintf("%v:%v", hit.DocID, hit.ID)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, hit)
+	}
+	return merged
 }
 
 func searchOptionsSummary[T any](opts *SearchOptions[T]) []any {
@@ -56,40 +262,111 @@ func searchOptionsSummary[T any](opts *SearchOptions[T]) []any {
 	return []any{"limit", opts.Limit, "category_path", opts.CategoryPath, "has_filter", opts.Filter != nil}
 }
 
-// SearchSemantics executes a spatial search (vector matching against mathematical bounds).
-func (kb *KnowledgeBase[T]) SearchSemantics(ctx context.Context, queryVector []float32, opts *SearchOptions[T]) ([]ai.Hit[T], error) {
-	log.Info("SearchSemantics invoked",
-		append([]any{"kb", kb.Name(), "query_vector_len", len(queryVector)}, searchOptionsSummary(opts)...)...)
-	config, err := kb.GetConfig(ctx)
-	if err == nil && config != nil && config.LastVectorized == 0 {
-		log.Warn("SearchSemantics blocked: KB not vectorized", "kb", kb.Name(), "last_vectorized", config.LastVectorized)
-		return nil, fmt.Errorf("Knowledge base is not vectorized")
+// Search provides one reusable entry point for single or batch retrieval.
+// Precedence:
+// 1. If CategoryPath specified: try CategoryByPath, fallback to CategoryByDistance
+// 2. If no category yet and Text present: use CategoryText embedding to get resolved in CategoryByDistance + TextSearch categories. (BOTH)
+// 3. If no category found: short circuit and return empty
+// 4. Use found categories to do vector search
+// 5. Return matching items
+func (kb *KnowledgeBase[T]) Search(ctx context.Context, requests []SearchRequest[T]) ([][]ai.Hit[T], error) {
+	if len(requests) == 0 {
+		return nil, nil
 	}
-	hits, err := kb.Store.Query(ctx, queryVector, opts)
-	if err != nil {
-		log.Error("SearchSemantics failed", "kb", kb.Name(), "error", err)
-	} else {
-		log.Info("SearchSemantics completed", "kb", kb.Name(), "hit_count", len(hits))
-	}
-	return hits, err
-}
 
-// SearchKeywords executes a traditional textual BM25 text-matched sparse search.
-func (kb *KnowledgeBase[T]) SearchKeywords(ctx context.Context, textQuery string, opts *SearchOptions[T]) ([]ai.Hit[T], error) {
-	log.Info("SearchKeywords invoked",
-		append([]any{"kb", kb.Name(), "query", textQuery}, searchOptionsSummary(opts)...)...)
-	config, err := kb.GetConfig(ctx)
-	if err == nil && config != nil && config.LastVectorized == 0 {
-		log.Warn("SearchKeywords blocked: KB not vectorized", "kb", kb.Name(), "last_vectorized", config.LastVectorized)
-		return nil, fmt.Errorf("Knowledge base is not vectorized")
+	results := make([][]ai.Hit[T], 0, len(requests))
+	for _, req := range requests {
+		var candidates []*Category
+
+		// Step 1: If CategoryPath specified, try CategoryByPath then CategoryByDistance
+		if strings.TrimSpace(req.CategoryPath) != "" {
+			cats, err := kb.findCategoryByPath(ctx, req.CategoryPath)
+			if err != nil {
+				return nil, err
+			}
+			if len(cats) > 0 {
+				candidates = append(candidates, cats...)
+			}
+		}
+
+		// Step 2: If no category yet and Text present, use CategoryText embedding to get resolved in CategoryByDistance + TextSearch categories. (BOTH)
+		if len(candidates) == 0 && strings.TrimSpace(req.Text) != "" {
+			// Use CategoryText embedding to get resolved in CategoryByDistance
+			if kb.Manager != nil && kb.Manager.embedder != nil {
+				vecs, err := embed.CategoryTexts(ctx, kb.Manager.embedder, []string{normalize(req.Text)})
+				if err == nil && len(vecs) > 0 {
+					cat, _, err := kb.Manager.FindClosestCategory(ctx, vecs[0])
+					if err == nil && cat != nil {
+						candidates = append(candidates, cat)
+					}
+				}
+			}
+
+			// ALSO get categories from TextSearch (BOTH paths, not fallback)
+			textCats, err := kb.findCategoriesByTextSearch(ctx, req.Text, req.Limit)
+			if err == nil && len(textCats) > 0 {
+				candidates = append(candidates, textCats...)
+			}
+		}
+
+		// Step 3: Short circuit if no category found
+		if len(candidates) == 0 {
+			continue
+		}
+
+		// Step 4: Use found categories to do vector search
+		queryVector := req.Vector
+		if len(queryVector) == 0 && strings.TrimSpace(req.Text) != "" && kb.Manager != nil && kb.Manager.embedder != nil {
+			vecs, err := embed.QueryTexts(ctx, kb.Manager.embedder, []string{normalize(req.Text)})
+			if err == nil && len(vecs) > 0 {
+				queryVector = vecs[0]
+			}
+		}
+
+		var hits []ai.Hit[T]
+
+		candidates = uniqueCategories(candidates)
+		for _, cat := range candidates {
+			catOpts := &SearchOptions[T]{
+				Limit:          req.Limit,
+				CategoryVector: cat.CenterVector,
+				Filter:         req.Filter,
+			}
+			catHits, err := kb.Store.QueryItems(ctx, queryVector, cat, catOpts)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(catHits) == 0 {
+				continue
+			}
+
+			// Boost items from better-matching categories by incorporating category distance
+			if len(queryVector) > 0 && len(cat.CenterVector) > 0 {
+				categoryDist := Distance(queryVector, cat.CenterVector, true)
+				// Adjust scores: smaller category distance = better match = higher score
+				// Category distance penalty scaled to keep item scores dominant
+				for i := range catHits {
+					catHits[i].Score = catHits[i].Score - (categoryDist * 0.1)
+				}
+			}
+
+			hits = append(hits, catHits...)
+		}
+
+		// Step 5: Sort by adjusted scores (category distance + item score)
+		if len(hits) > 1 {
+			sort.Slice(hits, func(i, j int) bool {
+				return hits[i].Score > hits[j].Score
+			})
+		}
+
+		// Return matching items
+		if len(hits) > 0 {
+			results = append(results, hits)
+		}
 	}
-	hits, err := kb.Store.QueryText(ctx, textQuery, opts)
-	if err != nil {
-		log.Error("SearchKeywords failed", "kb", kb.Name(), "error", err)
-	} else {
-		log.Info("SearchKeywords completed", "kb", kb.Name(), "hit_count", len(hits))
-	}
-	return hits, err
+	return results, nil
 }
 
 // Thought represents the individual entity of data in a batch categorization execution.
@@ -175,16 +452,77 @@ func (kb *KnowledgeBase[T]) IngestThoughts(ctx context.Context, thoughts []Thoug
 	}
 
 	// 4. Ensure Categories and Store
-	catCache := make(map[string]sop.UUID)
-	for _, thought := range thoughts {
-		catID, exists := catCache[thought.CategoryPath]
+	catCache := make(map[string]*Category)
+
+	// Batch collect all summaries for classification embedding
+	type thoughtWithIndex struct {
+		thought Thought[T]
+		index   int
+	}
+	var needsClassificationVecs []thoughtWithIndex
+	var allClassificationTexts []string
+
+	for i, thought := range thoughts {
+		if len(thought.Summaries) > 0 {
+			needsClassificationVecs = append(needsClassificationVecs, thoughtWithIndex{thought, i})
+			allClassificationTexts = append(allClassificationTexts, thought.Summaries...)
+		}
+	}
+
+	// Batch embed all classification vectors at once
+	var allClassificationVecs [][]float32
+	if len(allClassificationTexts) > 0 && kb.Manager != nil && kb.Manager.embedder != nil {
+		vecs, err := embed.CategoryTexts(ctx, kb.Manager.embedder, allClassificationTexts)
+		if err == nil {
+			allClassificationVecs = vecs
+		}
+	}
+
+	// Map classification vectors back to thoughts
+	thoughtClassificationVecs := make(map[int][][]float32)
+	vecIdx := 0
+	for _, twi := range needsClassificationVecs {
+		summaryCount := len(twi.thought.Summaries)
+		if vecIdx+summaryCount <= len(allClassificationVecs) {
+			thoughtClassificationVecs[twi.index] = allClassificationVecs[vecIdx : vecIdx+summaryCount]
+			vecIdx += summaryCount
+		}
+	}
+
+	for i, thought := range thoughts {
+		cat, exists := catCache[thought.CategoryPath]
 		if !exists {
-			var err error
-			catID, err = kb.Manager.EnsureCategory(ctx, thought.CategoryPath)
+			catID, err := kb.Manager.EnsureCategory(ctx, thought.CategoryPath)
 			if err != nil {
 				return err
 			}
-			catCache[thought.CategoryPath] = catID
+			// Retrieve the full category object
+			cats, err := kb.Store.Categories(ctx)
+			if err != nil {
+				return err
+			}
+			found, err := cats.Find(ctx, catID, false)
+			if err != nil {
+				return err
+			}
+			if !found {
+				return fmt.Errorf("category not found after ensuring: %v", catID)
+			}
+			cat, err = cats.GetCurrentValue(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Initialize CenterVector if empty - must use CategoryTexts (classification space)
+			if len(cat.CenterVector) == 0 && kb.Manager != nil && kb.Manager.embedder != nil {
+				catVecs, err := embed.CategoryTexts(ctx, kb.Manager.embedder, []string{normalize(cat.Name)})
+				if err == nil && len(catVecs) > 0 && len(catVecs[0]) > 0 {
+					cat.CenterVector = catVecs[0]
+					// Update the category in the store
+					cats.UpdateCurrentItem(ctx, cat.ID, cat)
+				}
+			}
+			catCache[thought.CategoryPath] = cat
 		}
 
 		item := Item[T]{
@@ -196,7 +534,10 @@ func (kb *KnowledgeBase[T]) IngestThoughts(ctx context.Context, thoughts []Thoug
 			VectorHash: thought.VectorHash,
 		}
 
-		err := kb.Store.UpsertByCategoryID(ctx, catID, nil, item, thought.Vectors)
+		// Use pre-batched classification vectors
+		classificationVecs := thoughtClassificationVecs[i]
+
+		err := kb.Store.UpsertByCategoryID(ctx, cat.ID, cat.CenterVector, item, thought.Vectors, classificationVecs)
 		if err != nil {
 			return err
 		}
@@ -230,6 +571,57 @@ func (kb *KnowledgeBase[T]) TriggerSleepCycle(ctx context.Context) error {
 	return nil
 }
 
+func encodeConfigValue[T any](config *KnowledgeBaseConfig) (T, error) {
+	var zero T
+	if config == nil {
+		return zero, nil
+	}
+
+	configBytes, err := json.Marshal(config)
+	if err != nil {
+		return zero, err
+	}
+
+	valueType := reflect.TypeOf(zero)
+	if valueType == nil {
+		return zero, nil
+	}
+	if valueType.Kind() == reflect.String {
+		value := reflect.ValueOf(string(configBytes)).Convert(valueType)
+		return value.Interface().(T), nil
+	}
+
+	var v T
+	if err := json.Unmarshal(configBytes, &v); err != nil {
+		return zero, err
+	}
+	return v, nil
+}
+
+func decodeConfigValue[T any](data T) (*KnowledgeBaseConfig, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	trimmed := bytes.TrimSpace(b)
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var stored string
+		if err := json.Unmarshal(trimmed, &stored); err == nil {
+			trimmed = bytes.TrimSpace([]byte(stored))
+		}
+	}
+
+	var cfg KnowledgeBaseConfig
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil, nil
+	}
+	if err := json.Unmarshal(trimmed, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
 // GetConfig retrieves the metadata configuration for this KnowledgeBase.
 func (kb *KnowledgeBase[T]) GetConfig(ctx context.Context) (*KnowledgeBaseConfig, error) {
 	if kb.configCache != nil {
@@ -255,18 +647,13 @@ func (kb *KnowledgeBase[T]) GetConfig(ctx context.Context) (*KnowledgeBaseConfig
 		return nil, err
 	}
 
-	b, err := json.Marshal(item.Data)
+	cfg, err := decodeConfigValue(item.Data)
 	if err != nil {
 		return nil, err
 	}
 
-	var cfg KnowledgeBaseConfig
-	if err := json.Unmarshal(b, &cfg); err != nil {
-		return nil, err
-	}
-
-	kb.configCache = &cfg
-	return &cfg, nil
+	kb.configCache = cfg
+	return cfg, nil
 }
 
 // SetConfig saves the metadata configuration for this KnowledgeBase.
@@ -278,19 +665,15 @@ func (kb *KnowledgeBase[T]) SetConfig(ctx context.Context, config *KnowledgeBase
 
 	nilKey := ItemKey{CategoryID: sop.NilUUID, ItemID: sop.NilUUID}
 
-	var v T
-	configBytes, err := json.Marshal(config)
+	storedData, err := encodeConfigValue[T](config)
 	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(configBytes, &v); err != nil {
 		return err
 	}
 
 	configItem := Item[T]{
 		ID:         sop.NilUUID,
 		CategoryID: sop.NilUUID,
-		Data:       v,
+		Data:       storedData,
 	}
 
 	_, err = itemsBtree.Upsert(ctx, nilKey, configItem)
@@ -300,12 +683,49 @@ func (kb *KnowledgeBase[T]) SetConfig(ctx context.Context, config *KnowledgeBase
 	return err
 }
 
+// Initialize ensures the knowledge base has an embedder attached based on its persisted config.
+// It uses the configured embedder name and dimension when available, falling back to a simple embedder.
+func (kb *KnowledgeBase[T]) Initialize(ctx context.Context) error {
+	if kb == nil || kb.Manager == nil {
+		return nil
+	}
+	if kb.Manager.embedder != nil {
+		return nil
+	}
+
+	cfg, err := kb.GetConfig(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		return nil
+	}
+
+	dim := cfg.EmbedderDimension
+	name := strings.TrimSpace(cfg.Embedder)
+	if name == "" {
+		name = kb.Store.Name()
+	}
+	if name == "" {
+		name = "simple"
+	}
+
+	embedder, err := embed.NewFromName(name, dim)
+	if err != nil {
+		return err
+	}
+	if embedder != nil {
+		kb.Manager.embedder = embedder
+	}
+	return nil
+}
+
 // ComputeVectorHash computes a predictable string hash representing the text content.
 // We optionally include dimensions, but explicitly exclude embedderName so that compatible models (same dims) don't trigger re-vectorization unless content actually changes.
 func ComputeVectorHash(embedderDim int, texts ...string) string {
 	hasher := sha256.New()
 
-	dimStr := "dim:" + string(rune(embedderDim)) + "::"
+	dimStr := "dim:" + strconv.Itoa(embedderDim) + "::"
 	hasher.Write([]byte(dimStr))
 
 	for _, t := range texts {

--- a/ai/memory/knowledge_base_crud.go
+++ b/ai/memory/knowledge_base_crud.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sharedcode/sop"
 	"github.com/sharedcode/sop/ai"
+	"github.com/sharedcode/sop/ai/embed"
 )
 
 // ============================================================================
@@ -97,9 +98,15 @@ func (kb *KnowledgeBase[T]) UpsertCategories(ctx context.Context, params []Upser
 
 		found, _ := catBtree.Find(ctx, p.Category.ID, false)
 		if found {
-			_, _ = catBtree.Update(ctx, p.Category.ID, p.Category)
+			_, err = catBtree.Update(ctx, p.Category.ID, p.Category)
+			if err != nil {
+				return err
+			}
 		} else {
-			_, _ = catBtree.Add(ctx, p.Category.ID, p.Category)
+			_, err = catBtree.Add(ctx, p.Category.ID, p.Category)
+			if err != nil {
+				return err
+			}
 		}
 
 		path := p.Category.Path
@@ -109,9 +116,15 @@ func (kb *KnowledgeBase[T]) UpsertCategories(ctx context.Context, params []Upser
 		if path != "" {
 			foundPath, _ := catsByPath.Find(ctx, path, false)
 			if foundPath {
-				_, _ = catsByPath.Update(ctx, path, p.Category.ID)
+				_, err = catsByPath.Update(ctx, path, p.Category.ID)
+				if err != nil {
+					return err
+				}
 			} else {
-				_, _ = catsByPath.Add(ctx, path, p.Category.ID)
+				_, err = catsByPath.Add(ctx, path, p.Category.ID)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -124,7 +137,10 @@ func (kb *KnowledgeBase[T]) DeleteCategories(ctx context.Context, categoryIDs []
 		return err
 	}
 	for _, id := range categoryIDs {
-		_, _ = tree.Remove(ctx, id)
+		_, err = tree.Remove(ctx, id)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -149,7 +165,10 @@ func (kb *KnowledgeBase[T]) ListCategories(ctx context.Context, param ListCatego
 
 	var categories []Category
 	matchCount := 0
-	ok, _ := catsTree.First(ctx)
+	ok, err := catsTree.First(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	for ok {
 		cat, _ := catsTree.GetCurrentValue(ctx)
@@ -306,19 +325,233 @@ func (kb *KnowledgeBase[T]) ListItems(ctx context.Context, param ListItemsParam)
 	return items, totalCount, nil
 }
 
-func convertToVectors(ctx context.Context, catPath string, embedder ai.Embeddings) ([][]float32, error) {
-	parts := strings.Split(catPath, "/")
-	if len(parts) == 0 {
-		parts = strings.Split(catPath, "\\")
+func chooseCategoryAnchor(name, description, systemPrompt string) string {
+	if text := strings.TrimSpace(name); text != "" {
+		return normalize(text)
 	}
-	if len(parts) == 0 {
-		return nil, nil
+	if text := strings.TrimSpace(description); text != "" {
+		return normalize(text)
 	}
-	vecs, err := embedder.EmbedTexts(ctx, parts)
+	return normalize(strings.TrimSpace(systemPrompt))
+}
+
+func (kb *KnowledgeBase[T]) RefreshSemanticVectors(ctx context.Context) error {
+	return refreshSemanticVectors(ctx, kb)
+}
+
+func refreshSemanticVectors[T any](ctx context.Context, kb *KnowledgeBase[T]) error {
+	if kb == nil || kb.Manager == nil || kb.Manager.embedder == nil {
+		return nil
+	}
+
+	targetDim := kb.Manager.embedder.Dim()
+	if targetDim <= 0 {
+		return nil
+	}
+
+	cats, err := kb.Store.Categories(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return vecs, nil
+	catsByDist, err := kb.Store.CategoriesByDistance(ctx)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := kb.GetConfig(ctx)
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		cfg = &KnowledgeBaseConfig{}
+	}
+
+	needRefresh := catsByDist.Count() == 0
+	if !needRefresh && len(kb.Store.DomainReference()) != targetDim {
+		needRefresh = true
+	}
+	if !needRefresh {
+		ok, err := cats.First(ctx)
+		if err != nil {
+			return err
+		}
+		for ok {
+			cat, err := cats.GetCurrentValue(ctx)
+			if err != nil {
+				return err
+			}
+			if cat == nil {
+				break
+			}
+			text := chooseCategoryAnchor(cat.Name, cat.Description, cfg.SystemPrompt)
+			if len(cat.CenterVector) != targetDim || cat.VectorHash != ComputeVectorHash(targetDim, text) {
+				needRefresh = true
+				break
+			}
+			ok, err = cats.Next(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if !needRefresh {
+		return nil
+	}
+
+	if len(kb.Store.DomainReference()) != targetDim {
+		anchor := chooseCategoryAnchor(kb.Store.Name(), cfg.Description, cfg.SystemPrompt)
+		if anchor == "" {
+			anchor = kb.Store.Name()
+		}
+		if anchor != "" {
+			vecs, err := embed.CategoryTexts(ctx, kb.Manager.embedder, []string{anchor})
+			if err != nil {
+				return err
+			}
+			if len(vecs) > 0 && len(vecs[0]) == targetDim {
+				cfg.DomainReference = vecs[0]
+				kb.Store.SetDomainReference(vecs[0])
+			}
+		}
+	}
+
+	if cfg.DomainReference != nil && len(cfg.DomainReference) == targetDim {
+		if err := kb.SetConfig(ctx, cfg); err != nil {
+			return err
+		}
+	}
+
+	oldVectors := map[sop.UUID][]float32{}
+	newVectors := map[sop.UUID][]float32{}
+	ok, err := cats.First(ctx)
+	if err != nil {
+		return err
+	}
+	for ok {
+		cat, err := cats.GetCurrentValue(ctx)
+		if err != nil {
+			return err
+		}
+		if cat == nil {
+			break
+		}
+		text := chooseCategoryAnchor(cat.Name, cat.Description, cfg.SystemPrompt)
+		oldVectors[cat.ID] = append([]float32(nil), cat.CenterVector...)
+		if text == "" {
+			ok, err = cats.Next(ctx)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		if len(cat.CenterVector) != targetDim || cat.VectorHash != ComputeVectorHash(targetDim, text) {
+			vecs, err := embed.CategoryTexts(ctx, kb.Manager.embedder, []string{text})
+			if err != nil {
+				return err
+			}
+			if len(vecs) > 0 && len(vecs[0]) == targetDim {
+				cat.CenterVector = vecs[0]
+				cat.VectorHash = ComputeVectorHash(targetDim, text)
+				if _, err := cats.UpdateCurrentItem(ctx, cat.ID, cat); err != nil {
+					return err
+				}
+			}
+		}
+		newVectors[cat.ID] = cat.CenterVector
+		ok, err = cats.Next(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	ok, err = catsByDist.First(ctx)
+	for ok && err == nil {
+		if _, err := catsByDist.RemoveCurrentItem(ctx); err != nil {
+			return err
+		}
+		ok, err = catsByDist.Next(ctx)
+	}
+	if err != nil {
+		return err
+	}
+
+	ok, err = cats.First(ctx)
+	if err != nil {
+		return err
+	}
+	for ok {
+		cat, err := cats.GetCurrentValue(ctx)
+		if err != nil {
+			return err
+		}
+		if cat == nil {
+			break
+		}
+		refVec := kb.Store.DomainReference()
+		if len(cat.ParentIDs) > 0 {
+			for _, parent := range cat.ParentIDs {
+				if len(newVectors[parent.ParentID]) > 0 {
+					refVec = newVectors[parent.ParentID]
+					break
+				}
+				if len(oldVectors[parent.ParentID]) > 0 {
+					refVec = oldVectors[parent.ParentID]
+					break
+				}
+			}
+		}
+		if len(refVec) == 0 {
+			refVec = kb.Store.DomainReference()
+		}
+		dist := Distance(refVec, cat.CenterVector, true)
+		if len(cat.ParentIDs) > 0 {
+			for _, parent := range cat.ParentIDs {
+				if _, err := catsByDist.Add(ctx, DistanceKey{ParentID: parent.ParentID, Distance: dist, ID: cat.ID}, 0); err != nil {
+					return err
+				}
+			}
+		} else {
+			if _, err := catsByDist.Add(ctx, DistanceKey{ParentID: sop.NilUUID, Distance: dist, ID: cat.ID}, 0); err != nil {
+				return err
+			}
+		}
+		ok, err = cats.Next(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func refreshSemanticVectorsInWriteTx[T any](ctx context.Context, kb *KnowledgeBase[T]) error {
+	if kb == nil || kb.Manager == nil || kb.Manager.embedder == nil {
+		return nil
+	}
+
+	store, ok := kb.Store.(*store[T])
+	if !ok || store == nil || store.db == nil {
+		return nil
+	}
+
+	writeTx, err := store.db.BeginTransaction(ctx, sop.ForWriting)
+	if err != nil {
+		return err
+	}
+	defer writeTx.Rollback(ctx)
+
+	refreshedKB, err := store.db.OpenKnowledgeBase(ctx, kb.Name(), writeTx, kb.Manager.llm, kb.Manager.embedder, false, true)
+	if err != nil {
+		return err
+	}
+	if err := refreshSemanticVectors(ctx, refreshedKB); err != nil {
+		return err
+	}
+	return writeTx.Commit(ctx)
+}
+
+func convertToVectors(ctx context.Context, catPath string, embedder ai.Embeddings) ([][]float32, error) {
+	return CategoryPathVectors(ctx, catPath, embedder)
 }
 
 // SearchByPath performs hierarchical category path search with dual-mode operation:
@@ -372,14 +605,16 @@ func (kb *KnowledgeBase[T]) SearchByPath(ctx context.Context, params []PathSearc
 			// Try search by Semantic Category Path.
 			vecs, err := convertToVectors(ctx, param.CategoryPath, kb.Manager.embedder)
 			if err != nil {
-				return nil, err
+				log.Warn("SearchByPath semantic fallback skipped", "category_path", param.CategoryPath, "error", err)
+				continue
 			}
 			cats, err := kb.Store.SemanticCategoryByPath(ctx, vecs)
 			if err != nil {
-				return nil, err
+				log.Warn("SearchByPath semantic fallback failed", "category_path", param.CategoryPath, "error", err)
+				continue
 			}
 			if len(cats) > 0 {
-				log.Info("SearchByPath semantic fallback matched", "category_path", param.CategoryPath, "cat_id", cats[0].ID.String())
+				log.Info("SearchByPath semantic fallback matched", "category_path", param.CategoryPath, "selected_cat_id", cats[0].ID.String(), "selected_cat_path", cats[0].Path, "candidate_count", len(cats), "candidate_ids", categoryIDs(cats), "candidate_paths", categoryPaths(cats))
 				// Just pick one for MVP.
 				catID = cats[0].ID
 			} else {
@@ -401,6 +636,8 @@ func (kb *KnowledgeBase[T]) SearchByPath(ctx context.Context, params []PathSearc
 			}
 		}
 
+		log.Info("SearchByPath leaf item scan", "category_path", param.CategoryPath, "search_text", param.SearchText, "selected_cat_id", catID, "item_scan_started", ok)
+		matchCount := 0
 		for ok {
 			itemReq := itemsTree.GetCurrentKey()
 			if itemReq.Key.ItemID.IsNil() {
@@ -411,12 +648,18 @@ func (kb *KnowledgeBase[T]) SearchByPath(ctx context.Context, params []PathSearc
 			}
 
 			item, err := itemsTree.GetCurrentValue(ctx)
-			if err == nil && len(item.Summaries) > 0 && strings.HasPrefix(item.Summaries[0], param.SearchText) {
+			matched := err == nil && len(item.Summaries) > 0 && strings.HasPrefix(item.Summaries[0], param.SearchText)
+			if matched {
+				matchCount++
+				log.Info("SearchByPath leaf item matched", "category_path", param.CategoryPath, "selected_cat_id", catID, "item_id", itemReq.Key.ItemID, "summary_prefix", item.Summaries[0], "search_text", param.SearchText)
 				results = append(results, item)
+			} else {
+				log.Debug("SearchByPath leaf item skipped", "category_path", param.CategoryPath, "selected_cat_id", catID, "item_id", itemReq.Key.ItemID, "summary_count", len(item.Summaries), "search_text", param.SearchText)
 			}
 
 			ok, _ = itemsTree.Next(ctx)
 		}
+		log.Info("SearchByPath leaf item summary", "category_path", param.CategoryPath, "selected_cat_id", catID, "match_count", matchCount, "result_count", len(results))
 	}
 
 	if results == nil {

--- a/ai/memory/knowledge_base_crud_test.go
+++ b/ai/memory/knowledge_base_crud_test.go
@@ -2,10 +2,12 @@ package memory
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/sharedcode/sop"
+	"github.com/sharedcode/sop/ai"
 	"github.com/sharedcode/sop/inmemory"
 )
 
@@ -30,10 +32,55 @@ type semanticFallbackStore struct {
 	captured     [][]float32
 }
 
+type modeAwareCategoryEmbedder struct {
+	categoryCalls int
+	queryCalls    int
+	textCalls     int
+	lastTexts     []string
+}
+
+func (m *modeAwareCategoryEmbedder) Name() string { return "mode-aware-category" }
+func (m *modeAwareCategoryEmbedder) Dim() int     { return 3 }
+func (m *modeAwareCategoryEmbedder) EmbedTexts(context.Context, []string) ([][]float32, error) {
+	m.textCalls++
+	return [][]float32{{1, 0, 0}}, nil
+}
+func (m *modeAwareCategoryEmbedder) EmbedCategoryTexts(_ context.Context, texts []string) ([][]float32, error) {
+	m.categoryCalls++
+	m.lastTexts = append([]string(nil), texts...)
+	return [][]float32{{1, 0, 0}}, nil
+}
+func (m *modeAwareCategoryEmbedder) EmbedDocumentTexts(context.Context, []string) ([][]float32, error) {
+	return [][]float32{{0, 0, 1}}, nil
+}
+func (m *modeAwareCategoryEmbedder) EmbedQueryTexts(context.Context, []string) ([][]float32, error) {
+	m.queryCalls++
+	return [][]float32{{0, 1, 0}}, nil
+}
+
+var _ ai.Embeddings = (*modeAwareCategoryEmbedder)(nil)
+var _ ai.EmbeddingModeSupport = (*modeAwareCategoryEmbedder)(nil)
+
 func (s *semanticFallbackStore) SemanticCategoryByPath(ctx context.Context, pathVectors [][]float32) ([]*Category, error) {
 	s.called = true
 	s.captured = append([][]float32(nil), pathVectors...)
 	return s.fallbackCats, nil
+}
+
+func TestEmbedCategoryPath_NormalizesLanguageTokens(t *testing.T) {
+	ctx := context.Background()
+	embedder := &modeAwareCategoryEmbedder{}
+
+	vecs, err := embedCategoryPath(ctx, "Language Bindings/C#", embedder)
+	if err != nil {
+		t.Fatalf("embedCategoryPath failed: %v", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) != 3 {
+		t.Fatalf("embedCategoryPath returned unexpected vectors: %#v", vecs)
+	}
+	if got := embedder.lastTexts; !reflect.DeepEqual(got, []string{"language bindings", "csharp"}) {
+		t.Fatalf("embedCategoryPath normalized tokens = %#v, want %#v", got, []string{"language bindings", "csharp"})
+	}
 }
 
 func TestBatchCategories(t *testing.T) {
@@ -169,7 +216,7 @@ func TestBatchItemsAndSearch(t *testing.T) {
 	}
 }
 
-func TestKnowledgeBase_SearchByPath_FallsBackToSemanticCategoryByPath(t *testing.T) {
+func TestKnowledgeBase_SearchByPath_UsesSemanticFallbackPath(t *testing.T) {
 	ctx := context.Background()
 	base := prepareTestStore()
 	catID := sop.NewUUID()
@@ -233,6 +280,93 @@ func TestKnowledgeBase_SearchByPath_SkipsWhenSemanticFallbackFindsNothing(t *tes
 	}
 	if !fallback.called {
 		t.Fatal("expected SemanticCategoryByPath to be invoked")
+	}
+}
+
+func TestChooseCategoryAnchor_NormalizesProgrammingLanguageTokens(t *testing.T) {
+	if got := chooseCategoryAnchor("Language Bindings/C#", "", ""); got != "language bindings csharp" {
+		t.Fatalf("chooseCategoryAnchor() = %q, want %q", got, "language bindings csharp")
+	}
+}
+
+func TestRefreshSemanticVectors_UsesCategoryEmbeddingMode(t *testing.T) {
+	ctx := context.Background()
+	s := prepareTestStore()
+	s.SetDomainReference([]float32{1, 0, 0})
+
+	embedder := &modeAwareCategoryEmbedder{}
+	kb := &KnowledgeBase[string]{
+		Store:   s,
+		Manager: NewMemoryManager[string](s, &MockLLM{}, embedder),
+	}
+
+	rootID := sop.NewUUID()
+	if _, err := s.AddCategory(ctx, &Category{
+		ID:         rootID,
+		Name:       "Root",
+		VectorHash: "stale",
+	}); err != nil {
+		t.Fatalf("AddCategory(root) failed: %v", err)
+	}
+
+	if err := refreshSemanticVectors(ctx, kb); err != nil {
+		t.Fatalf("refreshSemanticVectors failed: %v", err)
+	}
+	if embedder.categoryCalls == 0 {
+		t.Fatal("expected category embedding mode to be used for category vectors")
+	}
+	if embedder.textCalls != 0 {
+		t.Fatalf("expected generic EmbedTexts not to be used for category vectors, got %d calls", embedder.textCalls)
+	}
+}
+
+func TestRefreshSemanticVectors_RebuildsEmptyDistanceIndex(t *testing.T) {
+	ctx := context.Background()
+	s := prepareTestStore()
+	s.SetDomainReference([]float32{1, 0, 0})
+
+	embedder := &MockPlaybookEmbedder{Rules: []PlaybookRule{
+		{Keywords: []string{"root"}, Vector: []float32{1, 0, 0}},
+		{Keywords: []string{"child"}, Vector: []float32{0, 1, 0}},
+	}}
+	kb := &KnowledgeBase[string]{
+		Store:   s,
+		Manager: NewMemoryManager[string](s, &MockLLM{}, embedder),
+	}
+
+	rootID := sop.NewUUID()
+	childID := sop.NewUUID()
+	if _, err := s.AddCategory(ctx, &Category{
+		ID:           rootID,
+		Name:         "Root",
+		CenterVector: []float32{1, 0, 0},
+		VectorHash:   ComputeVectorHash(3, "Root"),
+	}); err != nil {
+		t.Fatalf("AddCategory(root) failed: %v", err)
+	}
+	if _, err := s.AddCategory(ctx, &Category{
+		ID:           childID,
+		Name:         "Child",
+		CenterVector: []float32{0, 1, 0},
+		VectorHash:   ComputeVectorHash(3, "Child"),
+		ParentIDs:    []CategoryParent{{ParentID: rootID}},
+	}); err != nil {
+		t.Fatalf("AddCategory(child) failed: %v", err)
+	}
+
+	catsByDist, err := s.CategoriesByDistance(ctx)
+	if err != nil {
+		t.Fatalf("CategoriesByDistance failed: %v", err)
+	}
+	if catsByDist.Count() != 0 {
+		t.Fatalf("expected empty distance index before refresh, got %d", catsByDist.Count())
+	}
+
+	if err := refreshSemanticVectors(ctx, kb); err != nil {
+		t.Fatalf("refreshSemanticVectors failed: %v", err)
+	}
+	if catsByDist.Count() == 0 {
+		t.Fatal("expected refreshSemanticVectors to rebuild an empty CategoriesByDistance index")
 	}
 }
 

--- a/ai/memory/knowledge_base_test.go
+++ b/ai/memory/knowledge_base_test.go
@@ -52,25 +52,60 @@ func TestKnowledgeBase_API(t *testing.T) {
 		t.Fatalf("IngestThought failed: %v", err)
 	}
 
-	hits, err := kb.SearchSemantics(ctx, []float32{1.0, 1.0, 1.0}, &SearchOptions[string]{Limit: 10, CategoryPath: "test_id"})
+	batch, err := kb.Search(ctx, []SearchRequest[string]{{Vector: []float32{1.0, 1.0, 1.0}, Limit: 10, CategoryPath: "test_id"}})
 	if err != nil {
-		t.Fatalf("SearchSemantics failed: %v", err)
+		t.Fatalf("Search failed: %v", err)
 	}
-	if len(hits) == 0 {
-		t.Errorf("Expected hits from SearchSemantics, got 0")
+	if len(batch) != 1 || len(batch[0]) == 0 {
+		t.Fatalf("expected semantic hits from Search, got %#v", batch)
 	}
 
-	khits, err := kb.SearchKeywords(ctx, "payload", &SearchOptions[string]{Limit: 10})
+	kbatch, err := kb.Search(ctx, []SearchRequest[string]{{Text: "payload", Limit: 10}})
 	if err != nil {
-		t.Fatalf("SearchKeywords failed: %v", err)
+		t.Fatalf("Search failed: %v", err)
 	}
-	if len(khits) == 0 {
-		t.Errorf("Expected hits from SearchKeywords, got 0")
+	if len(kbatch) != 1 || len(kbatch[0]) == 0 {
+		t.Fatalf("expected keyword hits from Search, got %#v", kbatch)
 	}
 
 	err = kb.TriggerSleepCycle(ctx)
 	if err != nil {
 		t.Fatalf("TriggerSleepCycle failed: %v", err)
+	}
+}
+
+func TestKnowledgeBase_InitializeUsesConfiguredEmbedder(t *testing.T) {
+	ctx := context.Background()
+
+	cats := inmemory.NewBtree[sop.UUID, *Category](true)
+	vecs := inmemory.NewBtree[VectorKey, Vector](false)
+	items := inmemory.NewBtree[ItemKey, Item[string]](false)
+
+	memStore := NewStore[string]("test_kb", nil, cats.Btree, inmemory.NewBtree[string, sop.UUID](false).Btree, inmemory.NewBtree[DistanceKey, byte](false).Btree, vecs.Btree, items.Btree, inmemory.NewBtree[sop.UUID, Document](false).Btree)
+	ds := memStore.(*store[string])
+	ds.SetTextIndex(&MockTextIndex{})
+
+	kb := &KnowledgeBase[string]{
+		Store:   ds,
+		Manager: NewMemoryManager[string](ds, &MockLLM{}, nil),
+	}
+
+	cfg := &KnowledgeBaseConfig{Embedder: "simple", EmbedderDimension: 7}
+	if err := kb.SetConfig(ctx, cfg); err != nil {
+		t.Fatalf("SetConfig failed: %v", err)
+	}
+
+	if err := kb.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	if kb.Manager == nil || kb.Manager.embedder == nil {
+		t.Fatal("expected Initialize to assign an embedder to the manager")
+	}
+	if kb.Manager.embedder.Name() != "simple" {
+		t.Fatalf("expected initialized embedder to use config name %q, got %q", "simple", kb.Manager.embedder.Name())
+	}
+	if kb.Manager.embedder.Dim() != 7 {
+		t.Fatalf("expected initialized embedder to use config dimension %d, got %d", 7, kb.Manager.embedder.Dim())
 	}
 }
 
@@ -84,6 +119,7 @@ func TestStaticKnowledgeBase(t *testing.T) {
 	memStore := NewStore[string]("test_kb", nil, categories.Btree, inmemory.NewBtree[string, sop.UUID](false).Btree, inmemory.NewBtree[DistanceKey, byte](false).Btree, vectors.Btree, items.Btree, inmemory.NewBtree[sop.UUID, Document](false).Btree)
 	ds := memStore.(*store[string])
 	ds.SetTextIndex(&MockTextIndex{})
+	ds.SetDomainReference([]float32{0.0, 0.0, 0.0})
 
 	kb := KnowledgeBase[string]{
 		Store:   ds,
@@ -100,38 +136,75 @@ func TestStaticKnowledgeBase(t *testing.T) {
 		t.Fatalf("Insert failed: %v", err)
 	}
 
-	hits, err := kb.SearchSemantics(ctx, []float32{0.1, 0.2, 0.3}, &SearchOptions[string]{Limit: 10, CategoryPath: "Fruits"})
+	batchFruits, err := kb.Search(ctx, []SearchRequest[string]{{Vector: []float32{0.1, 0.2, 0.3}, CategoryPath: "Fruits", Limit: 10}})
 	if err != nil {
-		t.Fatalf("SearchSemantics failed: %v", err)
+		t.Fatalf("Search failed: %v", err)
 	}
-	if len(hits) == 0 {
-		t.Errorf("Expected hits from SearchSemantics in Fruits category, got 0")
-	} else if hits[0].Payload != "apple is a fruit" {
-		t.Errorf("Expected apple is a fruit hit, got %v", hits[0].Payload)
+	if len(batchFruits) != 1 || len(batchFruits[0]) == 0 {
+		t.Fatalf("expected semantic hits in Fruits category, got %#v", batchFruits)
+	} else if batchFruits[0][0].Payload != "apple is a fruit" {
+		t.Errorf("Expected apple is a fruit hit, got %v", batchFruits[0][0].Payload)
 	}
 
-	hitsVehicles, err := kb.SearchSemantics(ctx, []float32{0.1, 0.2, 0.3}, &SearchOptions[string]{Limit: 10, CategoryPath: "Vehicles"})
+	batchVehicles, err := kb.Search(ctx, []SearchRequest[string]{{Vector: []float32{0.1, 0.2, 0.3}, CategoryPath: "Vehicles", Limit: 10}})
 	if err != nil {
-		t.Fatalf("SearchSemantics failed: %v", err)
+		t.Fatalf("Search failed: %v", err)
 	}
-	if len(hitsVehicles) != 1 || hitsVehicles[0].Payload != "car" {
-		t.Errorf("Expected hits from SearchSemantics in Vehicles category")
+	if len(batchVehicles) != 1 || len(batchVehicles[0]) != 1 || batchVehicles[0][0].Payload != "car" {
+		t.Errorf("Expected hits from Search in Vehicles category, got %#v", batchVehicles)
 	}
 
-	khits, err := kb.SearchKeywords(ctx, "fruit", &SearchOptions[string]{CategoryPath: "Fruits", Limit: 10})
+	batchKeyword, err := kb.Search(ctx, []SearchRequest[string]{{Text: "fruit", CategoryPath: "Fruits", Limit: 10}})
 	if err != nil {
-		t.Fatalf("SearchKeywords failed: %v", err)
+		t.Fatalf("Search failed: %v", err)
 	}
-	if len(khits) == 0 {
-		t.Errorf("Expected hits from SearchKeywords, got 0")
+	if len(batchKeyword) != 1 || len(batchKeyword[0]) == 0 {
+		t.Fatalf("expected keyword hits from Search, got %#v", batchKeyword)
 	}
 
-	khitsEmpty, err := kb.SearchKeywords(ctx, "fruit", &SearchOptions[string]{CategoryPath: "NonExistent", Limit: 10})
+	// NonExistent category will semantically fall back to closest category (semantic fallback is intentional)
+	batchEmpty, err := kb.Search(ctx, []SearchRequest[string]{{Text: "fruit", CategoryPath: "NonExistent", Limit: 10}})
 	if err != nil {
-		t.Fatalf("SearchKeywords failed: %v", err)
+		t.Fatalf("Search failed: %v", err)
 	}
-	if len(khitsEmpty) != 0 {
-		t.Errorf("Expected no hits for non-existent category, got %v", khitsEmpty)
+	// With semantic fallback, this will match the closest category
+	if len(batchEmpty) != 1 {
+		t.Fatalf("expected search result with semantic fallback, got %#v", batchEmpty)
+	}
+}
+
+func TestNormalize_NormalizesVectorizationText(t *testing.T) {
+	got := normalize("  A & B / C  ")
+	if got != "a and b c" {
+		t.Fatalf("normalize() = %q, want %q", got, "a and b c")
+	}
+}
+
+func TestNormalize_PreservesUnicodeTextAndNormalizesFullWidthPunctuation(t *testing.T) {
+	got := normalize("  Ａ＆Ｂ 你好 / 世界  ")
+	if got != "a and b 你好 世界" {
+		t.Fatalf("normalize() = %q, want %q", got, "a and b 你好 世界")
+	}
+}
+
+func TestNormalize_StabilizesProgrammingLanguageNames(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "csharp", in: "C#", want: "csharp"},
+		{name: "cpp", in: "C++", want: "cpp"},
+		{name: "dotnet", in: ".NET", want: "dotnet"},
+		{name: "path tokens", in: "Language Bindings/C#", want: "language bindings csharp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalize(tt.in); got != tt.want {
+				t.Fatalf("normalize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -167,6 +240,112 @@ func TestSearchOptionsSummary_SafelyExcludesFilterFunction(t *testing.T) {
 	}
 }
 
+func TestKnowledgeBase_Search_UsesSingleEntryPoint(t *testing.T) {
+	ctx := context.Background()
+
+	cats := inmemory.NewBtree[sop.UUID, *Category](true)
+	vecs := inmemory.NewBtree[VectorKey, Vector](true)
+	items := inmemory.NewBtree[ItemKey, Item[string]](true)
+
+	memStore := NewStore[string]("test_kb", nil, cats.Btree, inmemory.NewBtree[string, sop.UUID](false).Btree, inmemory.NewBtree[DistanceKey, byte](false).Btree, vecs.Btree, items.Btree, inmemory.NewBtree[sop.UUID, Document](false).Btree)
+	memStore.(*store[string]).SetTextIndex(&MockTextIndex{})
+	kb := KnowledgeBase[string]{
+		Store:   memStore,
+		Manager: NewMemoryManager[string](memStore, &MockLLM{}, &MockEmbedder{}),
+	}
+
+	if err := kb.IngestThoughts(ctx, []Thought[string]{{Summaries: []string{"fruit"}, CategoryPath: "Fruits", Vectors: [][]float32{{0.1, 0.2, 0.3}}, Data: "apple is a fruit"}}, ""); err != nil {
+		t.Fatalf("IngestThoughts failed: %v", err)
+	}
+
+	hits, err := kb.Search(ctx, []SearchRequest[string]{{Text: "fruit", Limit: 5}})
+	if err != nil {
+		t.Fatalf("Search failed: %v", err)
+	}
+	if len(hits) != 1 || len(hits[0]) == 0 {
+		t.Fatalf("expected one batch result with hits, got %#v", hits)
+	}
+}
+
+func TestKnowledgeBase_Search_AllowsTextOnlySearchWithoutVectorization(t *testing.T) {
+	ctx := context.Background()
+
+	categories := inmemory.NewBtree[sop.UUID, *Category](true)
+	vectors := inmemory.NewBtree[VectorKey, Vector](true)
+	items := inmemory.NewBtree[ItemKey, Item[string]](true)
+
+	memStore := NewStore[string]("test_kb", nil, categories.Btree, inmemory.NewBtree[string, sop.UUID](false).Btree, inmemory.NewBtree[DistanceKey, byte](false).Btree, vectors.Btree, items.Btree, inmemory.NewBtree[sop.UUID, Document](false).Btree)
+	ds := memStore.(*store[string])
+	ds.SetTextIndex(&MockTextIndex{})
+
+	kb := KnowledgeBase[string]{
+		Store:   ds,
+		Manager: NewMemoryManager[string](ds, &MockLLM{}, &MockEmbedder{}),
+	}
+	kb.configCache = &KnowledgeBaseConfig{LastVectorized: 0}
+
+	if err := kb.IngestThoughts(ctx, []Thought[string]{{Summaries: []string{"fruit"}, CategoryPath: "Fruits", Vectors: [][]float32{{0.1, 0.2, 0.3}}, Data: "apple is a fruit"}}, ""); err != nil {
+		t.Fatalf("IngestThoughts failed: %v", err)
+	}
+
+	batch, err := kb.Search(ctx, []SearchRequest[string]{{Text: "fruit", Limit: 10}})
+	if err != nil {
+		t.Fatalf("Search should allow text-only retrieval even when not vectorized: %v", err)
+	}
+	if len(batch) != 1 || len(batch[0]) == 0 {
+		t.Fatalf("expected text-only hits on non-vectorized KB, got %#v", batch)
+	}
+}
+
+func TestKnowledgeBase_Search_TextQueryCombinesVectorAndTextResults(t *testing.T) {
+	ctx := context.Background()
+
+	categories := inmemory.NewBtree[sop.UUID, *Category](true)
+	vectors := inmemory.NewBtree[VectorKey, Vector](true)
+	items := inmemory.NewBtree[ItemKey, Item[string]](true)
+
+	memStore := NewStore[string]("test_kb", nil, categories.Btree, inmemory.NewBtree[string, sop.UUID](false).Btree, inmemory.NewBtree[DistanceKey, byte](false).Btree, vectors.Btree, items.Btree, inmemory.NewBtree[sop.UUID, Document](false).Btree)
+	ds := memStore.(*store[string])
+	ds.SetTextIndex(&MockTextIndex{})
+
+	embedder := &MockPlaybookEmbedder{Rules: []PlaybookRule{{Keywords: []string{"fruit"}, CategoryName: "Fruit", Vector: []float32{0.9, 0.8, 0.7}}}}
+	kb := KnowledgeBase[string]{
+		Store:   ds,
+		Manager: NewMemoryManager[string](ds, &MockLLM{}, embedder),
+	}
+
+	cat := &Category{ID: sop.NewUUID(), Name: "Fruit", CenterVector: []float32{0.9, 0.8, 0.7}}
+	if _, err := ds.categories.Add(ctx, cat.ID, cat); err != nil {
+		t.Fatalf("add category failed: %v", err)
+	}
+
+	itemA := Item[string]{ID: sop.NewUUID(), CategoryID: cat.ID, Data: "fruit note", Summaries: []string{"fruit"}}
+	if err := ds.UpsertByCategoryID(ctx, cat.ID, cat.CenterVector, itemA, [][]float32{{0.1, 0.2, 0.3}}, nil); err != nil {
+		t.Fatalf("upsert item A failed: %v", err)
+	}
+
+	itemB := Item[string]{ID: sop.NewUUID(), CategoryID: cat.ID, Data: "banana note", Summaries: []string{"banana"}}
+	if err := ds.UpsertByCategoryID(ctx, cat.ID, cat.CenterVector, itemB, [][]float32{{0.9, 0.8, 0.7}}, nil); err != nil {
+		t.Fatalf("upsert item B failed: %v", err)
+	}
+
+	batch, err := kb.Search(ctx, []SearchRequest[string]{{Text: "fruit", Vector: []float32{0.9, 0.8, 0.7}, Limit: 10}})
+	if err != nil {
+		t.Fatalf("Search failed: %v", err)
+	}
+	if len(batch) != 1 || len(batch[0]) != 2 {
+		t.Fatalf("expected text query to combine semantic and text hits, got %#v", batch)
+	}
+
+	got := map[string]bool{}
+	for _, hit := range batch[0] {
+		got[hit.Payload] = true
+	}
+	if !got["fruit note"] || !got["banana note"] {
+		t.Fatalf("expected combined hits for both fruit and banana notes, got %#v", batch[0])
+	}
+}
+
 func TestKnowledgeBase_SearchKeywords_NoTextSearchEnabledReturnsNoHits(t *testing.T) {
 	ctx := context.Background()
 
@@ -180,11 +359,11 @@ func TestKnowledgeBase_SearchKeywords_NoTextSearchEnabledReturnsNoHits(t *testin
 		Manager: NewMemoryManager[string](store, &MockLLM{}, &MockEmbedder{}),
 	}
 
-	hits, err := kb.SearchKeywords(ctx, "fruit", &SearchOptions[string]{Limit: 10})
+	batch, err := kb.Search(ctx, []SearchRequest[string]{{Text: "fruit", Limit: 10}})
 	if err != nil {
-		t.Fatalf("SearchKeywords should not fail when text search is disabled: %v", err)
+		t.Fatalf("Search should not fail when text search is disabled: %v", err)
 	}
-	if len(hits) != 0 {
-		t.Fatalf("expected no keyword hits when text search is disabled, got %v", hits)
+	if len(batch) != 0 {
+		t.Fatalf("expected no search batches when text search is disabled, got %#v", batch)
 	}
 }

--- a/ai/memory/manager_test.go
+++ b/ai/memory/manager_test.go
@@ -21,8 +21,13 @@ func (m *MockEmbedder) EmbedTexts(ctx context.Context, texts []string) ([][]floa
 	}
 	vecs := make([][]float32, len(texts))
 	for i, text := range texts {
-		if text == "SubCat1" {
+		lower := fmt.Sprintf("%s", text)
+		if lower == "subcat1" {
 			vecs[i] = []float32{0.1, 0.2, 0.3} // Close to test vector
+		} else if lower == "fruits" {
+			vecs[i] = []float32{0.2, 0.3, 0.4} // Distinct vector for Fruits category
+		} else if lower == "vehicles" {
+			vecs[i] = []float32{0.8, 0.9, 1.0} // Distinct vector for Vehicles category
 		} else {
 			vecs[i] = []float32{0.5, 0.6, 0.7} // Default mismatch
 		}

--- a/ai/memory/math.go
+++ b/ai/memory/math.go
@@ -5,11 +5,30 @@ import (
 	"sort"
 )
 
+func alignedVectors(a, b []float32) ([]float32, []float32) {
+	if len(a) == 0 || len(b) == 0 {
+		return nil, nil
+	}
+
+	commonLen := len(a)
+	if len(b) < commonLen {
+		commonLen = len(b)
+	}
+
+	if commonLen == len(a) && commonLen == len(b) {
+		return a, b
+	}
+
+	return a[:commonLen], b[:commonLen]
+}
+
 // EuclideanDistance computes the Euclidean distance between two vectors.
 func EuclideanDistance(a, b []float32) float32 {
-	if len(a) != len(b) {
+	a, b = alignedVectors(a, b)
+	if len(a) == 0 || len(b) == 0 {
 		return 0
 	}
+
 	var sum float32
 	for i := range a {
 		diff := a[i] - b[i]
@@ -20,9 +39,11 @@ func EuclideanDistance(a, b []float32) float32 {
 
 // CosineSimilarity computes the mathematical cosine similarity between two vectors.
 func CosineSimilarity(a, b []float32) float32 {
-	if len(a) != len(b) || len(a) == 0 {
+	a, b = alignedVectors(a, b)
+	if len(a) == 0 || len(b) == 0 {
 		return 0
 	}
+
 	var dot, na, nb float32
 	for i := range a {
 		dot += a[i] * b[i]
@@ -38,9 +59,11 @@ func CosineSimilarity(a, b []float32) float32 {
 // 1. THE LIVE SEARCH LOOP (Blazing Fast - No Sqrts, No Divisions)
 // Use this inside your nested category loops to rank your documents.
 func DotProduct(a, b []float32) float32 {
-	if len(a) != len(b) {
+	a, b = alignedVectors(a, b)
+	if len(a) == 0 || len(b) == 0 {
 		return 0
 	}
+
 	var dot float32
 	for i := range a {
 		dot += a[i] * b[i]
@@ -71,7 +94,8 @@ func NormalizeVector(v []float32) []float32 {
 // FastEuclidean outputs the exact same distance metric as traditional Euclidean calculation,
 // but runs up to 4x faster on normalized vectors by utilizing DotProduct internally.
 func FastEuclidean(normalizedVectorA, NormalizedVectorB []float32) float32 {
-	if len(normalizedVectorA) != len(NormalizedVectorB) {
+	normalizedVectorA, NormalizedVectorB = alignedVectors(normalizedVectorA, NormalizedVectorB)
+	if len(normalizedVectorA) == 0 || len(NormalizedVectorB) == 0 {
 		return 0
 	}
 
@@ -101,6 +125,10 @@ func isNormalizedVector(v []float32) bool {
 }
 
 func Distance(a, b []float32, normalized bool) float32 {
+	a, b = alignedVectors(a, b)
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
 	if normalized && isNormalizedVector(a) && isNormalizedVector(b) {
 		return FastEuclidean(a, b)
 	}

--- a/ai/memory/math_test.go
+++ b/ai/memory/math_test.go
@@ -21,9 +21,9 @@ func TestCosineSimilarity(t *testing.T) {
 		t.Errorf("expected 1")
 	}
 
-	// invalid lengths
-	if CosineSimilarity(v1, []float32{1}) != 0 {
-		t.Errorf("expected 0")
+	// shared dimensions should be compared when lengths differ
+	if CosineSimilarity(v1, []float32{1}) != 1 {
+		t.Errorf("expected 1 over the shared dimension")
 	}
 	// zeros
 	if CosineSimilarity([]float32{0, 0, 0}, v1) != 0 {
@@ -43,6 +43,18 @@ func TestNormalizeVectorReturnsUnitNorm(t *testing.T) {
 	}
 	if math.Abs(norm-1) > 1e-6 {
 		t.Fatalf("expected unit norm, got %v", norm)
+	}
+}
+
+func TestDistanceHandlesMismatchedVectorLengths(t *testing.T) {
+	dist := Distance([]float32{1, 0, 0}, []float32{0, 1}, true)
+	if dist != 1.4142135 {
+		t.Fatalf("expected normalized distance over the shared dimensions, got %v", dist)
+	}
+
+	euclid := EuclideanDistance([]float32{1, 1, 1}, []float32{1, 2})
+	if euclid != 1 {
+		t.Fatalf("expected Euclidean distance over the shared dimensions, got %v", euclid)
 	}
 }
 

--- a/ai/memory/playbook_test.go
+++ b/ai/memory/playbook_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/sharedcode/sop"
+	"github.com/sharedcode/sop/ai/embed"
 	"github.com/sharedcode/sop/inmemory"
 )
 
@@ -75,7 +76,8 @@ func (m *MockPlaybookLLM) GenerateCategory(ctx context.Context, payload string) 
 	}
 
 	// Use embedder to fetch center vector for the concept
-	vecs, _ := m.Embedder.EmbedTexts(ctx, []string{catName})
+	// CenterVector is a classifier in classification space
+	vecs, _ := embed.CategoryTexts(ctx, m.Embedder, []string{catName})
 	vector := vecs[0]
 
 	return &Category{
@@ -229,7 +231,7 @@ func TestPlaybookSimulation_Harness(t *testing.T) {
 			// 2. Insert Payloads
 			for _, payload := range tt.Payloads {
 				// Embed to trigger thresholds and knn logic
-				eVecs, _ := embedder.EmbedTexts(ctx, []string{payload})
+				eVecs, _ := embed.DocumentTexts(ctx, embedder, []string{payload})
 				item := Item[string]{
 					ID:   sop.NewUUID(),
 					Data: payload,

--- a/ai/memory/store.go
+++ b/ai/memory/store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	log "log/slog"
 	"math"
+	"sort"
 	"strings"
 
 	"github.com/sharedcode/sop"
@@ -259,12 +260,14 @@ func (s *store[T]) UpsertByCategoryPath(ctx context.Context, categoryName string
 		}
 	}
 
-	return s.UpsertByCategoryID(ctx, c.ID, c.CenterVector, item, vecs)
+	return s.UpsertByCategoryID(ctx, c.ID, c.CenterVector, item, vecs, nil)
 }
 
 // UpsertByCategoryID inserts data bypassing Category lookup.
+// vecs are DocumentTexts (768 dim) used for item similarity search.
+// classificationVecs are CategoryTexts (256 dim) used for calculating DistanceToCategory.
 func (s *store[T]) UpsertByCategoryID(ctx context.Context, catID sop.UUID, catCenterVector []float32,
-	item Item[T], vecs [][]float32) error {
+	item Item[T], vecs [][]float32, classificationVecs [][]float32) error {
 
 	if catID == sop.NilUUID {
 		return fmt.Errorf("catID can't be nil")
@@ -274,10 +277,11 @@ func (s *store[T]) UpsertByCategoryID(ctx context.Context, catID sop.UUID, catCe
 
 	// Insert Vector links
 	var keys []VectorKey
-	for _, vec := range vecs {
+	for i, vec := range vecs {
 		dist := float32(0)
-		if len(catCenterVector) > 0 {
-			dist = Distance(vec, catCenterVector, true)
+		if len(catCenterVector) > 0 && len(classificationVecs) > i && len(classificationVecs[i]) > 0 {
+			// Calculate DistanceToCategory in classification space (CategoryTexts)
+			dist = Distance(classificationVecs[i], catCenterVector, true)
 		}
 		vk := VectorKey{CategoryID: catID, VectorID: sop.NewUUID(), DistanceToCategory: dist}
 
@@ -389,6 +393,10 @@ func (s *store[T]) QueryBatch(ctx context.Context, vectors [][]float32, opts *Se
 // Find Closest Category implements a beam search through the category tree, starting from the root and
 // exploring closest categories at each level until it finds the best overall match for the query vector.
 func (s *store[T]) FindClosestCategory(ctx context.Context, qVec []float32) (*Category, float32, error) {
+	if s.categoriesByDistance == nil || s.categoriesByDistance.Count() == 0 {
+		return s.findClosestCategoryLinear(ctx, qVec)
+	}
+
 	type candidate struct {
 		ParentID sop.UUID
 		Anchor   []float32
@@ -475,6 +483,40 @@ func (s *store[T]) FindClosestCategory(ctx context.Context, qVec []float32) (*Ca
 	return bestGlobalCat, bestGlobalDist, nil
 }
 
+func (s *store[T]) findClosestCategoryLinear(ctx context.Context, qVec []float32) (*Category, float32, error) {
+	ok, err := s.categories.First(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	if !ok {
+		return nil, -1, nil
+	}
+
+	var bestCat *Category
+	var bestDist float32 = -1
+	for ok {
+		cat, err := s.categories.GetCurrentValue(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+		if cat != nil && len(cat.CenterVector) > 0 {
+			dist := Distance(qVec, cat.CenterVector, true)
+			if bestCat == nil || dist < bestDist {
+				bestCat = cat
+				bestDist = dist
+			}
+		}
+		ok, err = s.categories.Next(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	if bestCat == nil {
+		return nil, -1, nil
+	}
+	return bestCat, bestDist, nil
+}
+
 func (s *store[T]) resolveTargetCategory(ctx context.Context, qVec []float32) (*Category, error) {
 	cat, _, err := s.FindClosestCategory(ctx, qVec)
 	return cat, err
@@ -519,37 +561,53 @@ func (s *store[T]) semanticCategoryByPartRecursive(ctx context.Context, parentID
 	if err != nil {
 		return nil, level, err
 	}
+	if len(candidates) == 0 {
+		return nil, level, nil
+	}
 	if level == len(pathVectors)-1 {
 		return candidates, level, nil
 	}
+
 	var result []*Category
+	deepestLevel := level
 	for _, candidate := range candidates {
 		if candidate == nil || candidate.ID.IsNil() {
 			continue
 		}
-		subCandidates, l, err := s.semanticCategoryByPartRecursive(ctx, candidate.ID, candidate.CenterVector, pathVectors, level+1)
+		subCandidates, subLevel, err := s.semanticCategoryByPartRecursive(ctx, candidate.ID, candidate.CenterVector, pathVectors, level+1)
 		if err != nil {
-			return nil, l, err
+			return nil, subLevel, err
 		}
-		if len(subCandidates) == 0 || l < len(pathVectors)-1 {
+		if len(subCandidates) == 0 || subLevel < len(pathVectors)-1 {
 			continue
+		}
+		if subLevel > deepestLevel {
+			deepestLevel = subLevel
 		}
 		result = append(result, subCandidates...)
 	}
 
-	return result, level, nil
+	return result, deepestLevel, nil
 }
 
 func (s *store[T]) semanticCategoryByPart(ctx context.Context, parentID sop.UUID, anchor []float32, partVector []float32) ([]*Category, error) {
+	log.Info("semanticCategoryByPart start", "parent_id", parentID, "anchor_len", len(anchor), "part_vector_len", len(partVector))
 	if len(partVector) == 0 {
+		log.Info("semanticCategoryByPart skip", "reason", "empty part vector", "parent_id", parentID)
 		return nil, nil
 	}
 	if len(anchor) == 0 {
 		return nil, fmt.Errorf("domain reference vector is not set. Ensure this KB had been vectorized.")
 	}
 
+	type candidateScore struct {
+		cat  *Category
+		dist float32
+	}
+
 	var result []*Category
 	dist := Distance(anchor, partVector, true)
+	log.Info("semanticCategoryByPart distance", "parent_id", parentID, "distance", dist, "anchor_len", len(anchor), "part_vector_len", len(partVector))
 
 	// Position cursor at the nearest distance entry for this parent.
 	if _, err := s.categoriesByDistance.Find(ctx, DistanceKey{ParentID: parentID, Distance: dist, ID: sop.NilUUID}, false); err != nil {
@@ -576,34 +634,48 @@ func (s *store[T]) semanticCategoryByPart(ctx context.Context, parentID sop.UUID
 		backSteps++
 	}
 
-	bestDist := float32(-1)
 	maxForward := backSteps + 1 + scanWindow
+	var scores []candidateScore
+	seen := map[sop.UUID]struct{}{}
 	for i := 0; i < maxForward; i++ {
 		currKey := s.categoriesByDistance.GetCurrentKey()
 		if currKey.Key.ParentID.Compare(parentID) != 0 {
 			break
 		}
-		if !currKey.Key.ID.IsNil() {
-			currDist := compare(dist, currKey.Key.Distance, bestDist)
-			if i == 0 || currDist <= 0 {
-				found, err := s.categories.Find(ctx, currKey.Key.ID, false)
+		if currKey.Key.ID.IsNil() {
+			if ok, err := s.categoriesByDistance.Next(ctx); !ok || err != nil {
 				if err != nil {
 					return nil, err
 				}
-				if found {
-					cat, err := s.categories.GetCurrentValue(ctx)
-					if err != nil {
-						return nil, err
-					}
-					if cat != nil {
-						if currDist < 0 {
-							bestDist = currKey.Key.Distance
-							result = []*Category{cat}
-						} else {
-							result = append(result, cat)
-						}
-					}
+				break
+			}
+			continue
+		}
+		if _, exists := seen[currKey.Key.ID]; exists {
+			if ok, err := s.categoriesByDistance.Next(ctx); !ok || err != nil {
+				if err != nil {
+					return nil, err
 				}
+				break
+			}
+			continue
+		}
+		found, err := s.categories.Find(ctx, currKey.Key.ID, false)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			cat, err := s.categories.GetCurrentValue(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if cat != nil {
+				actualDist := dist
+				if len(cat.CenterVector) > 0 {
+					actualDist = Distance(partVector, cat.CenterVector, true)
+				}
+				seen[currKey.Key.ID] = struct{}{}
+				scores = append(scores, candidateScore{cat: cat, dist: actualDist})
 			}
 		}
 		if ok, err := s.categoriesByDistance.Next(ctx); !ok || err != nil {
@@ -613,7 +685,55 @@ func (s *store[T]) semanticCategoryByPart(ctx context.Context, parentID sop.UUID
 			break
 		}
 	}
+	if len(scores) > 1 {
+		sort.Slice(scores, func(i, j int) bool {
+			if scores[i].dist == scores[j].dist {
+				return scores[i].cat.ID.Compare(scores[j].cat.ID) < 0
+			}
+			return scores[i].dist < scores[j].dist
+		})
+	}
+	// Increase limit from 3 to 10 to avoid missing relevant categories (e.g., C# when Java/Python/Rust exist)
+	if len(scores) > 10 {
+		scores = scores[:10]
+	}
+	for _, entry := range scores {
+		result = append(result, entry.cat)
+	}
+	log.Info("semanticCategoryByPart result", "parent_id", parentID, "candidate_count", len(result), "candidate_ids", categoryIDs(result), "candidate_paths", categoryPaths(result), "best_distance", func() float32 {
+		if len(scores) > 0 {
+			return scores[0].dist
+		}
+		return 0
+	}())
+	if len(result) == 0 {
+		log.Info("semanticCategoryByPart no candidates", "parent_id", parentID, "distance", dist)
+	}
 	return result, nil
+}
+
+func categoryIDs(cats []*Category) []string {
+	ids := make([]string, 0, len(cats))
+	for _, cat := range cats {
+		if cat == nil {
+			ids = append(ids, "<nil>")
+			continue
+		}
+		ids = append(ids, cat.ID.String())
+	}
+	return ids
+}
+
+func categoryPaths(cats []*Category) []string {
+	paths := make([]string, 0, len(cats))
+	for _, cat := range cats {
+		if cat == nil {
+			paths = append(paths, "<nil>")
+			continue
+		}
+		paths = append(paths, cat.Path)
+	}
+	return paths
 }
 
 func compare(vecDistance float32, A float32, B float32) int {
@@ -669,43 +789,33 @@ func (s *store[T]) Query(ctx context.Context, vec []float32, opts *SearchOptions
 			return nil, nil // Category strictly required but not found
 		}
 	} else {
-		var categories []*Category
-		ok, err := s.categories.First(ctx)
+		var err error
+		targetCategory, err = s.resolveTargetCategory(ctx, vec)
 		if err != nil {
 			return nil, err
 		}
-		if !ok {
-			return nil, nil // No data
-		}
-
-		for {
-			c, err := s.categories.GetCurrentValue(ctx)
-			if err == nil && c != nil {
-				categories = append(categories, c)
-			}
-			nextOk, nextErr := s.categories.Next(ctx)
-			if nextErr != nil || !nextOk {
-				break
-			}
-		}
-		var catPointers []*Category
-		for i := range categories {
-			catPointers = append(catPointers, categories[i])
-		}
-		targetCategory, _ = FindClosestCategoryFromPtrs(vec, catPointers)
 	}
 
 	if targetCategory == nil {
 		return nil, nil
 	}
 
+	return s.QueryItems(ctx, vec, targetCategory, opts)
+}
+
+func (s *store[T]) QueryItems(ctx context.Context, vec []float32, category *Category, opts *SearchOptions[T]) ([]ai.Hit[T], error) {
+	if opts == nil {
+		opts = &SearchOptions[T]{Limit: 10}
+	}
+	if category == nil || category.ID.IsNil() {
+		return nil, nil
+	}
+
 	var hits []ai.Hit[T]
 
-	// Find the start of the vectors for this Category ID in O(log N) time
-	// By submitting a search key with -1.0 distance, we fall immediately before or precisely
-	// at the first vector for this CategoryID in the B-Tree.
+	// Find the start of the vectors for this Category ID in O(log N) time.
 	searchKey := VectorKey{
-		CategoryID:         targetCategory.ID,
+		CategoryID:         category.ID,
 		DistanceToCategory: -1.0,
 	}
 
@@ -721,14 +831,14 @@ func (s *store[T]) Query(ctx context.Context, vec []float32, opts *SearchOptions
 	// until we are inside our target Category ID.
 	if !found {
 		currKey := s.vectors.GetCurrentKey()
-		if currKey.Key.CategoryID.Compare(targetCategory.ID) < 0 {
-			// Fast forward to first node >= targetCategory.ID
+		if currKey.Key.CategoryID.Compare(category.ID) < 0 {
+			// Fast forward to the first node >= this category ID.
 			for {
 				ok, err := s.vectors.Next(ctx)
 				if err != nil || !ok {
 					break
 				}
-				if s.vectors.GetCurrentKey().Key.CategoryID.Compare(targetCategory.ID) >= 0 {
+				if s.vectors.GetCurrentKey().Key.CategoryID.Compare(category.ID) >= 0 {
 					break
 				}
 			}
@@ -736,14 +846,18 @@ func (s *store[T]) Query(ctx context.Context, vec []float32, opts *SearchOptions
 	}
 
 	for {
-		vk := s.vectors.GetCurrentKey()
-
-		// If we've passed our target category, we can stop evaluating entirely
-		if vk.Key.CategoryID.Compare(targetCategory.ID) > 0 {
+		if len(matchingVectors) >= opts.Limit {
 			break
 		}
 
-		if vk.Key.CategoryID.Compare(targetCategory.ID) == 0 {
+		vk := s.vectors.GetCurrentKey()
+
+		// If we've passed our target category, we can stop evaluating entirely
+		if vk.Key.CategoryID.Compare(category.ID) > 0 {
+			break
+		}
+
+		if vk.Key.CategoryID.Compare(category.ID) == 0 {
 			v, err := s.vectors.GetCurrentValue(ctx)
 			if err == nil {
 				matchingVectors = append(matchingVectors, v)
@@ -764,10 +878,14 @@ func (s *store[T]) Query(ctx context.Context, vec []float32, opts *SearchOptions
 			item, err := s.items.GetCurrentValue(ctx)
 			if err == nil {
 				if opts.Filter == nil || opts.Filter(item.Data) {
+					var d float32
+					if len(vec) > 0 {
+						d = Distance(vec, v.Data, true)
+					}
 					hits = append(hits, ai.Hit[T]{
 						ID:      item.ID.String(),
 						DocID:   item.DocID,
-						Score:   Distance(vec, v.Data, true),
+						Score:   d,
 						Payload: item.Data,
 					})
 				}
@@ -775,15 +893,16 @@ func (s *store[T]) Query(ctx context.Context, vec []float32, opts *SearchOptions
 		}
 	}
 
-	// Sort hits by score ascending (Euclidean distance: lower is better)
-	for i := 0; i < len(hits); i++ {
-		for j := i + 1; j < len(hits); j++ {
-			if hits[i].Score > hits[j].Score {
-				hits[i], hits[j] = hits[j], hits[i]
+	if len(vec) > 0 {
+		// Sort hits by score ascending (Euclidean distance: lower is better)
+		for i := 0; i < len(hits); i++ {
+			for j := i + 1; j < len(hits); j++ {
+				if hits[i].Score > hits[j].Score {
+					hits[i], hits[j] = hits[j], hits[i]
+				}
 			}
 		}
 	}
-
 	if len(hits) > opts.Limit {
 		hits = hits[:opts.Limit]
 	}
@@ -834,13 +953,9 @@ func (s *store[T]) QueryTextBatch(ctx context.Context, texts []string, opts *Sea
 // QueryText performs a BM25 or keyword text search on the stored text representation of the thoughts.
 // When a use-case already has a reliable category taxonomy, CategoryPath-based retrieval can be
 // a cheaper SearchByPath-style alternative to enabling and maintaining the optional text index.
-
 func (s *store[T]) QueryText(ctx context.Context, text string, opts *SearchOptions[T]) ([]ai.Hit[T], error) {
 	if opts == nil {
 		opts = &SearchOptions[T]{Limit: 10}
-	}
-	if s.textIndex == nil {
-		return nil, nil
 	}
 
 	var targetCategoryID sop.UUID
@@ -857,23 +972,20 @@ func (s *store[T]) QueryText(ctx context.Context, text string, opts *SearchOptio
 			return nil, nil
 		}
 	} else if opts.CategoryPath != "" {
-		ok, err := s.categories.First(ctx)
+		ok, err := s.categoriesByPath.Find(ctx, opts.CategoryPath, false)
 		if err == nil && ok {
-			for {
-				c, err := s.categories.GetCurrentValue(ctx)
-				if err == nil && c != nil && c.Name == opts.CategoryPath {
-					targetCategoryID = c.ID
-					break
-				}
-				nextOk, _ := s.categories.Next(ctx)
-				if !nextOk {
-					break
-				}
+			catID, err := s.categoriesByPath.GetCurrentValue(ctx)
+			if err == nil {
+				targetCategoryID = catID
 			}
 		}
 		if targetCategoryID == sop.NilUUID {
 			return nil, nil // Category strictly requested but not found
 		}
+	}
+
+	if s.textIndex == nil {
+		return nil, nil
 	}
 
 	searchResults, err := s.textIndex.Search(ctx, text)
@@ -927,4 +1039,45 @@ func (s *store[T]) QueryText(ctx context.Context, text string, opts *SearchOptio
 		})
 	}
 	return results, nil
+}
+
+// GetCategoriesFromTextSearch extracts unique category IDs from text search results.
+func (s *store[T]) GetCategoriesFromTextSearch(ctx context.Context, text string) ([]*Category, error) {
+	if s.textIndex == nil {
+		return nil, nil
+	}
+
+	searchResults, err := s.textIndex.Search(ctx, text)
+	if err != nil {
+		return nil, err
+	}
+
+	seenCatIDs := make(map[sop.UUID]struct{})
+	var categories []*Category
+
+	for _, res := range searchResults {
+		parts := strings.Split(res.DocID, ",")
+		if len(parts) != 2 {
+			continue
+		}
+		catID, err := sop.ParseUUID(parts[0])
+		if err != nil {
+			continue
+		}
+		if _, seen := seenCatIDs[catID]; seen {
+			continue
+		}
+		seenCatIDs[catID] = struct{}{}
+
+		// Look up the category
+		found, err := s.categories.Find(ctx, catID, false)
+		if err == nil && found {
+			cat, err := s.categories.GetCurrentValue(ctx)
+			if err == nil && cat != nil && !cat.ID.IsNil() {
+				categories = append(categories, cat)
+			}
+		}
+	}
+
+	return categories, nil
 }

--- a/ai/memory/store_boundaries_test.go
+++ b/ai/memory/store_boundaries_test.go
@@ -38,7 +38,7 @@ func TestStore_CursorPaginationAndIsolation(t *testing.T) {
 			Data:       fmt.Sprintf("Payload %d", i),
 		}
 
-		err := st.UpsertByCategoryID(ctx, catID, nil, item, [][]float32{{float32(i), float32(i)}})
+		err := st.UpsertByCategoryID(ctx, catID, nil, item, [][]float32{{float32(i), float32(i)}}, nil)
 		if err != nil {
 			t.Fatalf("Upsert failed at %d: %v", i, err)
 		}

--- a/ai/memory/store_gc_test.go
+++ b/ai/memory/store_gc_test.go
@@ -26,7 +26,7 @@ func TestStore_GarbageCollection(t *testing.T) {
 	itemID1 := sop.NewUUID()
 	item1 := Item[string]{ID: itemID1, CategoryID: catID, Data: "I have 3 vectors"}
 
-	err := st.UpsertByCategoryID(ctx, catID, nil, item1, [][]float32{{1.0, 1.0}, {2.0, 2.0}, {3.0, 3.0}})
+	err := st.UpsertByCategoryID(ctx, catID, nil, item1, [][]float32{{1.0, 1.0}, {2.0, 2.0}, {3.0, 3.0}}, nil)
 	if err != nil {
 		t.Fatalf("Upsert item1 failed: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestStore_GarbageCollection(t *testing.T) {
 	itemID2 := sop.NewUUID()
 	item2 := Item[string]{ID: itemID2, CategoryID: catID, Data: "I have 1 vector"}
 
-	err = st.UpsertByCategoryID(ctx, catID, nil, item2, [][]float32{{4.0, 4.0}})
+	err = st.UpsertByCategoryID(ctx, catID, nil, item2, [][]float32{{4.0, 4.0}}, nil)
 	if err != nil {
 		t.Fatalf("Upsert item2 failed: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestStore_GarbageCollection(t *testing.T) {
 	}
 
 	// Overwrite Item 1 with just 1 vector, ensuring 2 vectors are garbage collected
-	err = st.UpsertByCategoryID(ctx, catID, nil, item1, [][]float32{{1.1, 1.1}})
+	err = st.UpsertByCategoryID(ctx, catID, nil, item1, [][]float32{{1.1, 1.1}}, nil)
 	if err != nil {
 		t.Fatalf("Re-upsert item1 failed: %v", err)
 	}

--- a/ai/memory/store_semantic_path_test.go
+++ b/ai/memory/store_semantic_path_test.go
@@ -102,6 +102,119 @@ func TestDistanceIndex_CanLocateCategoryNeighbors(t *testing.T) {
 	}
 }
 
+func TestSemanticCategoryByPath_VariousHierarchyFlavors(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name  string
+		build func(t *testing.T, s *store[string], dist *inmemory.BtreeInterface[DistanceKey, byte]) (path [][]float32, wantID sop.UUID)
+	}{
+		{
+			name: "root to leaf",
+			build: func(t *testing.T, s *store[string], dist *inmemory.BtreeInterface[DistanceKey, byte]) ([][]float32, sop.UUID) {
+				root := &Category{ID: sop.NewUUID(), Name: "Root", CenterVector: []float32{0.0, 0.0, 0.0}}
+				leaf := &Category{ID: sop.NewUUID(), Name: "Leaf", CenterVector: []float32{0.1, 0.0, 0.0}, ParentIDs: []CategoryParent{{ParentID: root.ID}}}
+				if _, err := s.AddCategory(ctx, root); err != nil {
+					t.Fatalf("AddCategory(root) failed: %v", err)
+				}
+				if _, err := s.AddCategory(ctx, leaf); err != nil {
+					t.Fatalf("AddCategory(leaf) failed: %v", err)
+				}
+				if ok, err := dist.Btree.Add(ctx, DistanceKey{ParentID: sop.NilUUID, Distance: 1.0, ID: root.ID}, 0); err != nil || !ok {
+					t.Fatalf("add root distance failed: ok=%v err=%v", ok, err)
+				}
+				if ok, err := dist.Btree.Add(ctx, DistanceKey{ParentID: root.ID, Distance: 0.1, ID: leaf.ID}, 0); err != nil || !ok {
+					t.Fatalf("add leaf distance failed: ok=%v err=%v", ok, err)
+				}
+				return [][]float32{{1.0, 0.0, 0.0}, {0.1, 0.0, 0.0}}, leaf.ID
+			},
+		},
+		{
+			name: "root to subcategory to leaf",
+			build: func(t *testing.T, s *store[string], dist *inmemory.BtreeInterface[DistanceKey, byte]) ([][]float32, sop.UUID) {
+				root := &Category{ID: sop.NewUUID(), Name: "Root", CenterVector: []float32{0.0, 0.0, 0.0}}
+				sub := &Category{ID: sop.NewUUID(), Name: "Subcategory", CenterVector: []float32{0.2, 0.0, 0.0}, ParentIDs: []CategoryParent{{ParentID: root.ID}}}
+				leaf := &Category{ID: sop.NewUUID(), Name: "Leaf", CenterVector: []float32{0.3, 0.0, 0.0}, ParentIDs: []CategoryParent{{ParentID: sub.ID}}}
+				for _, cat := range []*Category{root, sub, leaf} {
+					if _, err := s.AddCategory(ctx, cat); err != nil {
+						t.Fatalf("AddCategory(%s) failed: %v", cat.Name, err)
+					}
+				}
+				for _, entry := range []DistanceKey{
+					{ParentID: sop.NilUUID, Distance: 1.0, ID: root.ID},
+					{ParentID: root.ID, Distance: 0.2, ID: sub.ID},
+					{ParentID: sub.ID, Distance: 0.1, ID: leaf.ID},
+				} {
+					if ok, err := dist.Btree.Add(ctx, entry, 0); err != nil || !ok {
+						t.Fatalf("add distance entry failed: ok=%v err=%v", ok, err)
+					}
+				}
+				return [][]float32{{1.0, 0.0, 0.0}, {0.2, 0.0, 0.0}, {0.1, 0.0, 0.0}}, leaf.ID
+			},
+		},
+		{
+			name: "deep hierarchy leaf",
+			build: func(t *testing.T, s *store[string], dist *inmemory.BtreeInterface[DistanceKey, byte]) ([][]float32, sop.UUID) {
+				root := &Category{ID: sop.NewUUID(), Name: "Root", CenterVector: []float32{0.0, 0.0, 0.0}}
+				branch := &Category{ID: sop.NewUUID(), Name: "Branch", CenterVector: []float32{0.2, 0.0, 0.0}, ParentIDs: []CategoryParent{{ParentID: root.ID}}}
+				sub := &Category{ID: sop.NewUUID(), Name: "Subbranch", CenterVector: []float32{0.4, 0.0, 0.0}, ParentIDs: []CategoryParent{{ParentID: branch.ID}}}
+				leaf := &Category{ID: sop.NewUUID(), Name: "Leaf", CenterVector: []float32{0.6, 0.0, 0.0}, ParentIDs: []CategoryParent{{ParentID: sub.ID}}}
+				for _, cat := range []*Category{root, branch, sub, leaf} {
+					if _, err := s.AddCategory(ctx, cat); err != nil {
+						t.Fatalf("AddCategory(%s) failed: %v", cat.Name, err)
+					}
+				}
+				for _, entry := range []DistanceKey{
+					{ParentID: sop.NilUUID, Distance: 1.0, ID: root.ID},
+					{ParentID: root.ID, Distance: 0.2, ID: branch.ID},
+					{ParentID: branch.ID, Distance: 0.2, ID: sub.ID},
+					{ParentID: sub.ID, Distance: 0.2, ID: leaf.ID},
+				} {
+					if ok, err := dist.Btree.Add(ctx, entry, 0); err != nil || !ok {
+						t.Fatalf("add distance entry failed: ok=%v err=%v", ok, err)
+					}
+				}
+				return [][]float32{{1.0, 0.0, 0.0}, {0.2, 0.0, 0.0}, {0.2, 0.0, 0.0}, {0.2, 0.0, 0.0}}, leaf.ID
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cats := inmemory.NewBtree[sop.UUID, *Category](true)
+			dist := inmemory.NewBtree[DistanceKey, byte](false)
+			s := NewStore[string]("semantic_kb", nil,
+				cats.Btree,
+				inmemory.NewBtree[string, sop.UUID](false).Btree,
+				dist.Btree,
+				inmemory.NewBtree[VectorKey, Vector](false).Btree,
+				inmemory.NewBtree[ItemKey, Item[string]](false).Btree,
+				inmemory.NewBtree[sop.UUID, Document](false).Btree,
+			).(*store[string])
+			s.SetDomainReference([]float32{0.0, 0.0, 0.0})
+
+			pathVectors, wantID := tt.build(t, s, &dist)
+			candidates, err := s.SemanticCategoryByPath(ctx, pathVectors)
+			if err != nil {
+				t.Fatalf("SemanticCategoryByPath failed: %v", err)
+			}
+			if len(candidates) == 0 {
+				t.Fatal("expected at least one semantic candidate")
+			}
+			found := false
+			for _, cat := range candidates {
+				if cat != nil && cat.ID == wantID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected leaf category %s to appear among candidates, got %+v", wantID, candidates)
+			}
+		})
+	}
+}
+
 func TestSemanticCategoryByPath_ReturnsExpectedLeaf(t *testing.T) {
 	ctx := context.Background()
 	cats := inmemory.NewBtree[sop.UUID, *Category](true)

--- a/tools/confighub/config.go
+++ b/tools/confighub/config.go
@@ -1,0 +1,215 @@
+package confighub
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+)
+
+// ErasureConfigEntry defines a single EC zone configuration.
+type ErasureConfigEntry struct {
+	Key          string   `json:"key"`
+	DataChunks   int      `json:"data_chunks"`
+	ParityChunks int      `json:"parity_chunks"`
+	BasePaths    []string `json:"base_paths"`
+}
+
+// DatabaseConfig holds configuration for a single SOP database.
+type DatabaseConfig struct {
+	Name              string               `json:"name"`
+	Path              string               `json:"path"`
+	StoresFolders     []string             `json:"stores_folders,omitempty"`
+	Mode              string               `json:"mode"`
+	RedisURL          string               `json:"redis"`
+	IsSystem          bool                 `json:"is_system,omitempty"`
+	Warning           string               `json:"warning,omitempty"`
+	ErasureConfigs    []ErasureConfigEntry `json:"erasure_configs,omitempty"`
+	EnableObfuscation bool                 `json:"enable_obfuscation,omitempty"`
+}
+
+// Config holds the runtime configuration loaded from disk.
+type Config struct {
+	Port                   int              `json:"port"`
+	Databases              []DatabaseConfig `json:"databases"`
+	PageSize               int              `json:"pageSize"`
+	SystemDB               *DatabaseConfig  `json:"system_db,omitempty"`
+	RootPassword           string           `json:"root_password,omitempty"`
+	ProductionMode         bool             `json:"production_mode,omitempty"`
+	SessionTokenTTLMinutes int              `json:"session_token_ttl_minutes,omitempty"`
+	SessionSecret          string           `json:"session_secret,omitempty"`
+	AuthProviderName       string           `json:"auth_provider,omitempty"`
+	Users                  []any            `json:"users,omitempty"`
+}
+
+func ResolveConfigPath(explicit string) string {
+	if strings.TrimSpace(explicit) != "" {
+		return explicit
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		return filepath.Join(cwd, "config.json")
+	}
+	return "config.json"
+}
+
+func FindExistingConfigFile(explicit string) string {
+	seen := map[string]struct{}{}
+	for _, candidate := range CandidateConfigPaths(explicit) {
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func CandidateConfigPaths(explicit string) []string {
+	if p := strings.TrimSpace(explicit); p != "" {
+		return []string{p}
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		return []string{filepath.Join(cwd, "config.json")}
+	}
+	return []string{"config.json"}
+}
+
+func LoadConfig(path string) (Config, error) {
+	if strings.TrimSpace(path) == "" {
+		return Config{}, fmt.Errorf("config path cannot be empty")
+	}
+
+	var cfg Config
+	if err := loadConfigInto(path, &cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func loadConfigInto(path string, cfg any) error {
+	if cfg == nil {
+		return fmt.Errorf("config target cannot be nil")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := json.NewDecoder(f).Decode(cfg); err != nil {
+		return err
+	}
+
+	value := reflect.ValueOf(cfg)
+	if value.Kind() != reflect.Ptr || value.IsNil() {
+		return fmt.Errorf("config target must be a non-nil pointer")
+	}
+	resolveConfigRelativePaths(value.Elem(), filepath.Dir(path))
+	return nil
+}
+
+func resolveConfigRelativePaths(value reflect.Value, configDir string) {
+	if !value.IsValid() {
+		return
+	}
+
+	for value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return
+		}
+		value = value.Elem()
+	}
+
+	if value.Kind() != reflect.Struct {
+		return
+	}
+
+	if field := value.FieldByName("SystemDB"); field.IsValid() && field.CanAddr() {
+		resolveDatabaseConfig(field, configDir)
+	}
+
+	if field := value.FieldByName("Databases"); field.IsValid() && field.Kind() == reflect.Slice {
+		for i := 0; i < field.Len(); i++ {
+			resolveDatabaseConfig(field.Index(i), configDir)
+		}
+	}
+}
+
+func resolveDatabaseConfig(value reflect.Value, configDir string) {
+	for value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct || !value.CanAddr() {
+		return
+	}
+
+	if pathField := value.FieldByName("Path"); pathField.IsValid() && pathField.CanSet() && pathField.Kind() == reflect.String {
+		if path := strings.TrimSpace(pathField.String()); path != "" && !filepath.IsAbs(path) {
+			pathField.SetString(filepath.Join(configDir, path))
+		}
+	}
+
+	if storesField := value.FieldByName("StoresFolders"); storesField.IsValid() && storesField.Kind() == reflect.Slice {
+		for i := 0; i < storesField.Len(); i++ {
+			item := storesField.Index(i)
+			if item.Kind() == reflect.String && !filepath.IsAbs(item.String()) {
+				storesField.Index(i).SetString(filepath.Join(configDir, item.String()))
+			}
+		}
+	}
+
+	if ecField := value.FieldByName("ErasureConfigs"); ecField.IsValid() && ecField.Kind() == reflect.Slice {
+		for i := 0; i < ecField.Len(); i++ {
+			entry := ecField.Index(i)
+			if basePaths := entry.FieldByName("BasePaths"); basePaths.IsValid() && basePaths.Kind() == reflect.Slice {
+				for j := 0; j < basePaths.Len(); j++ {
+					item := basePaths.Index(j)
+					if item.Kind() == reflect.String && !filepath.IsAbs(item.String()) {
+						basePaths.Index(j).SetString(filepath.Join(configDir, item.String()))
+					}
+				}
+			}
+		}
+	}
+}
+
+func resolveConfigRelativePath(path, configDir string) string {
+	if path == "" {
+		return path
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(configDir, path)
+}
+
+func SaveConfig(path string, cfg Config) error {
+	if path == "" {
+		path = ResolveConfigPath("")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create config file: %w", err)
+	}
+	defer f.Close()
+
+	encoder := json.NewEncoder(f)
+	encoder.SetIndent("", "    ")
+	if err := encoder.Encode(cfg); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+	return nil
+}

--- a/tools/confighub/config_test.go
+++ b/tools/confighub/config_test.go
@@ -1,0 +1,68 @@
+package confighub
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveConfigPath_PrefersExplicitPath(t *testing.T) {
+	got := ResolveConfigPath("/tmp/custom.json")
+	if got != "/tmp/custom.json" {
+		t.Fatalf("ResolveConfigPath() = %q, want %q", got, "/tmp/custom.json")
+	}
+}
+
+func TestFindExistingConfigFile_FindsConfigInWorkingDir(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.json")
+	if err := os.WriteFile(configPath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(cwd)
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	got := FindExistingConfigFile("")
+	want, err := filepath.EvalSymlinks(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotClean, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotClean != want {
+		t.Fatalf("FindExistingConfigFile() = %q, want %q", gotClean, want)
+	}
+}
+
+func TestLoadConfig_ResolvesRelativePaths(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{
+		"databases": [
+			{"name": "db1", "path": "./data", "stores_folders": ["./stores"]}
+		]
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if got := cfg.Databases[0].Path; got != filepath.Join(tmp, "data") {
+		t.Fatalf("LoadConfig() database path = %q, want %q", got, filepath.Join(tmp, "data"))
+	}
+	if got := cfg.Databases[0].StoresFolders[0]; got != filepath.Join(tmp, "stores") {
+		t.Fatalf("LoadConfig() store folder = %q, want %q", got, filepath.Join(tmp, "stores"))
+	}
+}

--- a/tools/confighub/kb_case_test.go
+++ b/tools/confighub/kb_case_test.go
@@ -1,0 +1,82 @@
+package confighub
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sharedcode/sop"
+	"github.com/sharedcode/sop/ai/database"
+	"github.com/sharedcode/sop/ai/memory"
+	core "github.com/sharedcode/sop/database"
+)
+
+// TestCaseSensitivityInSearch tests if Search() is case-sensitive for CategoryPath
+func TestCaseSensitivityInSearch(t *testing.T) {
+	ctx := context.Background()
+	storagePath := "../../tools/config.json"
+
+	cfg, err := LoadConfig(storagePath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	dbOpts, err := core.GetOptions(ctx, cfg.SystemDB.Path)
+	if err != nil {
+		t.Fatalf("GetOptions failed: %v", err)
+	}
+
+	db := database.NewDatabase(dbOpts)
+
+	testCases := []struct {
+		name string
+		path string
+	}{
+		{"Exact case", "Language Bindings/C#"},
+		{"Lowercase", "language bindings/c#"},
+		{"UPPERCASE", "LANGUAGE BINDINGS/C#"},
+		{"Mixed", "language Bindings/c#"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tx, err := db.BeginTransaction(ctx, sop.ForReading)
+			if err != nil {
+				t.Fatalf("BeginTransaction failed: %v", err)
+			}
+			defer tx.Rollback(ctx)
+
+			kb, err := db.OpenKnowledgeBase(ctx, "sop", tx, nil, nil, false)
+			if err != nil {
+				t.Fatalf("OpenKnowledgeBase failed: %v", err)
+			}
+
+			if err = kb.Initialize(ctx); err != nil {
+				t.Fatalf("Initialize failed: %v", err)
+			}
+
+			req := []memory.SearchRequest[map[string]any]{{CategoryPath: tc.path, Limit: 5}}
+			hits, err := kb.Search(ctx, req)
+			if err != nil {
+				t.Fatalf("Search failed: %v", err)
+			}
+
+			if len(hits) > 0 && len(hits[0]) > 0 {
+				fmt.Printf("%s: Found %d hits, first score: %.4f\n", tc.name, len(hits[0]), hits[0][0].Score)
+				// Show first 3 hit categories
+				for i, hit := range hits[0] {
+					if i >= 3 {
+						break
+					}
+					catPath := ""
+					if cat, ok := hit.Payload["category"].(string); ok {
+						catPath = cat
+					}
+					fmt.Printf("  Hit %d: category=%q score=%.4f\n", i+1, catPath, hit.Score)
+				}
+			} else {
+				fmt.Printf("%s: NO HITS (path: %q)\n", tc.name, tc.path)
+			}
+		})
+	}
+}

--- a/tools/confighub/kb_search_debug_test.go
+++ b/tools/confighub/kb_search_debug_test.go
@@ -1,0 +1,92 @@
+package confighub
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sharedcode/sop"
+	"github.com/sharedcode/sop/ai/agent"
+	"github.com/sharedcode/sop/ai/database"
+	"github.com/sharedcode/sop/ai/memory"
+	core "github.com/sharedcode/sop/database"
+)
+
+// TestCompareSearchVsSearchKnowledgeBase compares direct Search() vs searchKnowledgeBase()
+func TestCompareSearchVsSearchKnowledgeBase(t *testing.T) {
+	ctx := context.Background()
+	storagePath := "../../tools/config.json"
+
+	cfg, err := LoadConfig(storagePath)
+	if err != nil {
+		t.Fatalf("LoadConfig(%s) failed: %v", storagePath, err)
+	}
+
+	dbOpts, err := core.GetOptions(ctx, cfg.SystemDB.Path)
+	if err != nil {
+		t.Fatalf("GetOptions failed: %v", err)
+	}
+
+	db := database.NewDatabase(dbOpts)
+
+	// Test 1: Direct Search() with exact path
+	t.Run("DirectSearch", func(t *testing.T) {
+		tx, err := db.BeginTransaction(ctx, sop.ForReading)
+		if err != nil {
+			t.Fatalf("BeginTransaction failed: %v", err)
+		}
+		defer tx.Rollback(ctx)
+
+		kb, err := db.OpenKnowledgeBase(ctx, "sop", tx, nil, nil, false)
+		if err != nil {
+			t.Fatalf("OpenKnowledgeBase failed: %v", err)
+		}
+
+		req := []memory.SearchRequest[map[string]any]{{CategoryPath: "Language Bindings/C#", Limit: 5}}
+		hits, err := kb.Search(ctx, req)
+		if err != nil {
+			t.Fatalf("Search failed: %v", err)
+		}
+
+		fmt.Printf("Direct Search hits: %d\n", len(hits))
+		if len(hits) > 0 && len(hits[0]) > 0 {
+			fmt.Printf("First hit score: %.4f\n", hits[0][0].Score)
+		} else {
+			t.Error("Direct Search found no hits for 'Language Bindings/C#'")
+		}
+	})
+
+	// Test 2: Simulate searchKnowledgeBase path extraction
+	t.Run("PathExtraction", func(t *testing.T) {
+		testCases := []struct {
+			query    string
+			catPath  string
+			category string
+		}{
+			{query: "Language Bindings/C#", catPath: "", category: ""},
+			{query: "C#", catPath: "Language Bindings", category: ""},
+			{query: "C# tutorials", catPath: "Language Bindings/C#", category: ""},
+			{query: "omni:sop:language bindings/c#", catPath: "", category: ""},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.query, func(t *testing.T) {
+				// Simulate what searchKnowledgeBase does
+				pathQuery, _ := agent.ExportSplitCategoryPathInstruction(tc.query)
+				effectivePath := pathQuery
+				if effectivePath == "" {
+					effectivePath = tc.catPath
+				}
+				if effectivePath == "" {
+					effectivePath = tc.category
+				}
+
+				fmt.Printf("Query: %q\n", tc.query)
+				fmt.Printf("  pathQuery extracted: %q\n", pathQuery)
+				fmt.Printf("  catPath param: %q\n", tc.catPath)
+				fmt.Printf("  effectivePath: %q\n", effectivePath)
+				fmt.Println()
+			})
+		}
+	})
+}

--- a/tools/confighub/kb_test.go
+++ b/tools/confighub/kb_test.go
@@ -1,0 +1,62 @@
+package confighub
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sharedcode/sop"
+	"github.com/sharedcode/sop/ai/database"
+	"github.com/sharedcode/sop/ai/memory"
+	core "github.com/sharedcode/sop/database"
+)
+
+func TestKB_BasicSearch(t *testing.T) {
+	ctx := context.Background()
+	storagePath := "../../tools/config.json"
+
+	cfg, err := LoadConfig(storagePath)
+	if err != nil {
+		t.Fatalf("LoadConfig(%s) failed: %v", storagePath, err)
+	}
+	if len(cfg.Databases) == 0 {
+		t.Fatal("LoadConfig returned no databases")
+	}
+
+	dbOpts, err := core.GetOptions(ctx, cfg.SystemDB.Path)
+	if err != nil {
+		t.Fatalf("GetOptions(%s) failed: %v", cfg.Databases[0].Path, err)
+	}
+
+	db := database.NewDatabase(dbOpts)
+
+	tx, err := db.BeginTransaction(ctx, sop.ForReading)
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+
+	kb, err := db.OpenKnowledgeBase(ctx, "sop", tx, nil, nil, false)
+	if err != nil {
+		t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	}
+
+	if err = kb.Initialize(ctx); err != nil {
+		t.Fatalf("KnowledgeBase.Initialize failed: %v", err)
+	}
+
+	req := []memory.SearchRequest[map[string]any]{{CategoryPath: "Language Bindings/C#", Limit: 5}}
+	hits, err := kb.Search(ctx, req)
+	if err != nil {
+		t.Fatalf("KnowledgeBase.Search failed: %v", err)
+	}
+
+	if len(hits) == 0 {
+		t.Fatalf("KnowledgeBase.Search expected hits for category path %q", req[0].CategoryPath)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	fmt.Printf("hits: %v\n", hits)
+}

--- a/tools/confighub/memory_test.go
+++ b/tools/confighub/memory_test.go
@@ -1,0 +1,41 @@
+package confighub
+
+import (
+	"testing"
+)
+
+func TestKnowledgeBase_BasicSearch(t *testing.T) {
+
+	// ctx := context.Background()
+	// storagePath := "../../tools/config.json"
+	// config, err := core.GetOptions(ctx, storagePath)
+	// if err != nil {
+	// 	t.Fatalf("GetOptions(%s) failed: %v", storagePath, err)
+	// }
+	// db := NewDatabase(config)
+
+	// tx, err := db.BeginTransaction(ctx, sop.ForReading)
+	// if err != nil {
+	// 	t.Fatalf("BeginTransaction failed: %v", err)
+	// }
+
+	// kb, err := db.OpenKnowledgeBase(ctx, "tasks3", tx, nil, nil, false)
+	// if err != nil {
+	// 	t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	// }
+
+	// req := []memory.SearchRequest[map[string]any]{{CategoryPath: "Language Bindings/c#", Limit: 5}}
+	// hits, err := kb.Search(ctx, req)
+	// if err != nil {
+	// 	t.Fatalf("KnowledgeBase.Search failed: %v", err)
+	// }
+
+	// if len(hits) == 0 {
+	// 	//t.Fatalf("KnowledgeBase.Search failed, no hits for %s", req[])
+	// }
+
+	// if err := tx.Commit(ctx); err != nil {
+	// 	t.Fatalf("Commit failed: %v", err)
+	// }
+
+}

--- a/tools/httpserver/category_items_crud.go
+++ b/tools/httpserver/category_items_crud.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/sharedcode/sop"
@@ -73,7 +74,7 @@ func handleAddSpaceCategory(w http.ResponseWriter, r *http.Request) {
 	var vec []float32
 	if config.ProductionMode {
 		embedder := embed.NewSimple("simple_hash", 384, nil)
-		v, err := embedder.EmbedTexts(ctx, []string{req.Name})
+		v, err := embed.CategoryTexts(ctx, embedder, []string{req.Name})
 		if err != nil || len(v) == 0 {
 			http.Error(w, "Failed to embed category", http.StatusInternalServerError)
 			return
@@ -130,9 +131,9 @@ func handleAddSpaceCategory(w http.ResponseWriter, r *http.Request) {
 	} else {
 		newID := sop.NewUUID()
 
-		pathVal := req.Path
+		pathVal := strings.TrimSpace(req.Path)
 		if pathVal == "" {
-			pathVal = req.Name
+			pathVal = strings.TrimSpace(req.Name)
 		}
 		var parentIDs []memory.CategoryParent
 
@@ -146,8 +147,14 @@ func handleAddSpaceCategory(w http.ResponseWriter, r *http.Request) {
 					found, _ := categoriesTree.Find(ctx, parsedParent, false)
 					if found {
 						pCat, _ := categoriesTree.GetCurrentValue(ctx)
-						if pCat != nil && pCat.Path != "" {
-							pathVal = pCat.Path + " / " + req.Name
+						if pCat != nil {
+							parentPath := strings.TrimSpace(pCat.Path)
+							childName := strings.TrimSpace(req.Name)
+							if parentPath != "" && childName != "" {
+								pathVal = parentPath + " / " + childName
+							} else if childName != "" {
+								pathVal = childName
+							}
 						}
 					}
 				}
@@ -671,7 +678,7 @@ func handleAddSpaceItemsBatch(w http.ResponseWriter, r *http.Request) {
 	var allEmbeddings [][]float32
 	if len(flatSummariesToEmbed) > 0 && config.ProductionMode {
 		// High-speed batched Embeddings call
-		v, err := batchEmbedder.EmbedTexts(ctx, flatSummariesToEmbed)
+		v, err := embed.DocumentTexts(ctx, batchEmbedder, flatSummariesToEmbed)
 		if err != nil || len(v) != len(flatSummariesToEmbed) {
 			http.Error(w, "Failed to embed item chunks in batch", http.StatusInternalServerError)
 			return

--- a/tools/httpserver/category_items_test.go
+++ b/tools/httpserver/category_items_test.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/sharedcode/sop"
+	aidb "github.com/sharedcode/sop/ai/database"
+	"github.com/sharedcode/sop/database"
 )
 
 func TestUpdateSpaceItemPersists(t *testing.T) {
@@ -156,6 +161,101 @@ func TestUpdateSpaceItemRequiresCategoryID(t *testing.T) {
 	})
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("Expected missing CategoryID to fail with 400, got %v body %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleAddSpaceCategory_NormalizesChildPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbName := "testdb_trim_child_path"
+	spaceName := "test_space_trim_child_path"
+
+	config = Config{
+		RootPassword: "secret_password",
+		Databases: []DatabaseConfig{{
+			Name: dbName,
+			Path: tmpDir,
+			Mode: "standalone",
+		}},
+	}
+
+	sendJSON := func(method, url string, handler http.HandlerFunc, body interface{}) *httptest.ResponseRecorder {
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequest(method, url, bytes.NewBuffer(b))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+		return rr
+	}
+
+	rr := sendJSON("POST", "/api/spaces/create", handleCreateSpace, CreateSpaceRequest{DatabaseName: dbName, SpaceName: spaceName})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Failed to create space: %v", rr.Body.String())
+	}
+
+	rr = sendJSON("POST", "/api/spaces/category/add?database="+dbName+"&name="+spaceName, handleAddSpaceCategory, AddSpaceCategoryRequest{Name: "Root A"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Failed to add root category: %v", rr.Body.String())
+	}
+	var rootRes map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&rootRes); err != nil {
+		t.Fatalf("Failed to decode root category response: %v", err)
+	}
+	rootID := rootRes["id"].(string)
+
+	rr = sendJSON("POST", "/api/spaces/category/add?database="+dbName+"&name="+spaceName, handleAddSpaceCategory, AddSpaceCategoryRequest{
+		Name:     " Child A1 ",
+		ParentID: rootID,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Failed to add child category: %v", rr.Body.String())
+	}
+	var childRes map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&childRes); err != nil {
+		t.Fatalf("Failed to decode child category response: %v", err)
+	}
+	childID := childRes["id"].(string)
+
+	ctx := context.Background()
+	dbOpts, err := getDBOptions(ctx, dbName)
+	if err != nil {
+		t.Fatalf("getDBOptions failed: %v", err)
+	}
+	trans, err := database.BeginTransaction(ctx, dbOpts, sop.ForReading)
+	if err != nil {
+		t.Fatalf("BeginTransaction failed: %v", err)
+	}
+	defer trans.Rollback(ctx)
+
+	db := aidb.NewDatabase(dbOpts)
+	kb, err := db.OpenKnowledgeBase(ctx, spaceName, trans, nil, nil, false)
+	if err != nil {
+		t.Fatalf("OpenKnowledgeBase failed: %v", err)
+	}
+
+	cats, err := kb.Store.Categories(ctx)
+	if err != nil {
+		t.Fatalf("Categories failed: %v", err)
+	}
+
+	childUUID, err := sop.ParseUUID(childID)
+	if err != nil {
+		t.Fatalf("ParseUUID failed: %v", err)
+	}
+
+	found, err := cats.Find(ctx, childUUID, false)
+	if err != nil {
+		t.Fatalf("Find child category failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected child category to exist")
+	}
+
+	cat, err := cats.GetCurrentValue(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentValue failed: %v", err)
+	}
+	if got, want := cat.Path, "Root A / Child A1"; got != want {
+		t.Fatalf("child category path = %q, want %q", got, want)
 	}
 }
 

--- a/tools/httpserver/config_handler.go
+++ b/tools/httpserver/config_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sharedcode/sop"
 	"github.com/sharedcode/sop/database"
 	"github.com/sharedcode/sop/fs"
+	"github.com/sharedcode/sop/tools/confighub"
 )
 
 // handleListEnvironments returns a list of JSON config files in the current directory.
@@ -711,6 +712,11 @@ func handleUninstallSystem(w http.ResponseWriter, r *http.Request) {
 	shouldDeleteSystem := req.DeleteSystemDB || req.DeleteData
 	shouldDeleteUsers := req.DeleteUserDBs || req.DeleteData
 
+	if shouldDeleteSystem {
+		http.Error(w, "Deleting the System DB is disabled because it stores session records and runtime metadata for the current environment.", http.StatusBadRequest)
+		return
+	}
+
 	// 1. Delete actual data folders if requested
 	if shouldDeleteSystem || shouldDeleteUsers {
 		// System DB
@@ -926,34 +932,20 @@ func sanitizedConfigForDisk(cfg Config) Config {
 // saveConfig writes the current configuration to the file specified in config.ConfigFile.
 func saveConfig() error {
 	if config.ConfigFile == "" {
-		// Default to config.json in the current working directory
-		cwd, err := os.Getwd()
-		if err == nil {
-			config.ConfigFile = filepath.Join(cwd, "config.json")
-		} else {
-			config.ConfigFile = "config.json"
-		}
+		config.ConfigFile = confighub.ResolveConfigPath("")
 	}
 
-	// Ensure directory exists
-	dir := filepath.Dir(config.ConfigFile)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
-	}
-
-	// Write config file
-	f, err := os.Create(config.ConfigFile)
+	payload, err := json.Marshal(sanitizedConfigForDisk(config))
 	if err != nil {
-		return fmt.Errorf("failed to create config file: %w", err)
+		return fmt.Errorf("failed to encode config for save: %w", err)
 	}
-	defer f.Close()
 
-	encoder := json.NewEncoder(f)
-	encoder.SetIndent("", "    ")
-	if err := encoder.Encode(sanitizedConfigForDisk(config)); err != nil {
-		return fmt.Errorf("failed to write config file: %w", err)
+	var shared confighub.Config
+	if err := json.Unmarshal(payload, &shared); err != nil {
+		return fmt.Errorf("failed to convert config for save: %w", err)
 	}
-	return nil
+
+	return confighub.SaveConfig(config.ConfigFile, shared)
 }
 
 // validateWritePermissions checks if the application can write to the specified paths

--- a/tools/httpserver/config_handler_test.go
+++ b/tools/httpserver/config_handler_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHandleUninstallSystem_RejectsSystemDBDeletion(t *testing.T) {
+	defer func() { config = Config{} }()
+
+	tmpDir := t.TempDir()
+	systemDBPath := filepath.Join(tmpDir, "system-db")
+	if err := os.MkdirAll(systemDBPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	config = Config{
+		ConfigFile: filepath.Join(tmpDir, "config.json"),
+		SystemDB:   &DatabaseConfig{Path: systemDBPath},
+	}
+
+	reqBody := map[string]any{"delete_system_db": true}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/system/uninstall", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handleUninstallSystem(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("handleUninstallSystem() status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	if _, err := os.Stat(systemDBPath); err != nil {
+		t.Fatalf("system DB path was removed unexpectedly: %v", err)
+	}
+}

--- a/tools/httpserver/llm_connection_handler.go
+++ b/tools/httpserver/llm_connection_handler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sharedcode/sop/ai"
+	"github.com/sharedcode/sop/ai/embed"
 )
 
 type llmConnectionTestRequest struct {
@@ -189,7 +190,7 @@ func handleTestEmbedderConnection(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), aiConnectionTestTimeout())
 	defer cancel()
 
-	vectors, err := embedder.EmbedTexts(ctx, []string{"connection test"})
+	vectors, err := embed.QueryTexts(ctx, embedder, []string{"connection test"})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return

--- a/tools/httpserver/main.ai.go
+++ b/tools/httpserver/main.ai.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sharedcode/sop/ai"
 	"github.com/sharedcode/sop/ai/agent"
 	aidb "github.com/sharedcode/sop/ai/database"
+	"github.com/sharedcode/sop/ai/embed"
 
 	_ "github.com/sharedcode/sop/ai/generator"
 	"github.com/sharedcode/sop/ai/memory"
@@ -78,11 +79,10 @@ func seedMetaCognitionAsync(userID, kbName string, sysOpts sop.DatabaseOptions) 
 		trans.Rollback(ctx)
 		return
 	}
-	opts := &memory.SearchOptions[map[string]any]{Limit: 1}
-	res, _ := kb.SearchKeywords(ctx, "Meta_Cognition", opts)
+	res, _ := kb.Search(ctx, []memory.SearchRequest[map[string]any]{{Text: "Meta_Cognition", Limit: 1}})
 	trans.Rollback(ctx)
 
-	if len(res) > 0 {
+	if len(res) > 0 && len(res[0]) > 0 {
 		return
 	}
 
@@ -97,7 +97,7 @@ func seedMetaCognitionAsync(userID, kbName string, sysOpts sop.DatabaseOptions) 
 	}
 
 	thoughtText := "Meta-Memory Rules: 1) Generalize bugs instead of memorizing stack traces. 2) Never duplicate information available in SOP. 3) Prioritize specific user preferences over generic defaults."
-	vecs, err := embedder.EmbedTexts(ctx, []string{thoughtText})
+	vecs, err := embed.DocumentTexts(ctx, embedder, []string{thoughtText})
 	if err == nil && len(vecs) > 0 {
 		data := map[string]any{
 			"type":        "meta_rule",
@@ -555,10 +555,9 @@ func constructPayload(ctx context.Context, w http.ResponseWriter, req *aiChatReq
 		obfuscation.GlobalObfuscator.RegisterResource(req.StoreName, "STORE")
 	}
 
-	fullMessage := req.Message
-	msgTrimmed := strings.TrimSpace(req.Message)
-	if req.Database != "" && !strings.HasPrefix(msgTrimmed, "/") && msgTrimmed != "last-tool" && msgTrimmed != "last_tool" {
-		fullMessage = fmt.Sprintf("Current Database: %s\n%s", req.Database, req.Message)
+	fullMessage := strings.TrimSpace(req.Message)
+	if fullMessage == "" {
+		fullMessage = req.Message
 	}
 
 	ctx = context.WithValue(ctx, "session_payload", payload)
@@ -1178,7 +1177,7 @@ func handleAIFeedback(w http.ResponseWriter, r *http.Request) {
 		// 384 dimensions is good balance
 		embedder := GetConfiguredEmbedder(nil)
 
-		vecs, err := embedder.EmbedTexts(ctx, []string{req.UserContent})
+		vecs, err := embed.DocumentTexts(ctx, embedder, []string{req.UserContent})
 		if err != nil {
 			log.Warn("Failed to embed user content", "error", err)
 			// Don't fail the request, just skip vectorization

--- a/tools/httpserver/main.ai.go
+++ b/tools/httpserver/main.ai.go
@@ -168,6 +168,7 @@ func handleAIChat(w http.ResponseWriter, r *http.Request) {
 
 	// Inject streaming writer bypass
 	ctx = context.WithValue(ctx, ai.CtxKeyWriter, &DirectFlushingWriter{w: w})
+	ctx = context.WithValue(ctx, ai.CtxKeyAppBaseURL, buildAppBaseURL(r))
 
 	if err := executeAgentLifecycle(ctx, r, agentSvc, req, sendEvent); err != nil {
 		return
@@ -224,6 +225,31 @@ type aiChatRequest struct {
 	ClientID    string                 `json:"client_id"`
 	Domain      string                 `json:"domain"`
 	SelectedKBs []ai.ArtifactReference `json:"selected_kbs"`
+}
+
+func buildAppBaseURL(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+
+	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if host == "" {
+		host = strings.TrimSpace(r.Host)
+	}
+	if host == "" {
+		return ""
+	}
+
+	proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+	if proto == "" {
+		if r.TLS != nil {
+			proto = "https"
+		} else {
+			proto = "http"
+		}
+	}
+
+	return strings.TrimRight(proto+"://"+host, "/")
 }
 
 func initializeRequest(w http.ResponseWriter, r *http.Request) (*aiChatRequest, error) {

--- a/tools/httpserver/main.go
+++ b/tools/httpserver/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sharedcode/sop/encoding"
 	"github.com/sharedcode/sop/fs"
 	"github.com/sharedcode/sop/jsondb"
+	"github.com/sharedcode/sop/tools/confighub"
 )
 
 // ErasureConfigEntry defines a single EC zone configuration
@@ -97,34 +98,11 @@ func firstNonEmpty(values ...string) string {
 }
 
 func candidateConfigPaths() []string {
-	if p := strings.TrimSpace(config.ConfigFile); p != "" {
-		return []string{p}
-	}
-
-	candidates := []string{}
-	if cwd, err := os.Getwd(); err == nil {
-		candidates = append(candidates, filepath.Join(cwd, "config.json"))
-	} else {
-		candidates = append(candidates, "config.json")
-	}
-	return candidates
+	return confighub.CandidateConfigPaths(config.ConfigFile)
 }
 
 func findExistingConfigFile() string {
-	seen := map[string]struct{}{}
-	for _, candidate := range candidateConfigPaths() {
-		if candidate == "" {
-			continue
-		}
-		if _, ok := seen[candidate]; ok {
-			continue
-		}
-		seen[candidate] = struct{}{}
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate
-		}
-	}
-	return ""
+	return confighub.FindExistingConfigFile(config.ConfigFile)
 }
 
 func setupWizardAIConfigJSON() template.JS {
@@ -536,18 +514,24 @@ func migrateLegacyRootPassword() {
 }
 
 func loadConfig(path string) error {
-	f, err := os.Open(path)
+	raw, err := confighub.LoadConfig(path)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	// Reset data pointers to prevent pollution from previous active configuration
 	config.Databases = nil
 	config.SystemDB = nil
 
-	if err := json.NewDecoder(f).Decode(&config); err != nil {
+	payload, err := json.Marshal(raw)
+	if err != nil {
 		return err
+	}
+	if err := json.Unmarshal(payload, &config); err != nil {
+		return err
+	}
+	if config.ConfigFile == "" {
+		config.ConfigFile = path
 	}
 
 	migrateLegacyRootPassword()
@@ -1148,9 +1132,6 @@ func saveConfigFile() {
 	encoder.SetIndent("", "    ")
 	encoder.Encode(config)
 	os.Rename(config.ConfigFile+".tmp", config.ConfigFile)
-	if err := ensureModelCatalogFile(config.ConfigFile); err != nil {
-		log.Error(fmt.Sprintf("Failed to save model catalog: %v", err))
-	}
 }
 
 func handleUpdateDatabase(w http.ResponseWriter, r *http.Request) {

--- a/tools/httpserver/main_ai_test.go
+++ b/tools/httpserver/main_ai_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -18,5 +19,25 @@ func TestInitializeRequest_UsesAuthenticatedUserID(t *testing.T) {
 	}
 	if got := chatReq.UserID; got != "alice" {
 		t.Fatalf("expected authenticated user ID to override request payload, got %q", got)
+	}
+}
+
+func TestConstructPayload_PreservesRawUserMessage(t *testing.T) {
+	oldConfig := config
+	defer func() { config = oldConfig }()
+
+	config = Config{Databases: []DatabaseConfig{{Name: "demo", Path: t.TempDir()}}}
+
+	req := &aiChatRequest{
+		Message:  "show me orders",
+		Database: "demo",
+	}
+
+	ctx, payload, _, fullMessage := constructPayload(context.Background(), httptest.NewRecorder(), req, llmSettings{}, func(string, any) {}, nil)
+	if ctx == nil || payload == nil {
+		t.Fatal("expected constructPayload to return context and payload")
+	}
+	if got := strings.TrimSpace(fullMessage); got != req.Message {
+		t.Fatalf("expected raw user message to stay untouched, got %q want %q", got, req.Message)
 	}
 }

--- a/tools/httpserver/model_catalog.go
+++ b/tools/httpserver/model_catalog.go
@@ -195,22 +195,6 @@ func modelCatalogCandidatePaths(configPath string) []string {
 	return paths
 }
 
-func saveModelCatalog(path string, catalog ModelCatalog) error {
-	f, err := os.Create(path + ".tmp")
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	encoder := json.NewEncoder(f)
-	encoder.SetIndent("", "    ")
-	if err := encoder.Encode(catalog); err != nil {
-		return err
-	}
-
-	return os.Rename(path+".tmp", path)
-}
-
 func loadModelCatalog(configPath string) (bool, error) {
 	modelCatalog = defaultModelCatalog()
 
@@ -232,43 +216,8 @@ func loadModelCatalog(configPath string) (bool, error) {
 
 		seededDefaults := ensureModelCatalogDefaults(&loaded)
 		modelCatalog = loaded
-
-		if seededDefaults {
-			if err := saveModelCatalog(path, modelCatalog); err != nil {
-				return false, err
-			}
-		}
-
 		return seededDefaults, nil
 	}
 
-	if configPath == "" {
-		return false, nil
-	}
-
-	path := resolveModelCatalogPath(configPath)
-	if err := saveModelCatalog(path, modelCatalog); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func ensureModelCatalogFile(configPath string) error {
-	if configPath == "" {
-		return nil
-	}
-
-	path := resolveModelCatalogPath(configPath)
-	if _, err := os.Stat(path); err == nil {
-		return nil
-	} else if !os.IsNotExist(err) {
-		return err
-	}
-
-	catalog := modelCatalog
-	if ensureModelCatalogDefaults(&catalog) {
-		modelCatalog = catalog
-	}
-
-	return saveModelCatalog(path, catalog)
+	return false, nil
 }

--- a/tools/httpserver/model_catalog_test.go
+++ b/tools/httpserver/model_catalog_test.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestLoadModelCatalogSeedsDefaultFile(t *testing.T) {
+func TestLoadModelCatalogUsesDefaultCatalogWithoutWritingFile(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.json")
 	modelCatalogPath := filepath.Join(tempDir, modelCatalogFilename)
@@ -16,8 +15,8 @@ func TestLoadModelCatalogSeedsDefaultFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadModelCatalog returned error: %v", err)
 	}
-	if !seededDefaults {
-		t.Fatal("expected loadModelCatalog to seed default model catalog file")
+	if seededDefaults {
+		t.Fatal("expected loadModelCatalog to avoid writing fallback catalog files")
 	}
 	if len(modelCatalog.LLM) == 0 {
 		t.Fatal("expected default llm catalog entries")
@@ -31,16 +30,8 @@ func TestLoadModelCatalogSeedsDefaultFile(t *testing.T) {
 	if modelCatalog.LLM[0].Options[0].Value != "gemini:gemini-3.1-pro-preview" {
 		t.Fatalf("unexpected first default llm option: %q", modelCatalog.LLM[0].Options[0].Value)
 	}
-	data, err := os.ReadFile(modelCatalogPath)
-	if err != nil {
-		t.Fatalf("expected seeded model catalog file: %v", err)
-	}
-	var persisted ModelCatalog
-	if err := json.Unmarshal(data, &persisted); err != nil {
-		t.Fatalf("unmarshal seeded model catalog: %v", err)
-	}
-	if len(persisted.LLM) == 0 || persisted.LLM[0].Options[0].Value != "gemini:gemini-3.1-pro-preview" {
-		t.Fatal("expected seeded file to contain default llm catalog")
+	if _, err := os.Stat(modelCatalogPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no model catalog file to be created, got err=%v", err)
 	}
 }
 
@@ -72,7 +63,7 @@ func TestLoadModelCatalogPreservesConfiguredFile(t *testing.T) {
 	}
 }
 
-func TestSaveConfigFileSeedsModelCatalogSidecar(t *testing.T) {
+func TestSaveConfigFileDoesNotCreateModelCatalogSidecar(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.json")
 	modelCatalogPath := filepath.Join(tempDir, modelCatalogFilename)
@@ -82,19 +73,8 @@ func TestSaveConfigFileSeedsModelCatalogSidecar(t *testing.T) {
 
 	saveConfigFile()
 
-	if _, err := os.Stat(modelCatalogPath); err != nil {
-		t.Fatalf("expected model catalog sidecar to be created: %v", err)
-	}
-	data, err := os.ReadFile(modelCatalogPath)
-	if err != nil {
-		t.Fatalf("read model catalog sidecar: %v", err)
-	}
-	var persisted ModelCatalog
-	if err := json.Unmarshal(data, &persisted); err != nil {
-		t.Fatalf("unmarshal model catalog sidecar: %v", err)
-	}
-	if len(persisted.LLM) == 0 || persisted.LLM[0].Options[0].Value != "gemini:gemini-3.1-pro-preview" {
-		t.Fatal("expected sidecar to contain default llm catalog")
+	if _, err := os.Stat(modelCatalogPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no model catalog sidecar to be created, got err=%v", err)
 	}
 }
 

--- a/tools/httpserver/space_manager.go
+++ b/tools/httpserver/space_manager.go
@@ -482,13 +482,14 @@ func handlePreloadSpace(w http.ResponseWriter, r *http.Request) {
 		isGoRun := strings.Contains(os.Args[0], "go-build") || strings.HasPrefix(os.Args[0], os.TempDir())
 		if isGoRun {
 			fmt.Printf("SOP Knowledge Base JSON not found. Auto-compiling since running in dev mode...\n")
-			compilerPath := "./ai/cmd/knowledge_compiler"
+			compilerDir := "./ai/cmd/knowledge_compiler"
 			if _, err := os.Stat("../../ai/cmd/knowledge_compiler"); err == nil {
-				compilerPath = "../../ai/cmd/knowledge_compiler"
+				compilerDir = "../../ai/cmd/knowledge_compiler"
 			} else if _, err := os.Stat("../ai/cmd/knowledge_compiler"); err == nil {
-				compilerPath = "../ai/cmd/knowledge_compiler"
+				compilerDir = "../ai/cmd/knowledge_compiler"
 			}
-			cmd := exec.Command("go", "run", compilerPath)
+			cmd := exec.Command("bash", "run.sh")
+			cmd.Dir = compilerDir
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err == nil {

--- a/tools/httpserver/templates/index.html
+++ b/tools/httpserver/templates/index.html
@@ -732,11 +732,11 @@
                 </div>
                 
                 <div style="background: rgba(255,0,0,0.1); padding: 10px; border-left: 3px solid var(--danger-bg);">
-                    <label style="display: flex; align-items: flex-start; gap: 10px; cursor: pointer; user-select: none;">
-                        <input type="checkbox" id="uninstall-delete-system-db" style="margin-top: 4px;"> 
+                    <label style="display: flex; align-items: flex-start; gap: 10px; cursor: not-allowed; user-select: none; opacity: 0.75;">
+                        <input type="checkbox" id="uninstall-delete-system-db" style="margin-top: 4px;" disabled> 
                         <div>
                             <strong>Delete System DB (Shared Brain)?</strong><br>
-                            <span style="font-size: 0.9em; color: var(--text-color);">Delete the shared registry. <span style="color: var(--danger-bg);">Check only if you want to wipe the shared environment.</span></span>
+                            <span style="font-size: 0.9em; color: var(--text-color);">Disabled for safety: the System DB holds session records and runtime metadata used by the running environment.</span>
                         </div>
                     </label>
                 </div>

--- a/tools/httpserver/templates/modals.html
+++ b/tools/httpserver/templates/modals.html
@@ -252,19 +252,29 @@
             <strong>SOP is a Database architecture built for AI.</strong> Whether you're quickly spinning up custom Spaces dynamically or executing complex NoSQL B-Tree transactions, I'm here to help.<br><br>
             Type <strong>/list_tools</strong> to show all available tool commands.<br><br>
             
-            <em style="color: var(--text-muted); font-size: 0.9em;">Want to learn SOP?</em><br>
-            <em style="color: var(--text-muted); font-size: 0.9em;">Sample how to work with Spaces:</em>
-            <ul style="color: var(--text-muted); font-size: 0.9em; margin-top: 4px;">
-                <li>"Generate sample tasks and add them to my Tasks space"</li>
-            </ul>
+            <div style="margin: 0 0 6px 0;">
+                <em style="color: var(--text-muted); font-size: 0.9em; display: block; margin-bottom: 2px;">Want to learn SOP?</em>
+                <em style="color: var(--text-muted); font-size: 0.9em; display: block; margin-bottom: 2px;">Sample how to work with Spaces:</em>
+                <ul style="color: var(--text-muted); font-size: 0.9em; margin: 0 0 0 18px; padding: 0; list-style-position: outside;">
+                    <li style="margin: 0 0 2px 0; padding: 0;">"Generate sample tasks and add them to my Tasks space"</li>
+                </ul>
+            </div>
+            <div style="margin: 0 0 6px 0;">
+                <em style="color: var(--text-muted); font-size: 0.9em; display: block; margin-bottom: 2px;">Routing based prompt:</em>
+                <ul style="color: var(--text-muted); font-size: 0.9em; margin: 0 0 0 18px; padding: 0; list-style-position: outside;">
+                    <li style="margin: 0 0 2px 0; padding: 0;">"omni:sop:language binding:c#"</li>
+                </ul>
+            </div>
 
             {{if .HasDemo}}
-            <em style="color: var(--text-muted); font-size: 0.9em;">With Demo Data loaded, try these examples:</em>
-            <ul style="color: var(--text-muted); font-size: 0.9em; margin-top: 4px;">
-                <li>"Show me all users sorted by Age descending"</li>
-                <li>"Find orders for users with first_name 'John' with total amount > 500"</li>
-                <li>"Create a script named 'expensive_orders' to find orders over $1000"</li>
-            </ul>
+            <div style="margin: 0 0 0 0;">
+                <em style="color: var(--text-muted); font-size: 0.9em; display: block; margin-bottom: 2px;">With Demo Data loaded, try these examples:</em>
+                <ul style="color: var(--text-muted); font-size: 0.9em; margin: 0 0 0 18px; padding: 0; list-style-position: outside;">
+                    <li style="margin: 0 0 2px 0; padding: 0;">"Show me all users sorted by Age descending"</li>
+                    <li style="margin: 0 0 2px 0; padding: 0;">"Find orders for users with first_name 'John' with total amount > 500"</li>
+                    <li style="margin: 0 0 2px 0; padding: 0;">"Create a script named 'expensive_orders' to find orders over $1000"</li>
+                </ul>
+            </div>
             {{end}}
             
         </div>

--- a/tools/httpserver/templates/modals.html
+++ b/tools/httpserver/templates/modals.html
@@ -114,8 +114,8 @@
                 <label style="display: flex; align-items: start; gap: 8px; cursor: pointer;">
                     <input type="checkbox" id="delete-env-user-dbs-check" style="margin-top: 3px;" checked>
                     <div style="font-size: 13px;">
-                        <strong>Delete User DBs?</strong><br>
-                        <span style="color: var(--text-muted); font-size: 12px;">Removes all User Databases referenced by this config.</span>
+                        <strong>Destroy User DB Assets?</strong><br>
+                        <span style="color: var(--text-muted); font-size: 12px;">Permanently remove the target environment’s user database assets when they are no longer needed.</span>
                     </div>
                 </label>
             </div>
@@ -124,8 +124,8 @@
                 <label style="display: flex; align-items: start; gap: 8px; cursor: pointer;">
                     <input type="checkbox" id="delete-env-system-db-check" style="margin-top: 3px;">
                     <div style="font-size: 13px;">
-                        <strong>Delete System DB (Shared Brain)?</strong><br>
-                        <span style="color: var(--text-muted); font-size: 12px;">Removes the central registry. <span style="color: var(--danger-bg);">Warning: This might affect other users sharing this brain.</span></span>
+                        <strong>Destroy Shared System DB Assets?</strong><br>
+                        <span style="color: var(--text-muted); font-size: 12px;">Permanently remove the shared registry assets for this environment when you are destroying the target setup itself.</span>
                     </div>
                 </label>
             </div>
@@ -133,7 +133,7 @@
 
         <div style="display:flex; justify-content:flex-end; gap:10px;">
             <button onclick="closeDeleteEnvModal()" style="padding: 6px 16px; background: var(--button-bg); color: var(--button-text); border: none; border-radius: 4px; cursor: pointer;">Cancel</button>
-            <button id="delete-env-confirm-btn" style="padding: 6px 16px; background: var(--danger-bg); color: white; border: none; border-radius: 4px; cursor: pointer;">Delete</button>
+            <button id="delete-env-confirm-btn" style="padding: 6px 16px; background: var(--danger-bg); color: white; border: none; border-radius: 4px; cursor: pointer;">Destroy Assets</button>
         </div>
     </div>
 </div>

--- a/tools/httpserver/templates/modals.html
+++ b/tools/httpserver/templates/modals.html
@@ -262,7 +262,7 @@
             <div style="margin: 0 0 6px 0;">
                 <em style="color: var(--text-muted); font-size: 0.9em; display: block; margin-bottom: 2px;">Routing based prompt:</em>
                 <ul style="color: var(--text-muted); font-size: 0.9em; margin: 0 0 0 18px; padding: 0; list-style-position: outside;">
-                    <li style="margin: 0 0 2px 0; padding: 0;">"omni:sop:language binding:c#"</li>
+                    <li style="margin: 0 0 2px 0; padding: 0;">"sop:language bindings:c#"</li>
                 </ul>
             </div>
 

--- a/tools/httpserver/templates/scripts_part01.html
+++ b/tools/httpserver/templates/scripts_part01.html
@@ -562,16 +562,26 @@
 
     // Dedicated KeyUp Listener for Setup Wizard (prevents double-triggering confirmation)
     document.addEventListener('keyup', function(event) {
-        if (event.key === "Escape") {
-            const wizard = document.getElementById('setup-wizard');
-            if (wizard && wizard.style.display !== 'none' && wizard.style.display !== '') {
-                // Ensure no other modal is covering it (simple check)
-                 if(document.getElementById('global-alert-modal').style.display === 'flex') return;
-                 if(document.getElementById('global-confirm-modal').style.display === 'flex') return;
-                 
-                 event.preventDefault();
-                 event.stopImmediatePropagation();
-                 wizardCancel();
+        const wizard = document.getElementById('setup-wizard');
+        if (wizard && wizard.style.display !== 'none' && wizard.style.display !== '') {
+            // Ensure no other modal is covering it (simple check)
+            if(document.getElementById('global-alert-modal').style.display === 'flex') return;
+            if(document.getElementById('global-confirm-modal').style.display === 'flex') return;
+            
+            if (event.key === "Escape") {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                wizardCancel();
+            } else if (event.key === "Enter") {
+                // On page 3 (Finish), support Enter key to complete setup
+                if (typeof currentWizardStep !== 'undefined' && currentWizardStep === 3) {
+                    // Don't trigger if user is typing in a textarea
+                    if (event.target.tagName === 'TEXTAREA') return;
+                    
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+                    wizardNext();
+                }
             }
         }
     });

--- a/tools/httpserver/templates/scripts_part11.html
+++ b/tools/httpserver/templates/scripts_part11.html
@@ -450,7 +450,7 @@
 
     function deleteEnvironment(filename) {
         envToDelete = filename;
-        document.getElementById('delete-env-msg').textContent = `Are you sure you want to delete the environment configuration '${filename}'?`;
+        document.getElementById('delete-env-msg').textContent = `Destroy the assets for environment '${filename}'? This permanently removes the configuration and any selected data stores that are no longer needed.`;
         
         // Reset checkboxes to default safe state
         if(document.getElementById('delete-env-user-dbs-check')) {
@@ -478,7 +478,7 @@
         const btn = document.getElementById('delete-env-confirm-btn');
         if (btn) {
             btn.disabled = false;
-            btn.textContent = "Confirm Delete";
+            btn.textContent = "Destroy Assets";
         }
         
         envToDelete = null;


### PR DESCRIPTION
Sample prefix based routing (that does NOT incur LLM calls, purely local RAG tool calls using "semantic" categories matching):

sop: - displays all root Categories
sop:language bindings - displays different language bindings
sop:language bindings:c#:page:2 - displays page 2 of C# discussions, if it is multi-paged

Because it is using Semantic matching, in example above, "language bindings" will match with "Language Bindings & Tooling". So, sop:language binding:c# will find or match with sop:Language Bindings & Tooling:C#

Thus, totally reducing need for BM25/Lucene Index text search type. Semantic Category Search is a very powerful tool, complementing the KnowledgeBase visualization and Semantic nested Category vectorization, enabling high volume "thoughts" or items storage, grouping, access/query, an industry first that SOP is introducing.
